### PR TITLE
feat: integrate gh-issue-sync for local issue mirroring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .claude/.sk-state.json
 .claude/skills/groundwork_*/
 .groundwork/
+.issues/

--- a/README.md
+++ b/README.md
@@ -48,6 +48,31 @@ groundwork init --dry-run
 groundwork update --dry-run
 ```
 
+## Local Issue Mirroring
+
+Groundwork integrates with [gh-issue-sync](https://github.com/mitsuhiko/gh-issue-sync)
+for local issue mirroring. Issues are synced to a gitignored `.issues/` directory —
+GitHub remains the source of truth; the local copy is a working surface.
+
+### Setup
+
+Install gh-issue-sync ([installation options](https://github.com/mitsuhiko/gh-issue-sync#installation)),
+then run `groundwork init`. The CLI will detect the tool and initialize `.issues/` automatically.
+
+Or initialize manually:
+
+    gh-issue-sync init
+    gh-issue-sync pull
+
+### How it works
+
+Groundwork skills handle sync at the right moments:
+- `planning` pulls fresh issues at session-open, pushes state updates at session-close
+- `issue-craft` pushes after creating or closing issues
+- `land` pulls after closing to update the local mirror
+
+For manual sync: `gh-issue-sync pull`, `gh-issue-sync push`, or `gh-issue-sync sync` (bidirectional).
+
 ## CLI Behavior Notes
 
 - `groundwork init` / `groundwork update` reconcile Groundwork-managed dependencies in `agents.toml`.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -113,6 +113,12 @@ Prevents:
 - ambiguous issue descriptions requiring clarifications mid-execution
 - non-verifiable "done" statements
 
+### Local Issue Mirroring
+
+Issues are mirrored locally via `gh-issue-sync`. The `.issues/` directory is
+gitignored — it is a working surface, not a second source of truth. Skills
+sync at natural boundaries: pull before reading, push after writing.
+
 ## 4. Execution + Verification (upstream)
 
 Groundwork v0.1 includes these upstream Superpowers skills:

--- a/agents.toml
+++ b/agents.toml
@@ -11,18 +11,19 @@ specification = { path = "./skills/specification" }
 decomposition = { path = "./skills/decomposition" }
 completion = { path = "./skills/completion" }
 using-groundwork = { path = "./skills/using-groundwork" }
-groundwork_original_ground = { gh = "pentaxis93/groundwork", path = "skills/foundation/ground" }
-groundwork_original_research = { gh = "pentaxis93/groundwork", path = "skills/foundation/research" }
-groundwork_original_bdd = { gh = "pentaxis93/groundwork", path = "skills/specification/bdd" }
-groundwork_original_planning = { gh = "pentaxis93/groundwork", path = "skills/decomposition/planning" }
-groundwork_original_issue_craft = { gh = "pentaxis93/groundwork", path = "skills/decomposition/issue-craft" }
-groundwork_original_land = { gh = "pentaxis93/groundwork", path = "skills/completion/land" }
-groundwork_superpowers_brainstorming = { gh = "obra/superpowers", path = "skills/brainstorming", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
-groundwork_superpowers_writing_skills = { gh = "obra/superpowers", path = "skills/writing-skills", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
-groundwork_superpowers_writing_plans = { gh = "obra/superpowers", path = "skills/writing-plans", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
-groundwork_superpowers_subagent_driven_development = { gh = "obra/superpowers", path = "skills/subagent-driven-development", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
-groundwork_superpowers_test_driven_development = { gh = "obra/superpowers", path = "skills/test-driven-development", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
-groundwork_superpowers_systematic_debugging = { gh = "obra/superpowers", path = "skills/systematic-debugging", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
-groundwork_superpowers_verification_before_completion = { gh = "obra/superpowers", path = "skills/verification-before-completion", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
-groundwork_superpowers_requesting_code_review = { gh = "obra/superpowers", path = "skills/requesting-code-review", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
-groundwork_superpowers_receiving_code_review = { gh = "obra/superpowers", path = "skills/receiving-code-review", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
+ground = { gh = "pentaxis93/groundwork", path = "skills/foundation/ground" }
+research = { gh = "pentaxis93/groundwork", path = "skills/foundation/research" }
+bdd = { gh = "pentaxis93/groundwork", path = "skills/specification/bdd" }
+planning = { gh = "pentaxis93/groundwork", path = "skills/decomposition/planning" }
+issue_craft = { gh = "pentaxis93/groundwork", path = "skills/decomposition/issue-craft" }
+land = { gh = "pentaxis93/groundwork", path = "skills/completion/land" }
+using_groundwork = { gh = "pentaxis93/groundwork", path = "skills/using-groundwork" }
+brainstorming = { gh = "obra/superpowers", path = "skills/brainstorming", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
+writing_skills = { gh = "obra/superpowers", path = "skills/writing-skills", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
+writing_plans = { gh = "obra/superpowers", path = "skills/writing-plans", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
+subagent_driven_development = { gh = "obra/superpowers", path = "skills/subagent-driven-development", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
+test_driven_development = { gh = "obra/superpowers", path = "skills/test-driven-development", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
+systematic_debugging = { gh = "obra/superpowers", path = "skills/systematic-debugging", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
+verification_before_completion = { gh = "obra/superpowers", path = "skills/verification-before-completion", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
+requesting_code_review = { gh = "obra/superpowers", path = "skills/requesting-code-review", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
+receiving_code_review = { gh = "obra/superpowers", path = "skills/receiving-code-review", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }

--- a/crates/groundwork-cli/src/main.rs
+++ b/crates/groundwork-cli/src/main.rs
@@ -210,6 +210,8 @@ fn run_install_in_directory(
     let sk_runner = ensure_sk_available()?;
     sk_runner.sync()?;
 
+    bootstrap_issue_sync(base_path);
+
     let sk_version = sk_runner
         .version()
         .unwrap_or_else(|_| "unknown".to_string());
@@ -302,6 +304,16 @@ fn run_doctor() -> Result<()> {
             );
         }
         println!("ok: bootstrap prerequisites satisfied");
+    }
+
+    if command_exists("gh-issue-sync") {
+        let ver = run_command_capture(&["gh-issue-sync", "--version"])
+            .unwrap_or_else(|_| "unknown".into());
+        println!("ok: gh-issue-sync available ({})", ver.trim());
+    } else {
+        println!(
+            "warn: gh-issue-sync not found (install from https://github.com/mitsuhiko/gh-issue-sync)"
+        );
     }
 
     println!(
@@ -644,6 +656,50 @@ impl SkRunner {
         match self.mode {
             SkMode::Binary => "sk",
             SkMode::Npx => "npx @skills-supply/sk",
+        }
+    }
+}
+
+fn bootstrap_issue_sync(base_path: &Path) {
+    if !command_exists("gh-issue-sync") {
+        println!(
+            "note: install gh-issue-sync for local issue mirroring (https://github.com/mitsuhiko/gh-issue-sync)"
+        );
+        return;
+    }
+
+    let issues_dir = base_path.join(".issues");
+    if issues_dir.exists() {
+        return;
+    }
+
+    let init_status = Command::new("gh-issue-sync")
+        .arg("init")
+        .current_dir(base_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .status();
+
+    if !init_status.map(|s| s.success()).unwrap_or(false) {
+        println!("warn: gh-issue-sync init failed");
+        return;
+    }
+
+    let pull_output = Command::new("gh-issue-sync")
+        .arg("pull")
+        .current_dir(base_path)
+        .output();
+
+    match pull_output {
+        Ok(output) if output.status.success() => {
+            let count = issues_dir
+                .read_dir()
+                .map(|entries| entries.filter_map(|e| e.ok()).count())
+                .unwrap_or(0);
+            println!("ok: synced {} issues to .issues/", count);
+        }
+        _ => {
+            println!("warn: gh-issue-sync pull failed");
         }
     }
 }

--- a/skills/completion/land/SKILL.md
+++ b/skills/completion/land/SKILL.md
@@ -113,6 +113,12 @@ curl -sf -X PATCH \
   "https://weforge.build/api/v1/repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}" >/dev/null
 ```
 
