### PR TITLE
fix(curation): remove skill-authoring meta-skill from runtime pipeline (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Five-stage methodology pipeline: frame constraints, define behavior, decompose, execute and verify, land
 - Nine core skills: `ground`, `research`, `bdd`, `issue-craft`, `next-issue`, `plan`, `documentation`, `land`, and `using-groundwork` (methodology orientation)
-- Eight curated skills from [obra/superpowers](https://github.com/obra/superpowers): `brainstorming`, `writing-skills`, `subagent-driven-development`, `test-driven-development`, `systematic-debugging`, `verification-before-completion`, `requesting-code-review`, `receiving-code-review`
+- Seven curated skills from [obra/superpowers](https://github.com/obra/superpowers): `brainstorming`, `subagent-driven-development`, `test-driven-development`, `systematic-debugging`, `verification-before-completion`, `requesting-code-review`, `receiving-code-review`
 - Rust CLI (`groundwork init`, `update`, `list`, `doctor`) with curated manifest and `sk` integration
 - Automatic `gh-issue-sync` installation during `groundwork init`
 - Schema distribution in CLI: `init/update` now provision `.groundwork/schemas/`, create `.groundwork/artifacts/`, and `doctor` reports schema completeness/drift
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Renamed `planning` skill to `next-issue`; added separate `plan` skill for design convergence
 - Reframed sovereignty as a fractal principle (applies at every interface, not just human-agent)
 - Removed the prescriptive step-script decomposition skill from the curated set and live pipeline docs; rationale recorded in [`docs/research/epic-7-methodology-research.md`](docs/research/epic-7-methodology-research.md). Groundwork intentionally overrides `brainstorming`'s upstream `writing-plans` handoff through `WORKFLOW.md` and `using-groundwork`.
+- Removed the curated skill-authoring meta-skill from runtime docs/config so first-session agents only load pipeline-relevant skills.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ For the full integration manual, see [WORKFLOW.md](WORKFLOW.md). For formal hand
 | `verification-before-completion` | Verification | False completion claims without evidence |
 | `documentation` | Verification | Drifted docs, missing artifact updates |
 | `land` | Completion | Branch rot, unclosed issues, incomplete delivery |
-| `writing-skills` | Meta | Deploying untested process documentation |
 | `using-groundwork` | Meta | Using skills in isolation instead of as a connected pipeline |
 
 ## Install

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -172,7 +172,6 @@ If `gh-issue-sync pull` fails with missing project scope (`read:project`) or `gr
 | `receiving-code-review` | when receiving review feedback, before implementing suggestions |
 | `documentation` | after code changes that may cause drift, at project initialization, when architectural decisions are made, or when docs fail the audience test |
 | `verification-before-completion` | before claiming work is complete, fixed, or passing — evidence first |
-| `writing-skills` | when creating or revising a SKILL.md — TDD-for-documentation with pressure-scenario validation |
 | `land` | merge-and-close completion events: `land`, `merge and close`, `ship it` |
 
 ## Install

--- a/agents.toml
+++ b/agents.toml
@@ -16,7 +16,6 @@ land = { gh = "pentaxis93/groundwork", path = "skills/completion/land" }
 documentation = { gh = "pentaxis93/groundwork", path = "skills/verification/documentation" }
 using_groundwork = { gh = "pentaxis93/groundwork", path = "skills/using-groundwork" }
 brainstorming = { gh = "obra/superpowers", path = "skills/brainstorming", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
-writing_skills = { gh = "obra/superpowers", path = "skills/writing-skills", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
 subagent_driven_development = { gh = "obra/superpowers", path = "skills/subagent-driven-development", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
 test_driven_development = { gh = "obra/superpowers", path = "skills/test-driven-development", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
 systematic_debugging = { gh = "obra/superpowers", path = "skills/systematic-debugging", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }

--- a/manifests/curation.v1.toml
+++ b/manifests/curation.v1.toml
@@ -15,11 +15,6 @@ path = "skills/brainstorming"
 reason = "Prevents coding-before-design by enforcing design clarification."
 
 [[curated_sources.skills]]
-name = "writing-skills"
-path = "skills/writing-skills"
-reason = "Prevents deploying untested skills by enforcing TDD-for-documentation with pressure-scenario validation."
-
-[[curated_sources.skills]]
 name = "subagent-driven-development"
 path = "skills/subagent-driven-development"
 reason = "Prevents context drift by using fresh subagents and staged review loops."


### PR DESCRIPTION
## Summary
- remove the curated `writing-skills` entry from runtime manifest and dependency config
- remove routing/docs references from README and WORKFLOW so first-session agents see only pipeline-relevant skills
- update changelog curated-skill inventory and note the runtime removal

## Verification
- `rg -n -i "writing[-_ ]skills|writing.skills" . --glob '!.issues/**' --glob '!docs/research/**' --glob '!.codex/**'`
- `cargo test`
