### PR TITLE
refactor(research): v1.2 → v1.3 — lean tool guidance, actionable output template, portable

### DIFF
--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -228,13 +228,13 @@ Official docs miss the "clever hacks" and "power user moves." Target them with q
 | Pattern | Query Template | Domain Filter |
 |---------|---------------|---------------|
 | GitHub issue archaeology | `[tech] workaround OR hack OR trick` | `github.com` |
-| Maintainer statements | `[tech] [problem] fix OR resolved` | `github.com` |
+| Maintainer statements | `[tech] [problem] fix OR resolved` | `github.com`, `search_depth: "advanced"` |
 | Stack Overflow deep cuts | `[tech] [problem] note that OR also need to` | `stackoverflow.com` |
 | Recent developments | `[tech] [feature] announcement OR release` | Use `time_range: "month"` |
 | Breaking changes | `[tech] breaking change OR migration guide` | Use `topic: "news"` |
 | Config wisdom | `[tool] dotfiles OR awesome-[tool] config` | `github.com` |
 
-**Emotional language signals:** Hard-won knowledge often comes with markers like "Finally!", "After hours of debugging...", "The trick is...", "What the docs don't tell you..." When you find such knowledge, preserve the source, version, solution, and caveats alongside it.
+**Emotional language signals:** Hard-won knowledge often comes with markers like "Finally!", "After hours of debugging...", "The trick is...", "What the docs don't tell you..." When you find such knowledge, capture it with context: `[Problem] / [Source + date] / [Version] / [Solution] / [Caveats]`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Slim Tavily parameter tables to strategic guidance only (parallelization, escalation, extract-vs-search); agents already get parameters from tool schemas
- Cut over-engineered source evaluation scoring table; keep trust hierarchy and red flags
- Replace ghost `google_search` references with `WebSearch` (the actual available tool)
- Fix `webfetch` → `WebFetch` casing (3 occurrences)
- Add skip/abbreviate guidance to Phase 1 for unambiguous queries
- Add concrete output template to Phase 6 (Synthesis) with findings, conflicts, confidence, limitations
- Condense Practical Wisdom from ~60 lines to ~15 (code block → table, emotional signals → paragraph)
- Replace vault-specific "Vault Integration" with generic "Persisting Findings"

Net result: 324 → 277 lines, no broken tool references, portable across projects.

## Test plan

- [ ] Read final SKILL.md top-to-bottom for coherence
- [ ] Verify no references to `google_search`, lowercase `webfetch`, or vault-specific paths
- [ ] Run `sk sync --skill-target name --non-interactive` to confirm installed copy updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)