+### 5a. Sync issue state to local mirror
+
+```bash
+gh-issue-sync pull
+```
+
 ### 6. Verify and report
 
 ```bash

--- a/skills/decomposition/issue-craft/SKILL.md
+++ b/skills/decomposition/issue-craft/SKILL.md
@@ -52,6 +52,7 @@ without clarification.
 8. Run deterministic lint:
 `python scripts/issue_lint.py --type <task|epic|bug|spike> <issue.md>`.
 9. Assemble using template from `references/templates.md`.
+10. Push to remote: `gh-issue-sync push`.
 
 ### decompose-epic
 1. Extract deliverables (artifacts that must exist when done).
@@ -96,6 +97,7 @@ Prefer strict mode when type is known:
 `python scripts/issue_lint.py --type <task|epic|bug|spike> <issue.md>`.
 
 ### triage-issues
+0. Sync local issues: `gh-issue-sync pull`.
 1. Refine non-ready issues first.
 2. Build dependency graph for backlog.
 3. Create topological execution layers.
@@ -108,6 +110,7 @@ Prefer strict mode when type is known:
 2. Check scope deviations and split unintended extra work.
 3. Update parent epic/task checklist.
 4. Close with commit/PR reference (`Closes #N`).
+5. Sync closure to remote: `gh-issue-sync push`.
 
 ## Triggers
 - creating issues

