### PR TITLE
feat: define artifact frontmatter schema

### DIFF
--- a/crates/groundwork-cli/tests/artifact_frontmatter_schema.rs
+++ b/crates/groundwork-cli/tests/artifact_frontmatter_schema.rs
@@ -1,0 +1,263 @@
+use jsonschema::Validator;
+use serde_json::Value;
+
+const SCHEMA_PATH: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../../schemas/artifact-frontmatter.schema.json");
+const SPEC_FIXTURE: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../../tests/fixtures/spec-artifact-frontmatter.yaml");
+const VERIFICATION_FIXTURE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../tests/fixtures/verification-artifact-frontmatter.yaml"
+);
+
+fn load_schema() -> Validator {
+    let text = std::fs::read_to_string(SCHEMA_PATH).expect("read schema");
+    let value: Value = serde_json::from_str(&text).expect("parse schema JSON");
+    Validator::new(&value).expect("compile schema")
+}
+
+fn yaml_to_json(yaml: &str) -> Value {
+    serde_yml::from_str(yaml).expect("parse YAML")
+}
+
+// ── Valid fixtures ──────────────────────────────────────────────
+
+#[test]
+fn valid_spec_artifact_frontmatter() {
+    let validator = load_schema();
+    let text = std::fs::read_to_string(SPEC_FIXTURE).expect("read fixture");
+    let instance = yaml_to_json(&text);
+    assert!(validator.is_valid(&instance), "spec fixture should be valid");
+}
+
+#[test]
+fn valid_verification_artifact_frontmatter() {
+    let validator = load_schema();
+    let text = std::fs::read_to_string(VERIFICATION_FIXTURE).expect("read fixture");
+    let instance = yaml_to_json(&text);
+    assert!(
+        validator.is_valid(&instance),
+        "verification fixture should be valid"
+    );
+}
+
+// ── Required field rejections ───────────────────────────────────
+
+#[test]
+fn rejects_missing_schema() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "freshness: fresh\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\n",
+    );
+    assert!(!validator.is_valid(&instance), "missing schema should be rejected");
+}
+
+#[test]
+fn rejects_missing_freshness() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: schemas/x.schema.json\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\n",
+    );
+    assert!(
+        !validator.is_valid(&instance),
+        "missing freshness should be rejected"
+    );
+}
+
+#[test]
+fn rejects_missing_produced_by() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: schemas/x.schema.json\nfreshness: fresh\nproduced_at: \"2026-03-05T14:30:00Z\"\n",
+    );
+    assert!(
+        !validator.is_valid(&instance),
+        "missing produced_by should be rejected"
+    );
+}
+
+#[test]
+fn rejects_missing_produced_at() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: schemas/x.schema.json\nfreshness: fresh\nproduced_by: ground\n",
+    );
+    assert!(
+        !validator.is_valid(&instance),
+        "missing produced_at should be rejected"
+    );
+}
+
+// ── Enum rejections ─────────────────────────────────────────────
+
+#[test]
+fn rejects_unknown_freshness() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: schemas/x.schema.json\nfreshness: expired\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\n",
+    );
+    assert!(
+        !validator.is_valid(&instance),
+        "unknown freshness value should be rejected"
+    );
+}
+
+#[test]
+fn rejects_unknown_approval() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: schemas/x.schema.json\nfreshness: fresh\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\napproval: maybe\n",
+    );
+    assert!(
+        !validator.is_valid(&instance),
+        "unknown approval value should be rejected"
+    );
+}
+
+// ── additionalProperties rejections ─────────────────────────────
+
+#[test]
+fn rejects_extra_field_at_top_level() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: schemas/x.schema.json\nfreshness: fresh\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\nversion: \"1.0\"\n",
+    );
+    assert!(
+        !validator.is_valid(&instance),
+        "extra field at top level should be rejected"
+    );
+}
+
+#[test]
+fn rejects_extra_field_in_dependency_entry() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: schemas/x.schema.json\nfreshness: fresh\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\ndepends_on:\n  - artifact: behavior-contract\n    optional: true\n",
+    );
+    assert!(
+        !validator.is_valid(&instance),
+        "extra field in dependency entry should be rejected"
+    );
+}
+
+// ── String pattern rejections ───────────────────────────────────
+
+#[test]
+fn rejects_invalid_produced_by() {
+    let validator = load_schema();
+
+    for bad in ["", "Has Spaces", "../traversal", "UPPER", "123-start"] {
+        let yaml = format!(
+            "schema: schemas/x.schema.json\nfreshness: fresh\nproduced_by: \"{bad}\"\nproduced_at: \"2026-03-05T14:30:00Z\"\n"
+        );
+        let instance = yaml_to_json(&yaml);
+        assert!(
+            !validator.is_valid(&instance),
+            "produced_by {:?} should be rejected",
+            bad
+        );
+    }
+}
+
+#[test]
+fn rejects_absolute_schema_path() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: /etc/shadow\nfreshness: fresh\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\n",
+    );
+    assert!(
+        !validator.is_valid(&instance),
+        "absolute schema path should be rejected"
+    );
+}
+
+#[test]
+fn rejects_traversal_schema_path() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: ../../../etc/passwd\nfreshness: fresh\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\n",
+    );
+    assert!(
+        !validator.is_valid(&instance),
+        "traversal schema path should be rejected"
+    );
+}
+
+#[test]
+fn rejects_invalid_produced_at() {
+    let validator = load_schema();
+
+    for bad in [
+        "2026-03-05",                     // date only, no time
+        "2026-03-05T14:30:00",            // no timezone
+        "not-a-date",                     // garbage
+        "2026-03-05 14:30:00Z",           // space instead of T
+    ] {
+        let yaml = format!(
+            "schema: schemas/x.schema.json\nfreshness: fresh\nproduced_by: ground\nproduced_at: \"{bad}\"\n"
+        );
+        let instance = yaml_to_json(&yaml);
+        assert!(
+            !validator.is_valid(&instance),
+            "produced_at {:?} should be rejected",
+            bad
+        );
+    }
+}
+
+// ── Optional field acceptance ───────────────────────────────────
+
+#[test]
+fn valid_without_depends_on() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: schemas/x.schema.json\nfreshness: fresh\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\n",
+    );
+    assert!(
+        validator.is_valid(&instance),
+        "omitting depends_on should be valid"
+    );
+}
+
+#[test]
+fn valid_with_empty_depends_on() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: schemas/x.schema.json\nfreshness: fresh\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\ndepends_on: []\n",
+    );
+    assert!(
+        validator.is_valid(&instance),
+        "empty depends_on should be valid"
+    );
+}
+
+#[test]
+fn valid_without_approval() {
+    let validator = load_schema();
+    let instance = yaml_to_json(
+        "schema: schemas/x.schema.json\nfreshness: fresh\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\ndepends_on:\n  - artifact: behavior-contract\n",
+    );
+    assert!(
+        validator.is_valid(&instance),
+        "omitting approval should be valid"
+    );
+}
+
+// ── Dependency pattern rejections ───────────────────────────────
+
+#[test]
+fn rejects_invalid_dependency_artifact_name() {
+    let validator = load_schema();
+
+    for bad in ["", "Has Spaces", "../traversal", "UPPER", "123-start"] {
+        let yaml = format!(
+            "schema: schemas/x.schema.json\nfreshness: fresh\nproduced_by: ground\nproduced_at: \"2026-03-05T14:30:00Z\"\ndepends_on:\n  - artifact: \"{bad}\"\n"
+        );
+        let instance = yaml_to_json(&yaml);
+        assert!(
+            !validator.is_valid(&instance),
+            "dependency artifact name {:?} should be rejected",
+            bad
+        );
+    }
+}

