### PR TITLE
feat: broaden next-issue from work selection to work initiation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,7 +56,7 @@ The five stages are not a taxonomy — they are an integration architecture. Eac
 
 1. **Frame constraints** (`ground`, `research`) produces verified constraints and substantiated evidence
 2. **Define behavior** (`bdd`) produces Given/When/Then behavior contracts
-3. **Decompose** (`issue-craft`, `next-issue`, `plan`) produces executable issues and implementation designs
+3. **Decompose** (`issue-craft`, `next-issue`, `plan`) produces executable issues, prepared workspaces (branch + draft PR), and implementation designs
 4. **Execute and verify** (curated skills) produces tested implementations and review evidence
 5. **Land** (`land`) produces closed issues, merged code, and behavior coverage records
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Broadened `next-issue` from work selection to work initiation — now covers selection, workspace preparation (branch + draft PR), and session open/close as the opening bookend to `land`
+- `next-issue` accepts issue number(s) directly (skipping selection) or a topic string (narrowing selection), in addition to no-args full selection
+- Multi-issue batching into a single PR is an explicitly supported pattern
+- Session open captures starting direction instead of requiring a rigid binary done condition upfront
+- Added `next-issue -> execution` and `next-issue <-> land` handoff contracts to pipeline contract
+
 ### Added
 
 - Five-stage methodology pipeline: frame constraints, define behavior, decompose, execute and verify, land

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Changed
-
-- Broadened `next-issue` from work selection to work initiation — now covers selection, workspace preparation (branch + draft PR), and session open/close as the opening bookend to `land`
-- `next-issue` accepts issue number(s) directly (skipping selection) or a topic string (narrowing selection), in addition to no-args full selection
-- Multi-issue batching into a single PR is an explicitly supported pattern
-- Session open captures starting direction instead of requiring a rigid binary done condition upfront
-- Added `next-issue -> execution` and `next-issue <-> land` handoff contracts to pipeline contract
-
 ### Added
 
 - Five-stage methodology pipeline: frame constraints, define behavior, decompose, execute and verify, land
@@ -27,6 +19,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Broadened `next-issue` from work selection to work initiation — now covers selection, workspace preparation (branch + draft PR), and session open/close as the opening bookend to `land`
+- `next-issue` accepts issue number(s) directly (skipping selection) or a topic string (narrowing selection), in addition to no-args full selection
+- Multi-issue batching into a single PR is an explicitly supported pattern
+- Session open captures starting direction instead of requiring a rigid binary done condition upfront
+- Added `next-issue -> execution` and `next-issue <-> land` handoff contracts to pipeline contract
 - Migrated license from Apache-2.0 to MIT
 - Rewrote README from first principles around the pipeline concept
 - Renamed `planning` skill to `next-issue`; added separate `plan` skill for design convergence

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There is one path, not a menu. Every piece of work flows through five stages:
 
 **2. Define behavior** — `bdd` defines the behavior contract in Given/When/Then scenarios. This contract threads through every subsequent stage — it is the integration mechanism, not a planning artifact.
 
-**3. Decompose** — `issue-craft` produces agent-executable issues with binary acceptance criteria from the behavior contract. `next-issue` selects session-sized work from the issue graph. `brainstorming` explores design approaches. `plan` converges to a decision-complete implementation design. `writing-plans` translates it into concrete steps. The issue graph is the project's working memory across sessions.
+**3. Decompose** — `issue-craft` produces agent-executable issues with binary acceptance criteria from the behavior contract. `next-issue` initiates a work session — selecting work from the issue graph (or accepting issue numbers directly), creating a feature branch and draft PR, and starting with a clear direction. It is the opening bookend to `land`. `brainstorming` explores design approaches. `plan` converges to a decision-complete implementation design. `writing-plans` translates it into concrete steps. The issue graph is the project's working memory across sessions.
 
 **4. Execute and verify** — `test-driven-development` implements behavior through RED-GREEN-REFACTOR — each RED test maps to a named scenario from stage 2. `systematic-debugging` finds root cause before proposing fixes. Code review and `verification-before-completion` gate completion with behavior-level evidence.
 
