### PR TITLE
refactor(plan): v1.0 → v1.1 — lean, motivated, better-triggered

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -73,9 +73,6 @@ code.
 4. Identify existing patterns, utilities, and conventions to reuse.
 5. Note what you still do not know after exploration.
 
-Do not skip this phase. Planning from imagination produces plans that
-collide with the actual codebase.
-
 ### phase-2-resolve-intent
 
 Clarify what the change must achieve and what is out of scope. Without


### PR DESCRIPTION
## Summary

- **Eliminate ~26% redundancy**: Remove Three standalone sections (Two Kinds of Unknowns, Requirements, Principles) that restated content already present in the procedures. Fold the one genuinely new principle (`minimum-viable-detail`) into `write-plan`.
- **Strengthen description for triggering**: Add pushier language per skill-creator guidance to combat undertriggering.
- **Add phase motivations**: Each phase now opens with a one-line "why" explaining what failure it prevents, so the agent understands the purpose rather than following steps mechanically.
- **Add interim artifact destination guidance**: `write-plan` now specifies where plans go (conversation vs file), with a note that the pipeline contract will formalize this.

## Test plan

- [ ] Read the updated skill end-to-end and verify no guidance was lost — every piece of removed content should be traceable to its surviving location in the procedures
- [ ] Verify the description triggers appropriately on planning-relevant prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)