--- a/docs/architecture/decisions/0003-artifact-frontmatter-format.md
+++ b/docs/architecture/decisions/0003-artifact-frontmatter-format.md
@@ -1,0 +1,80 @@
+# ADR-0003: Artifact Frontmatter Format
+
+**Status:** Accepted
+**Date:** 2026-03-05
+
+## Context
+
+With the pipeline contract schema defined for skills (ADR-0002), every artifact produced by the pipeline also needs machine-readable metadata. This frontmatter lives at the top of each artifact file in `.groundwork/artifacts/` and is the read surface for `groundwork check` — it builds the dependency graph and computes pipeline state from these fields.
+
+This ADR documents four design decisions about that frontmatter's structure: the two-axis status model, why certain states are computed rather than stored, how dependencies reference other artifacts, and how artifact content format is determined.
+
+## Decision Drivers
+
+- The frontmatter must support both agent-driven and human-driven state transitions
+- Pipeline state must be derivable without global coordination between artifacts
+- Artifact references must be stable across projects with different directory layouts
+- The schema must be machine-validatable using the same `jsonschema` tooling as skill frontmatter
+
+## Decision
+
+### 1. Two-axis status model: freshness x approval
+
+Artifact status is modeled as two orthogonal axes rather than a single status field:
+
+- **`freshness`** (`fresh` | `stale`) — determined by agents. An artifact is `fresh` when it was produced from current inputs; `stale` when any of its dependencies have changed since production.
+- **`approval`** (`pending` | `approved` | `rejected`) — determined by humans. Present only when `pipeline.toml` requires human review for the artifact type.
+
+**Rationale:** Agent-determined and human-determined states change at different times, through different mechanisms, and for different reasons. Collapsing them into a single enum (e.g., `draft`, `reviewed`, `approved`, `stale`) creates ambiguous states: is a `stale` artifact one that was never reviewed, or one that was approved but whose inputs changed? Two orthogonal axes make every combination expressible and unambiguous.
+
+### 2. Computed states: `blocked` and `ready` are derived, not stored
+
+The states `blocked` (waiting on upstream dependencies) and `ready` (all dependencies satisfied, eligible to run) are computed by `groundwork check` from the dependency graph. They are not stored in artifact frontmatter.
+
+**Rationale:** Storing `blocked` or `ready` in individual artifacts would require keeping them in sync whenever any upstream artifact changes. This creates a distributed consistency problem — every artifact update would need to cascade through the graph. Instead, `groundwork check` reads all artifact frontmatter, builds the dependency graph, and computes these states on demand. The graph is the single source of truth; individual artifacts only store their own local state.
+
+### 3. Artifact names, not file paths
+
+The `depends_on` array references artifacts by type name (e.g., `behavior-contract`) or by specific filename (e.g., `tested-implementation.yaml`), not by file paths. The dependency entry pattern (`^[a-z][a-z0-9]*([-.][a-z0-9]+)*$`) is slightly more permissive than the skill-schema artifact entry pattern to accommodate filenames with extensions.
+
+**Rationale:** Same rationale as ADR-0002 decision 2 — artifact type names are stable identifiers that mean the same thing across projects. File paths are implementation details. The `schema` field (separate from dependency entries) points to the artifact type's schema definition, keeping structural validation separate from dependency declaration.
+
+### 4. Artifact content format
+
+The content below the frontmatter varies by artifact type:
+
+- **YAML frontmatter + Markdown body** for prose-heavy artifacts (e.g., implementation plans, behavior contracts). The frontmatter is validated by this schema; the Markdown body carries the artifact's content but is not schema-validated.
+- **Pure YAML** for structured artifacts (e.g., test evidence, completion records). The entire file is YAML, and both frontmatter and body sections are schema-validatable.
+
+The artifact type schema (referenced by the `schema` field in frontmatter) determines which format applies.
+
+**Rationale:** Prose-heavy artifacts need Markdown for readability — forcing implementation plans into YAML structures would sacrifice clarity for machine-parseability. Structured artifacts benefit from end-to-end schema validation. Rather than forcing one format on all artifact types, the type schema declares the expected format. This keeps the frontmatter schema simple (it validates only the common metadata header) while allowing type schemas to specify their own content structure.
+
+### 5. String-level type constraints
+
+The `schema` field uses the same relative-path pattern as ADR-0002 decision 4 (`^[a-z0-9]`, `minLength: 1`). The `produced_by` field uses the kebab-case skill-name pattern (`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`). The `depends_on` artifact pattern (`^[a-z][a-z0-9]*([-.][a-z0-9]+)*$`) is slightly more permissive to allow filenames with extensions. The `produced_at` field uses a regex for ISO 8601 with mandatory timezone; fractional seconds are intentionally excluded — producing agents must truncate to whole seconds.
+
+As with ADR-0002: the `schema` path pattern blocks leading `../` and `/` but not mid-path traversal segments (e.g., `a/../b`); runtime path resolution must canonicalize.
+
+## Consequences
+
+### Good
+
+- `groundwork check` can build the full dependency graph from frontmatter alone, without parsing artifact bodies
+- The two-axis model makes agent and human state transitions independent — no coordination required
+- Computed states (`blocked`, `ready`) are always consistent because they derive from the graph, not from stored values
+- The content format decision avoids a false choice between prose readability and schema validation
+
+### Neutral
+
+- The `approval` field is optional at the schema level. Whether an artifact type requires approval is a pipeline configuration concern (`pipeline.toml`), not a format concern.
+
+### Bad
+
+- Two axes mean more states to reason about (6 combinations when approval is present). Tooling must present these clearly.
+- Dependency names must be coordinated across skills and artifacts. There is no registry yet; that is a future concern (same as ADR-0002).
+
+### Risks
+
+- If the dependency graph grows large, computing `blocked`/`ready` on every `groundwork check` invocation could become slow. Caching strategies can mitigate this if needed.
+- The content format split (Markdown vs. pure YAML) means tooling must handle two parsing paths. The `schema` field tells tooling which path to take, but this adds implementation complexity.