@@ -39,7 +39,7 @@ For the full integration manual, see [WORKFLOW.md](WORKFLOW.md). For formal hand
 | `research` | Foundation | Unsubstantiated decisions, hallucinated facts |
 | `bdd` | Specification | Vague specs, testing implementation instead of behavior |
 | `issue-craft` | Decomposition | Non-executable tasks, vague acceptance criteria |
-| `next-issue` | Decomposition | Recency drift, scope creep, blocker bypass |
+| `next-issue` | Decomposition | Recency drift, scope creep, blocker bypass, no branch/PR before coding |
 | `brainstorming` | Decomposition | Coding before design is approved |
 | `plan` | Decomposition | Unclear scope, design choices left to implementer |
 | `writing-plans` | Decomposition | Vague execution plans without file-level specificity |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -22,7 +22,7 @@ Invoke `bdd` to define the behavior contract in Given/When/Then scenarios. Each 
 
 Use `issue-craft` to create, decompose, refine, and close issues. It produces agent-executable issues with binary acceptance criteria, explicit dependencies, and bounded scope. For epics with 4+ tasks, it builds dependency graphs with execution layers.
 
-Use `next-issue` to select session-sized work from the issue graph. It reads unblocked issues, ranks by value and unblock leverage, and declares a session goal with a binary done condition and explicit scope gate.
+Use `next-issue` to initiate a work session. It selects session-sized work from the issue graph (or accepts issue numbers directly), creates a feature branch and draft PR, and starts with a clear direction and explicit scope gate. It is the opening bookend to `land` — `next-issue` initiates work, `land` closes it. Multi-issue batching into a single PR is supported when issues form a cohesive change.
 
 Use `brainstorming` before designing a solution or making a significant architectural choice. It explores 2-3 approaches with trade-offs and produces an approved design document.
 
@@ -152,7 +152,7 @@ Issues are mirrored locally via `gh-issue-sync`. The `.issues/` directory is git
 | `research` | when reliable external evidence is needed for decisions |
 | `bdd` | when defining or refining behavior expectations |
 | `issue-craft` | creating/refining task/epic/bug/spike issues |