--- a/skills/decomposition/planning/SKILL.md
+++ b/skills/decomposition/planning/SKILL.md
@@ -32,6 +32,7 @@ increment, and leave the next session a truthful handoff.
 ## Procedures
 
 ### session-open
+0. Sync local issues: `gh-issue-sync pull`.
 1. Read operator request and relevant issue thread(s).
 2. Identify all ready (unblocked) candidate issues.
 3. Apply force filters first: direct operator request or hard deadline.
@@ -61,6 +62,7 @@ Write:
 ### session-close
 1. Reach stable checkpoint (done increment or explicit WIP note).
 2. Update issue state and leave a concise progress comment.
+2a. Sync changes to remote: `gh-issue-sync push`.
 3. Record decisions, blockers, and the exact next step.
 4. Ensure any follow-up work is represented as issue(s).
 5. Sync workspace and close.

--- a/skills/using-groundwork/SKILL.md
+++ b/skills/using-groundwork/SKILL.md
@@ -17,7 +17,7 @@ Groundwork is one connected methodology, not a skill collection. Every skill clo
 
 ## The Flow
 
-`ground` fires first — establishing what the work must enable. From grounded constraints, `bdd` defines the behavior contract — executable expectations threading through every step. `planning` and `issue-craft` decompose that contracted behavior into session-sized, agent-executable work. `writing-plans` translates behavior into implementation steps. `test-driven-development` implements them through RED-GREEN-REFACTOR — each RED test maps to a named behavior scenario. `subagent-driven-development` parallelizes independent tasks when the plan supports it. `verification-before-completion` demands behavior-level evidence before any completion claim. `land` closes the loop: merge, cleanup, and behavior coverage record.
+`ground` fires first — establishing what the work must enable. Local issues (`.issues/`) mirror the forge — `gh-issue-sync pull` before reading, `push` after writing. From grounded constraints, `bdd` defines the behavior contract — executable expectations threading through every step. `planning` and `issue-craft` decompose that contracted behavior into session-sized, agent-executable work. `writing-plans` translates behavior into implementation steps. `test-driven-development` implements them through RED-GREEN-REFACTOR — each RED test maps to a named behavior scenario. `subagent-driven-development` parallelizes independent tasks when the plan supports it. `verification-before-completion` demands behavior-level evidence before any completion claim. `land` closes the loop: merge, cleanup, and behavior coverage record.
 
 ## Cross-Cutting Disciplines
 


### PR DESCRIPTION
## Summary

- Add `bootstrap_issue_sync()` to CLI: detects `gh-issue-sync`, runs `init` + `pull` on `groundwork init`
- Add `gh-issue-sync` availability check to `groundwork doctor`
- Wire sync points into skills at natural boundaries: `planning` (pull at session-open, push at session-close), `issue-craft` (push after create/close, pull before triage), `land` (pull after close)
- Add "Local Issue Mirroring" sections to README and WORKFLOW
- Gitignore `.issues/` directory
- Reconcile `agents.toml` aliases to match current manifest (stutter fix applied)

## Test plan

- [x] `cargo build` — compiles clean
- [x] `cargo test` — 6/6 tests pass
- [x] Skill sync points verified: pull before read, push after write
- [x] `bootstrap_issue_sync` is non-fatal — missing tool prints a note, failures warn but don't block init

🤖 Generated with [Claude Code](https://claude.com/claude-code)