### PR TITLE
Generalize land skill from WeForge to GitHub

### DIFF
--- a/docs/architecture/decisions/0001-pipeline-integration-strategy.md
+++ b/docs/architecture/decisions/0001-pipeline-integration-strategy.md
@@ -30,7 +30,7 @@ Integration strategy depends on where a skill sits relative to pipeline boundari
 **Own (make first-party)** when the skill is at a pipeline boundary and must produce or consume specific handoff artifacts, or when the upstream skill embeds context assumptions that conflict with Groundwork's general-purpose scope. The signal is: documentation alone cannot make the skill behave correctly in the pipeline.
 
 **Current evidence for this distinction:**
-- `land` (core, boundary skill) has 8 hardcoded WeForge API calls — a legacy from personal tooling. It works for one forge but breaks the README's promise of "a methodology library for AI coding agents." This is a boundary skill that must eventually be generalized.
+- `land` (core, boundary skill) uses `gh` CLI for forge operations. This is a boundary skill that must remain forge-agnostic.
 - `research` (core, boundary skill) declares `compatibility: opencode` and references an opencode-specific agent file. Same pattern — context assumptions from a prior environment.
 - `test-driven-development` (curated, mid-pipeline) works with any codebase and any agent. No pipeline-specific adaptation needed. Curation is correct here.
 
@@ -53,5 +53,5 @@ Integration strategy depends on where a skill sits relative to pipeline boundari
 
 ### Risks
 
-- Legacy skill debt (`land`, `research`) is acknowledged but not resolved by this ADR. These skills need separate issues to generalize their context assumptions.
+- Legacy skill debt (`research`) is acknowledged but not resolved by this ADR. `land` was generalized in issue #23; `research` still needs a separate issue to generalize its context assumptions.
 - Future upstream skills may change in ways that break curation assumptions. Pinning to commits mitigates this but does not eliminate it.

--- a/docs/research/what-should-groundwork-be-made-of.md
+++ b/docs/research/what-should-groundwork-be-made-of.md
@@ -166,9 +166,9 @@ Recommendation: adapt to "solo shipping checklist" (especially migrations, flags
 
 22. **`groundwork:land`** (in this repo)
 Solves: "shipping without cleanup/closure" with a one-word closeout workflow.
-Quality: strong but WeForge-specific.
+Quality: strong; generalized to GitHub CLI.
 Mission fit: high.
-Recommendation: keep; consider forge-agnostic wrapper plus WeForge plugin variant.
+Recommendation: keep.
 
 ### D) Security and Safety of Inputs (prevents: prompt injection, tool abuse, poisoned requirements)
 

--- a/skills/land/SKILL.md
+++ b/skills/land/SKILL.md
@@ -91,7 +91,7 @@ else
 fi
 
 gh issue comment "$ISSUE_NUMBER" --body "$BODY"
-gh issue close "$ISSUE_NUMBER" --reason completed
+gh issue close "$ISSUE_NUMBER"
 ```
 
 ### 5a. Sync issue state to local mirror
@@ -114,7 +114,7 @@ Success conditions:
 - current branch is `main`
 - working tree is clean
 - feature branch absent on origin
-- issue state is `closed`
+- issue state is `CLOSED`
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace all WeForge-specific `curl` calls and `pass show` auth with `gh` CLI equivalents (`gh pr list`, `gh issue comment`, `gh issue close`, `gh issue view`)
- Remove OWNER/REPO URL parsing — `gh` resolves repo context from the git remote automatically
- Update Related Skills from `forgejo-api`/`credentials` to `issue-craft`/`next-issue`

Closes #23

## Test plan

- [ ] Grep `skills/land/SKILL.md` for `weforge`, `pass show`, `curl`, `forgejo` — expect zero matches
- [ ] Read through the final file to confirm procedure flow is coherent
- [ ] Run `land` on a feature branch to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)