--- a/schemas/artifact-frontmatter.schema.json
+++ b/schemas/artifact-frontmatter.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/artifact-frontmatter.schema.json",
+  "title": "Artifact Frontmatter",
+  "description": "Validates the YAML frontmatter on pipeline artifacts in .groundwork/artifacts/. Defines freshness, approval, provenance, and dynamic dependencies.",
+  "type": "object",
+  "required": ["schema", "freshness", "produced_by", "produced_at"],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "type": "string",
+      "description": "Path to the artifact type's schema, relative to .groundwork/.",
+      "pattern": "^[a-z0-9]",
+      "minLength": 1
+    },
+    "freshness": {
+      "type": "string",
+      "description": "Agent-determined staleness axis.",
+      "enum": ["fresh", "stale"]
+    },
+    "produced_by": {
+      "type": "string",
+      "description": "The skill name that produced this artifact.",
+      "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+    },
+    "produced_at": {
+      "type": "string",
+      "description": "ISO 8601 datetime with mandatory timezone offset.",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]\\d{2}:\\d{2})$"
+    },
+    "depends_on": {
+      "type": "array",
+      "description": "Dynamic dependencies declared by the producing agent.",
+      "items": {
+        "$ref": "#/$defs/dependency-entry"
+      }
+    },
+    "approval": {
+      "type": "string",
+      "description": "Human-determined approval axis. Present only when pipeline.toml requires it.",
+      "enum": ["pending", "approved", "rejected"]
+    }
+  },
+  "$defs": {
+    "dependency-entry": {
+      "type": "object",
+      "description": "A reference to an artifact this artifact depends on.",
+      "required": ["artifact"],
+      "additionalProperties": false,
+      "properties": {
+        "artifact": {
+          "type": "string",
+          "description": "Artifact type name or specific artifact filename.",
+          "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/spec-artifact-frontmatter.yaml
+++ b/tests/fixtures/spec-artifact-frontmatter.yaml
@@ -1,0 +1,4 @@
+schema: schemas/verified-constraints.schema.json
+freshness: fresh
+produced_by: ground
+produced_at: "2026-03-05T14:30:00Z"

--- a/tests/fixtures/verification-artifact-frontmatter.yaml
+++ b/tests/fixtures/verification-artifact-frontmatter.yaml
@@ -1,0 +1,8 @@
+schema: schemas/test-evidence.schema.json
+freshness: stale
+produced_by: test-driven-development
+produced_at: "2026-03-05T16:45:00+00:00"
+depends_on:
+  - artifact: behavior-contract
+  - artifact: tested-implementation.yaml
+approval: pending


### PR DESCRIPTION
## Summary

- Add `schemas/artifact-frontmatter.schema.json` — JSON Schema for pipeline artifact metadata (`schema`, `freshness`, `produced_by`, `produced_at`, `depends_on`, `approval`)
- Add two test fixtures (minimal spec artifact, full verification artifact) and 17 Rust validation tests covering required fields, enum constraints, `additionalProperties`, string patterns, and optional field acceptance
- Add ADR-0003 documenting the two-axis status model (freshness × approval), computed states, artifact name references, and content format decisions

Closes #34

## Test plan

- [x] `cargo test -p groundwork-cli` — all 17 new tests pass alongside 11 existing tests (28 total)
- [x] JSON Schema parses cleanly (`python3 -c "import json; json.load(open(...))"`)
- [x] ADR-0003 covers all four acceptance-criteria topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)