### PR TITLE
Remove brainstorming from functioning codebase

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,7 +60,7 @@ The five stages are not a taxonomy — they are an integration architecture. Eac
 
 1. **Frame constraints** (`ground`, `research`) produces verified constraints and substantiated evidence
 2. **Define behavior** (`bdd`) produces Given/When/Then behavior contracts
-3. **Decompose** (`issue-craft`, `next-issue`, `plan`, plus design exploration in `brainstorming`) produces executable issues and implementation designs
+3. **Decompose** (`issue-craft`, `next-issue`, `plan`) produces executable issues and implementation designs
 4. **Execute and verify** (curated skills) produces tested implementations and review evidence
 5. **Land** (`land`) produces closed issues, merged code, and behavior coverage records
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Five-stage methodology pipeline: frame constraints, define behavior, decompose, execute and verify, land
 - Nine core skills: `ground`, `research`, `bdd`, `issue-craft`, `next-issue`, `plan`, `documentation`, `land`, and `using-groundwork` (methodology orientation)
-- Seven curated skills from [obra/superpowers](https://github.com/obra/superpowers): `brainstorming`, `subagent-driven-development`, `test-driven-development`, `systematic-debugging`, `verification-before-completion`, `requesting-code-review`, `receiving-code-review`
+- Six curated skills from [obra/superpowers](https://github.com/obra/superpowers): `subagent-driven-development`, `test-driven-development`, `systematic-debugging`, `verification-before-completion`, `requesting-code-review`, `receiving-code-review`
 - Rust CLI (`groundwork init`, `update`, `list`, `doctor`) with curated manifest and `sk` integration
 - Automatic `gh-issue-sync` installation during `groundwork init`
 - Schema distribution in CLI: `init/update` now provision `.groundwork/schemas/`, create `.groundwork/artifacts/`, and `doctor` reports schema completeness/drift
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `using-groundwork` skill upgraded to v2.1.0: added Entry Point section, folded routing table triggers into flow stages (single source of truth), compressed BDD/Documentation threading from enumerated arrows to principle-based guidance, consolidated corruption modes from 11 items to 5 named categories, added relationship cues to stage 4 execution skills. 108 → 70 lines, same skill coverage. Patch bump: structural refinement, no behavioral change.
 - `using-groundwork` skill upgraded to v2.0.0: restructured as five numbered pipeline stages, added sovereignty guardrail with anti-prescription principle (WHAT/HOW boundary), expanded cross-cutting disciplines (documentation threading, research at any stage), converted routing to table format, added corruption modes for prescription and documentation gaps. Major version bump reflects structural rewrite of the methodology orientation document.
 - `land` skill upgraded to v1.1: added CHANGELOG verification step before merge, updated overview to reflect 7-step procedure. Minor version bump: additive behavioral change (new precondition check).
-- `pipeline-contract.md` updated to v0.2: fixed heading levels (## → ###), updated step 3 to include brainstorming, clarified `documentation-review` reference to "`documentation` skill's review mode"
+- `pipeline-contract.md` updated to v0.2: fixed heading levels (## → ###), clarified `documentation-review` reference to "`documentation` skill's review mode"
 - Added `CLAUDE.md` documenting skill management with `sk` fork
 - Migrated license from Apache-2.0 to MIT
 - `land` skill upgraded to v1.3: added pre-merge acceptance criteria evaluation — satisfied issues are closed, partial issues receive a progress comment listing delivered and remaining criteria, issues without extractable criteria stay open for human review. Prevents premature closure when a branch delivers part of an issue's scope.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There is one path, not a menu. Every piece of work flows through five stages:
 
 **2. Define behavior** — `bdd` defines the behavior contract in Given/When/Then scenarios. This contract threads through every subsequent stage — it is the integration mechanism, not a planning artifact.
 
-**3. Decompose** — `issue-craft` produces agent-executable issues with binary acceptance criteria from the behavior contract. `next-issue` selects session-sized work from the issue graph. `brainstorming` explores design approaches. `plan` converges to a decision-complete implementation design. Approved designs become executable work through `issue-craft`. The issue graph is the project's working memory across sessions.
+**3. Decompose** — `issue-craft` produces agent-executable issues with binary acceptance criteria from the behavior contract. `next-issue` selects session-sized work from the issue graph. `plan` converges to a decision-complete implementation design. Approved designs become executable work through `issue-craft`. The issue graph is the project's working memory across sessions.
 
 **4. Execute and verify** — `test-driven-development` implements behavior through RED-GREEN-REFACTOR — each RED test maps to a named scenario from stage 2. `systematic-debugging` finds root cause before proposing fixes. Code review and `verification-before-completion` gate completion with behavior-level evidence.
 
@@ -41,7 +41,6 @@ For the concise inventory and shipped order reference, see [`skills/skills.toml`
 | `bdd` | Specification | Vague specs, testing implementation instead of behavior |
 | `issue-craft` | Decomposition | Non-executable tasks, vague acceptance criteria |
 | `next-issue` | Decomposition | Recency drift, scope creep, blocker bypass |
-| `brainstorming` | Decomposition | Coding before design is approved |
 | `plan` | Decomposition | Unclear scope, design choices left to implementer |
 | `test-driven-development` | Execution | Implementation-first regressions |
 | `subagent-driven-development` | Execution | Context drift in parallel work |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -26,8 +26,6 @@ Use `issue-craft` to create, decompose, refine, and close issues. It produces ag
 
 Use `next-issue` to select session-sized work from the issue graph. It reads unblocked issues, ranks by value and unblock leverage, and declares a session goal with a binary done condition and explicit scope gate.
 
-Use `brainstorming` before designing a solution or making a significant architectural choice. It explores 2-3 approaches with trade-offs and produces an approved design document.
-
 Use `plan` to converge from exploration to a decision-complete implementation design before modifying code. It explores the codebase, resolves intent, and produces a plan where every design choice is explicit — the implementer does not need to make any decisions. Based on Codex CLI plan mode (MIT), adapted for autonomous execution.
 
 After a design is approved, use `issue-craft` to express the implementation as agent-executable work units with binary acceptance criteria. Approved designs flow into `plan` for convergence and into `issue-craft` for decomposition.
@@ -163,7 +161,6 @@ If `gh-issue-sync pull` fails with missing project scope (`read:project`) or `gr
 | `bdd` | when defining or refining behavior expectations |
 | `issue-craft` | creating/refining task/epic/bug/spike issues |
 | `next-issue` | selecting session-sized work from issue graph, or when a task feels too big to hold in one session |
-| `brainstorming` | before designing a solution or making a significant architectural choice |
 | `plan` | implementation needs design convergence — multiple approaches, unclear scope, or cross-cutting changes |
 | `test-driven-development` | when implementing any feature or bugfix — RED → GREEN → REFACTOR |
 | `subagent-driven-development` | when executing a plan whose tasks are independent and can run in parallel |

--- a/agents.toml
+++ b/agents.toml
@@ -15,7 +15,6 @@ issue_craft = { gh = "pentaxis93/groundwork", path = "skills/issue-craft" }
 land = { gh = "pentaxis93/groundwork", path = "skills/land" }
 documentation = { gh = "pentaxis93/groundwork", path = "skills/documentation" }
 using_groundwork = { gh = "pentaxis93/groundwork", path = "skills/using-groundwork" }
-brainstorming = { gh = "obra/superpowers", path = "skills/brainstorming", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
 subagent_driven_development = { gh = "obra/superpowers", path = "skills/subagent-driven-development", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
 test_driven_development = { gh = "obra/superpowers", path = "skills/test-driven-development", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
 systematic_debugging = { gh = "obra/superpowers", path = "skills/systematic-debugging", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }

--- a/crates/groundwork-cli/src/main.rs
+++ b/crates/groundwork-cli/src/main.rs
@@ -1919,7 +1919,6 @@ mod tests {
                 "ground",
                 "research",
                 "bdd",
-                "brainstorming",
                 "plan",
                 "issue_craft",
                 "next_issue",

--- a/docs/architecture/pipeline-contract.md
+++ b/docs/architecture/pipeline-contract.md
@@ -7,7 +7,7 @@ This file defines the canonical integration contract for Groundwork's methodolog
 Groundwork has one coherent path:
 1. `ground` frames constraints.
 2. `bdd` defines and maintains behavior contract.
-3. `brainstorming` explores approaches. `plan` converges from exploration to a decision-complete implementation design. `issue-craft` decomposes that design into agent-executable issues. `next-issue` selects session-sized work.
+3. `plan` converges from exploration to a decision-complete implementation design. `issue-craft` decomposes that design into agent-executable issues. `next-issue` selects session-sized work.
 4. Curated middle skills implement and verify the same behavior contract.
 5. `land` closes work with behavior coverage visibility.
 

--- a/docs/architecture/pipeline-design.md
+++ b/docs/architecture/pipeline-design.md
@@ -84,7 +84,7 @@ Epic 1 implementation integration (`#36`):
 
 ### Structural/decomposition open area (`Pending`)
 
-- Decomposition-stage topology is settled in the live pipeline as `brainstorming` for exploration, `plan` for convergence, and `issue-craft` for executable work units.
+- Decomposition-stage topology is settled in the live pipeline as `plan` for convergence and `issue-craft` for executable work units.
 - Wrapper-skill policy for curated boundary skills remains open beyond the current decomposition routing.
 
 ## Source of Truth and Cross-References

--- a/skills/skills.toml
+++ b/skills/skills.toml
@@ -29,14 +29,6 @@ repo = "pentaxis93/groundwork"
 use_when = "Use when defining or refining behavior expectations."
 
 [[skills]]
-name = "brainstorming"
-path = "skills/brainstorming"
-provider = "gh"
-repo = "obra/superpowers"
-rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a"
-use_when = "Use before designing a solution or making a significant architectural choice."
-
-[[skills]]
 name = "plan"
 path = "skills/plan"
 provider = "gh"

--- a/skills/using-groundwork/SKILL.md
+++ b/skills/using-groundwork/SKILL.md
@@ -31,7 +31,7 @@ Five stages, in dependency order. Each produces what the next consumes.
 
 2. **Define behavior.** `bdd` defines the behavior contract in Given/When/Then scenarios. This contract threads through every subsequent stage.
 
-3. **Decompose.** Explore approaches (`brainstorming`), converge to a decision-complete design (`plan`), break the design into agent-executable issues (`issue-craft`), and select session-sized work (`next-issue`).
+3. **Decompose.** Converge to a decision-complete design (`plan`), break the design into agent-executable issues (`issue-craft`), and select session-sized work (`next-issue`).
 
 4. **Execute and verify.** Implement through RED-GREEN-REFACTOR (`test-driven-development`), parallelize independent tasks (`subagent-driven-development`), find root cause before fixing (`systematic-debugging`), review code (`requesting-code-review`, `receiving-code-review`), verify behavior-level evidence before claiming done (`verification-before-completion`), and ensure documentation accuracy (`documentation`).
 


### PR DESCRIPTION
## Summary
- Remove brainstorming from shipped dependency manifests (`agents.toml`, `skills/skills.toml`)
- Update CLI shipped-skill order expectation to drop brainstorming
- Align active (non-research) methodology docs with the updated decomposition flow

## Verification
- `cargo test -p groundwork-cli`
- `rg -n -i --hidden --glob '!.git' 'brainstorming' /home/pentaxis93/src/groundwork | grep -v '/docs/research/' || true`
