### PR TITLE
docs: remove redundant land confirmation

### DIFF
--- a/.codex/skills/land/SKILL.md
+++ b/.codex/skills/land/SKILL.md
@@ -20,6 +20,7 @@ Use this skill when the user wants full delivery closure in one command.
 6. Verify final state
 
 Do not stop after merge.
+Do not ask for an additional confirmation before landing; invoking `land` is the user's approval to execute this workflow.
 
 ---
 

--- a/skills/completion/land/SKILL.md
+++ b/skills/completion/land/SKILL.md
@@ -20,6 +20,7 @@ Use this skill when the user wants full delivery closure in one command.
 6. Verify final state
 
 Do not stop after merge.
+Do not ask for an additional confirmation before landing; invoking `land` is the user's approval to execute this workflow.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that invoking `land` is already approval to execute the landing workflow
- remove the implied need for a second confirmation before merge/close actions

## Verification
- reviewed the resulting diff in both in-repo skill copies