-| `next-issue` | selecting session-sized work from issue graph, or when a task feels too big to hold in one session |
+| `next-issue` | initiating a work session — selecting work, creating branch and draft PR, or when given specific issue number(s) to work on |
 | `brainstorming` | before designing a solution or making a significant architectural choice |
 | `plan` | implementation needs design convergence — multiple approaches, unclear scope, or cross-cutting changes |
 | `writing-plans` | when you have a decision-complete design and need a structured implementation plan before touching code |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -107,7 +107,7 @@ State is determined by reading issue content, not forge metadata (labels, column
 |-------------|----------------------------------------------|------------------------------------|-------------------------------------|
 | draft       | Intent captured, not yet agent-executable     | Issue created without full criteria | Criteria, scope, and size filled in |
 | ready       | Agent-executable and unblocked                | All fields complete, deps closed   | Session claims it                   |
-| in-progress | Active session is working on it               | Session declares goal against it   | Session closes or blocks            |
+| in-progress | Active session is working on it               | Session begins working on it       | Session closes or blocks            |
 | blocked     | Waiting on one or more open dependencies      | Dependency discovered or reopened  | All blocking issues closed          |
 | closed      | All acceptance criteria verified              | Verified and merged                | Reopened for regression             |
 | stale       | No progress for 14+ days while still open     | Clock expires                      | Resumed, split, or closed as wont-fix |

--- a/docs/architecture/pipeline-contract.md
+++ b/docs/architecture/pipeline-contract.md
@@ -89,6 +89,7 @@ Fail condition:
 5. Do not accept completion evidence that lacks documentation review.
 6. Do not land user-visible changes without a CHANGELOG entry.
 7. Do not treat stale documentation as authoritative over code behavior.
+8. Do not begin implementation without a prepared workspace (branch and draft PR).
 
 ## Quick Compliance Checklist
 
@@ -100,3 +101,5 @@ Fail condition:
 - [ ] Documentation review completed before verification.
 - [ ] User-facing changes include CHANGELOG entry.
 - [ ] Documentation coverage status recorded at completion.
+- [ ] Feature branch and draft PR exist before implementation begins.
+- [ ] Work initiated with preparation (next-issue) and closed with full delivery (land).

--- a/docs/architecture/pipeline-contract.md
+++ b/docs/architecture/pipeline-contract.md
@@ -7,7 +7,7 @@ This file defines the canonical integration contract for Groundwork's methodolog
 Groundwork has one coherent path:
 1. `ground` frames constraints.
 2. `bdd` defines and maintains behavior contract.
-3. `next-issue` + `issue-craft` decompose executable work; `plan` converges the implementation design.
+3. `issue-craft` decomposes executable work; `next-issue` initiates a work session (select, branch, draft PR); `plan` converges the implementation design.
 4. Curated middle skills implement and verify the same behavior contract.
 5. `land` closes work with behavior coverage visibility.
 
@@ -65,6 +65,20 @@ Requirement:
 
 Fail condition:
 - user-visible change landed without CHANGELOG entry or documentation coverage statement.
+
+## `next-issue -> execution`
+Requirement:
+- workspace is prepared (feature branch and draft PR exist) before implementation begins.
+
+Fail condition:
+- implementation starts on main or without a draft PR referencing the issue(s).
+
+## `next-issue <-> land`
+Requirement:
+- `next-issue` and `land` are symmetric bookends. `next-issue` opens work (branch, draft PR, direction). `land` closes it (merge, cleanup, close issue).
+
+Fail condition:
+- work initiated without preparation (no branch/PR) or closed without full delivery (merge without issue close).
 
 ## Anti-Divergence Rules
 

--- a/skills/completion/land/SKILL.md
+++ b/skills/completion/land/SKILL.md
@@ -150,5 +150,6 @@ Success conditions:
 
 ## Related Skills
 
+- `next-issue`: the opening bookend — `next-issue` initiates work (select, branch, draft PR), `land` closes it.
 - `forgejo-api` for API endpoint details
 - `credentials` for token-safe command patterns

--- a/skills/completion/land/SKILL.md
+++ b/skills/completion/land/SKILL.md
@@ -30,6 +30,8 @@ Do not stop after merge.
 - Issue number must be known:
   - Prefer explicit user-provided issue number.
   - Else infer from branch name pattern `issue-<number>`.
+  - Note: `land` currently handles single-issue branches only. For multi-issue
+    batches (from `next-issue`), close additional issues manually.
 - Use WeForge API token from `pass`:
   - Default: `pass show weforge/fulcrum-token`
 

--- a/skills/decomposition/issue-craft/SKILL.md
+++ b/skills/decomposition/issue-craft/SKILL.md
@@ -144,6 +144,6 @@ Prefer strict mode when type is known:
 - `right-sized`: optimize for single focused execution session.
 
 ## Cross-References
-- `next-issue`: session-level prioritization and execution discipline.
+- `next-issue`: work initiation — selects work, prepares workspace (branch + draft PR), opens session.
 - `bdd`: behavior framing and test naming discipline.
 - `dev-workflow`: issue-to-commit linkage and completion hygiene.

--- a/skills/decomposition/next-issue/SKILL.md
+++ b/skills/decomposition/next-issue/SKILL.md
@@ -1,12 +1,16 @@
 ---
 name: next-issue
-description: Session work-selection discipline for issue-tracker-first execution. Use for selecting next work, declaring a concrete session goal, and closing with explicit state updates.
+description: >-
+  Work initiation discipline: select session-sized work from the issue graph,
+  set up the workspace, and leave the next session a truthful handoff.
+  Opening bookend to `land`. Use for starting a work session, whether you
+  already know the issue or need to choose one.
 ---
 
 # Next Issue
 
-Plan from the issue graph, not from memory. The goal is always a single,
-verifiable increment that can be completed in one focused session.
+The opening bookend of the work pipeline. `next-issue` initiates work;
+`land` closes it. Between them: plan, implement, verify.
 
 Key terms — *issue graph*, *unblocked*, *execution layer*, *session-sized* —
 are defined in WORKFLOW.md § Issue-Based Development.
@@ -15,17 +19,47 @@ For issue decomposition and boundary contracts, use `issue-craft`.
 For first-principles design decisions, use `ground`.
 
 ## Goal
-Choose the highest-leverage unblocked issue, execute one session-sized
-increment, and leave the next session a truthful handoff.
+
+Select session-sized work, prepare the workspace, and start with a clear
+direction. End with an honest handoff to the next session.
+
+## Invocation Modes
+
+The skill accepts three input forms. Selection is skipped when unnecessary.
+
+### No arguments
+
+Full selection from the issue graph. This is the default when the agent
+does not know what to work on.
+
+→ Proceeds through: selection → preparation → session open.
+
+### Issue number(s)
+
+One or more issue numbers provided by the operator or already known.
+Multiple issues are batched into a single PR when they form a cohesive
+change.
+
+→ Skips selection. Proceeds through: preparation → session open.
+
+### Topic string
+
+A phrase describing the area of work (e.g., "documentation thread",
+"CLI error handling"). Narrows the candidate set, then proceeds through
+selection from the narrowed list.
+
+→ Proceeds through: narrowed selection → preparation → session open.
 
 ## Constraints
+
 - `issue-tracker-source-of-truth`: planning state lives in forge issues, not local task trackers.
-- `session-goal-declared-first`: write one concrete session goal before execution.
 - `one-session-increment`: commit to one independently verifiable increment.
 - `dependencies-are-hard-blockers`: do not start blocked work.
 - `session-close-mandatory`: every session ends with explicit state update.
+- `workspace-before-code`: branch and draft PR exist before implementation begins.
 
 ## Requirements
+
 - `next-action-is-executable`: next action names artifact, command, and done condition.
 - `priority-from-impact`: prioritize value, time criticality, and unblock leverage.
 - `scope-gate-explicit`: record what is intentionally out of scope for this session.
@@ -34,59 +68,107 @@ increment, and leave the next session a truthful handoff.
 
 ## Procedures
 
-### session-open
+### select
+
+Applies when no issue number is provided. Skip entirely when issue(s) are
+already known.
+
 0. Sync local issues: `gh-issue-sync pull`.
 1. Read operator request and relevant issue thread(s).
-2. Identify all ready (unblocked) candidate issues — an issue is ready when
+2. If a topic string was provided, filter candidates to that area.
+3. Identify all ready (unblocked) candidate issues — an issue is ready when
    its body is agent-executable and every hard dependency is closed.
-3. Apply force filters first: direct operator request or hard deadline.
-4. Rank top candidates by:
-- value
-- time criticality
-- unblock leverage
-- expected effort
-5. Select one issue-sized increment.
-6. Declare session goal and scope gate before touching code.
+4. Apply force filters first: direct operator request or hard deadline.
+5. Rank top candidates by value, time criticality, unblock leverage,
+   and expected effort.
+6. Select one issue or a cohesive batch (2-3 related issues that belong
+   in a single PR).
 
-### choose-next-issue
-Decision stack (<=3 minutes):
+Decision stack (≤3 minutes):
 1. Force filter: operator request or deadline cliff wins immediately.
 2. Shortlist 3-5 unblocked issues from the lowest available execution layer.
-3. Score with WSJF-lite:
-`(Value + TimeCriticality + UnblockLeverage) / Effort`
+3. Score: `(Value + TimeCriticality + UnblockLeverage) / Effort`.
 4. Prefer the highest score that can be completed this session.
 5. If tie: choose the option that unblocks the most downstream work.
 
-### define-session-goal
+### prepare
+
+Set up the workspace for the selected work. This phase runs for all
+invocation modes.
+
+1. Create a feature branch from `main`:
+   - Single issue: `issue-<number>/<slug>` (e.g., `issue-27/next-issue-initiation`)
+   - Multi-issue batch: `issues-<numbers>/<slug>` (e.g., `issues-5-8/attribution-cleanup`)
+2. Push the branch and open a draft PR referencing the issue(s):
+   - Title: concise description of the work
+   - Body: `Resolves #N` (or `Resolves #N, resolves #M` for batches)
+   - Draft status: the PR is not ready for review until verification passes
+3. Load issue context into the session: read issue body, comments, and
+   any linked issues or dependencies.
+
+### session-open
+
+Note the starting direction. This is a compass heading, not a contract —
+real development is iterative and the goal sharpens as you learn.
+
 Write:
-- `Session goal`: one observable outcome (artifact or behavior).
-- `Done condition`: binary pass/fail check.
+- `Starting direction`: what you intend to accomplish (1-2 sentences).
 - `Scope gate`: specific nearby work intentionally excluded this session.
 
+Do not require a binary done condition upfront. The closing handoff is
+where honest state matters most.
+
 ### session-close
+
 1. Reach stable checkpoint (done increment or explicit WIP note).
 2. Update issue state and leave a concise progress comment.
 3. Record decisions, blockers, and the exact next step.
 4. Ensure any follow-up work is represented as issue(s).
 5. Sync all changes to remote: `gh-issue-sync push`.
-6. Sync workspace and close.
+
+The closing handoff is the load-bearing artifact:
+- Where you actually ended up (not what you predicted).
+- What remains and what's next.
+- Whether the draft PR is ready for review or still WIP.
+
+## Multi-Issue Batching
+
+Batching 2-3 cohesive issues into a single PR is a legitimate pattern when:
+- The issues share a single deliverable (e.g., related cleanup tasks).
+- Implementing them separately would create throwaway intermediate states.
+- They are all session-sized *in aggregate*.
+
+The draft PR references all issues. `land` closes all referenced issues.
+Do not batch unrelated work — that is scope creep, not batching.
 
 ## Corruption Modes
+
 - `recency-drift`: picking last-touched work instead of highest leverage.
-- `implicit-goal`: starting implementation without explicit session goal.
 - `scope-creep`: crossing concern boundaries mid-session.
 - `blocker-bypass`: beginning blocked work anyway.
 - `state-lag`: issue tracker not reflecting real implementation state.
 - `open-loop-close`: ending session without a concrete next step.
 - `undefined-state`: using terms like "unblocked" or "session-sized" without
   operational definitions — see WORKFLOW.md § Issue-Based Development.
+- `skipped-preparation`: starting implementation without a branch and draft PR.
+- `premature-precision`: treating the starting direction as a rigid contract
+  instead of a compass heading that sharpens with learning.
+- `forced-selection`: running full selection when the operator already
+  specified the issue — wasting time re-deriving a known answer.
+- `unbatched-coupling`: working issues separately that should be a single
+  cohesive PR, creating throwaway intermediate states.
 
 ## Principles
+
 - `clarity-over-volume`: fewer, sharper goals beat broad, vague activity.
 - `truthful-state`: inaccurate issue state is planning debt.
 - `finish-or-frame`: either finish the increment or clearly frame unfinished state.
+- `closing-over-opening`: the closing handoff matters more than the opening direction.
+  Honest state at session end is more valuable than precise prediction at session start.
 
 ## Cross-References
+
+- `land`: the closing bookend — `next-issue` initiates work, `land` closes it.
 - `issue-craft`: decomposition, issue boundaries, acceptance criteria contracts.
 - `ground`: validate assumptions before committing to an approach.
 - `bdd`: behavior-first test strategy for implementation increments.

--- a/skills/decomposition/next-issue/SKILL.md
+++ b/skills/decomposition/next-issue/SKILL.md
@@ -87,7 +87,7 @@ already known.
 Decision stack (≤3 minutes):
 1. Force filter: operator request or deadline cliff wins immediately.
 2. Shortlist 3-5 unblocked issues from the lowest available execution layer.
-3. Score: `(Value + TimeCriticality + UnblockLeverage) / Effort`.
+3. Score (WSJF-lite): `(Value + TimeCriticality + UnblockLeverage) / Effort`.
 4. Prefer the highest score that can be completed this session.
 5. If tie: choose the option that unblocks the most downstream work.
 
@@ -96,6 +96,7 @@ Decision stack (≤3 minutes):
 Set up the workspace for the selected work. This phase runs for all
 invocation modes.
 
+0. Sync local issues if not already synced: `gh-issue-sync pull`.
 1. Create a feature branch from `main`:
    - Single issue: `issue-<number>/<slug>` (e.g., `issue-27/next-issue-initiation`)
    - Multi-issue batch: `issues-<numbers>/<slug>` (e.g., `issues-5-8/attribution-cleanup`)
@@ -121,10 +122,11 @@ where honest state matters most.
 ### session-close
 
 1. Reach stable checkpoint (done increment or explicit WIP note).
-2. Update issue state and leave a concise progress comment.
-3. Record decisions, blockers, and the exact next step.
-4. Ensure any follow-up work is represented as issue(s).
-5. Sync all changes to remote: `gh-issue-sync push`.
+2. Push commits to the feature branch.
+3. Update issue state and leave a concise progress comment.
+4. Record decisions, blockers, and the exact next step.
+5. Ensure any follow-up work is represented as issue(s).
+6. Sync all changes to remote: `gh-issue-sync push`.
 
 The closing handoff is the load-bearing artifact:
 - Where you actually ended up (not what you predicted).
@@ -138,7 +140,11 @@ Batching 2-3 cohesive issues into a single PR is a legitimate pattern when:
 - Implementing them separately would create throwaway intermediate states.
 - They are all session-sized *in aggregate*.
 
-The draft PR references all issues. `land` closes all referenced issues.
+The draft PR references all issues. At session close, `land` closes all
+referenced issues. Note: `land` currently handles single-issue closing;
+for multi-issue batches, close additional issues manually until `land`
+gains multi-issue support.
+
 Do not batch unrelated work — that is scope creep, not batching.
 
 ## Corruption Modes
@@ -151,6 +157,8 @@ Do not batch unrelated work — that is scope creep, not batching.
 - `undefined-state`: using terms like "unblocked" or "session-sized" without
   operational definitions — see WORKFLOW.md § Issue-Based Development.
 - `skipped-preparation`: starting implementation without a branch and draft PR.
+- `directionless-start`: beginning implementation without noting a starting
+  direction or scope gate — the session-open phase was skipped entirely.
 - `premature-precision`: treating the starting direction as a rigid contract
   instead of a compass heading that sharpens with learning.
 - `forced-selection`: running full selection when the operator already

--- a/skills/decomposition/plan/SKILL.md
+++ b/skills/decomposition/plan/SKILL.md
@@ -182,6 +182,6 @@ implementation mistakes.
   must implement.
 - `writing-plans`: step-by-step execution breakdown — takes a
   decision-complete design and produces ordered implementation steps.
-- `next-issue`: work selection — identifies which issue to plan for.
+- `next-issue`: work initiation — selects work and prepares workspace before planning begins.
 - `issue-craft`: issue quality — ensures the issue is agent-executable
   before planning begins.

--- a/skills/specification/bdd/SKILL.md
+++ b/skills/specification/bdd/SKILL.md
@@ -101,7 +101,7 @@ When a test fails after change, classify failure as one of:
 - `single-pipeline`: BDD and TDD are complementary stages in one flow, not alternatives.
 
 ## Cross-References
-- `next-issue`: session-level prioritization and execution sequencing.
+- `next-issue`: work initiation — selects work, prepares workspace, opens session.
 - `issue-craft`: acceptance-criteria rigor and issue decomposition.
 - `superpowers/writing-plans`: decomposes implementation while preserving behavior traceability.
 - `superpowers/test-driven-development`: executes RED-GREEN-REFACTOR for BDD-defined behaviors.

--- a/skills/using-groundwork/SKILL.md
+++ b/skills/using-groundwork/SKILL.md
@@ -17,7 +17,7 @@ Groundwork is one connected methodology, not a skill collection. Every skill clo
 
 ## The Flow
 
-`ground` fires first — establishing what the work must enable. Local issues (`.issues/`) mirror the forge — `gh-issue-sync pull` before reading, `push` after writing. From grounded constraints, `bdd` defines the behavior contract — executable expectations threading through every step. `issue-craft` decomposes that contracted behavior into agent-executable issues. `next-issue` selects session-sized work from the issue graph. `plan` converges from exploration to a decision-complete implementation design — every approach, interface, and edge case resolved before code changes. `writing-plans` translates the design into implementation steps. `test-driven-development` implements them through RED-GREEN-REFACTOR — each RED test maps to a named behavior scenario. `subagent-driven-development` parallelizes independent tasks when the plan supports it. `verification-before-completion` demands behavior-level evidence before any completion claim. `land` closes the loop: merge, cleanup, and behavior coverage record.
+`ground` fires first — establishing what the work must enable. Local issues (`.issues/`) mirror the forge — `gh-issue-sync pull` before reading, `push` after writing. From grounded constraints, `bdd` defines the behavior contract — executable expectations threading through every step. `issue-craft` decomposes that contracted behavior into agent-executable issues. `next-issue` initiates a work session — selecting from the issue graph (or accepting issue numbers directly), creating a feature branch and draft PR, and starting with a clear direction. It is the opening bookend to `land`. `plan` converges from exploration to a decision-complete implementation design — every approach, interface, and edge case resolved before code changes. `writing-plans` translates the design into implementation steps. `test-driven-development` implements them through RED-GREEN-REFACTOR — each RED test maps to a named behavior scenario. `subagent-driven-development` parallelizes independent tasks when the plan supports it. `verification-before-completion` demands behavior-level evidence before any completion claim. `land` closes the loop: merge, cleanup, and behavior coverage record.
 
 ## Why Issues Are Central
 
@@ -44,7 +44,7 @@ reliable. See WORKFLOW.md § Issue-Based Development for operational definitions
 - Outcomes unclear or behavior undefined? → `bdd`
 - Need reliable external evidence? → `research`
 - Creating, decomposing, or refining issues? → `issue-craft`
-- Selecting next work from the issue graph? → `next-issue`
+- Starting a work session (select work, create branch, open draft PR)? → `next-issue`
 - Multiple approaches or unclear scope? → `plan`
 - Ready to translate design into steps? → `writing-plans`
 - Implementing behavior? → `test-driven-development`


### PR DESCRIPTION
## Summary

- Broadens `next-issue` from a selection-only skill to a full work initiation discipline — the opening bookend to `land`
- Adds three invocation modes: no-args (full selection), issue number(s) (skip to preparation), topic string (narrowed selection)
- New `prepare` phase creates feature branch and opens draft PR before implementation begins
- Session open captures starting direction instead of requiring a rigid binary done condition upfront
- Multi-issue batching into a single PR is an explicitly supported pattern

## Test plan

- [ ] Read the rewritten `next-issue` SKILL.md and verify all 8 acceptance criteria from #27 are met
- [ ] Verify cross-references are updated in `issue-craft`, `plan`, `bdd`, `land`, `using-groundwork`
- [ ] Verify WORKFLOW.md pipeline description and routing table reflect the broadened role
- [ ] Verify pipeline-contract.md has the new `next-issue -> execution` and `next-issue <-> land` handoff contracts
- [ ] Verify CHANGELOG.md entry covers the changes

Resolves #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)