### PR TITLE
fix: restore missing bundled resources for bdd and issue-craft skills

### DIFF
--- a/skills/bdd/SKILL.md
+++ b/skills/bdd/SKILL.md
@@ -11,7 +11,9 @@ metadata:
 BDD reframes testing as behavior specification: what the system should do,
 under what context, with observable outcomes.
 
-Reference: [Dan North: Introducing BDD](https://dannorth.net/introducing-bdd/)
+References:
+- [Dan North: Introducing BDD](https://dannorth.net/introducing-bdd/)
+- For concrete language-specific patterns, see [references/language-patterns.md](references/language-patterns.md)
 
 ## Goal
 

--- a/skills/bdd/references/language-patterns.md
+++ b/skills/bdd/references/language-patterns.md
@@ -1,0 +1,259 @@
+# Language Patterns
+
+Concrete BDD patterns for common languages. Each section shows how to
+apply sentence-named behaviours and Given/When/Then structure using the
+language's native test tooling.
+
+## Table of Contents
+
+- [Naming Conventions](#naming-conventions)
+- [Rust](#rust)
+- [Python](#python)
+- [TypeScript / JavaScript](#typescript--javascript)
+- [When to Use a BDD Framework](#when-to-use-a-bdd-framework)
+
+---
+
+## Naming Conventions
+
+The naming pattern adapts to each language's conventions while
+preserving the core rule: test names are sentences describing behaviour.
+
+| Language | Convention | Example |
+|----------|-----------|---------|
+| Rust | `should_` prefix, snake_case | `should_reject_empty_name` |
+| Python | `should_` prefix, snake_case | `test_should_reject_empty_name` |
+| TypeScript | `it("should ...")` or `test("should ...")` | `it("should reject empty name")` |
+| Go | `TestShould` prefix, PascalCase | `TestShouldRejectEmptyName` |
+| Java | `should` prefix, camelCase | `shouldRejectEmptyName` |
+
+The `should` prefix enforces the sentence template from Dan North:
+"The module **should** do something." If a name doesn't fit this
+template, the behaviour may belong elsewhere.
+
+---
+
+## Rust
+
+### Module structure
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_expand_tilde_to_home_directory() {
+        // Given
+        let home = "/home/user";
+        let input = "~/config/loadout.toml";
+
+        // When
+        let result = expand_path(input, home);
+
+        // Then
+        assert_eq!(result, PathBuf::from("/home/user/config/loadout.toml"));
+    }
+
+    #[test]
+    fn should_return_path_unchanged_when_no_tilde() {
+        // Given
+        let input = "/absolute/path/file.toml";
+
+        // When
+        let result = expand_path(input, "/home/user");
+
+        // Then
+        assert_eq!(result, PathBuf::from("/absolute/path/file.toml"));
+    }
+}
+```
+
+Reading the test names as a specification:
+
+```
+expand_path
+  - should expand tilde to home directory
+  - should return path unchanged when no tilde
+```
+
+### Integration tests with temp directories
+
+```rust
+use tempfile::TempDir;
+
+#[test]
+fn should_create_symlink_to_skill_source() {
+    // Given
+    let tmp = TempDir::new().unwrap();
+    let source = tmp.path().join("source/my-skill");
+    let target = tmp.path().join("target");
+    fs::create_dir_all(&source).unwrap();
+    fs::write(source.join("SKILL.md"), "---\nname: my-skill\n---").unwrap();
+    fs::create_dir_all(&target).unwrap();
+
+    // When
+    link_skill(&source, &target).unwrap();
+
+    // Then
+    let link = target.join("my-skill");
+    assert!(link.is_symlink());
+    assert_eq!(fs::read_link(&link).unwrap(), source);
+}
+```
+
+### Error behaviours
+
+```rust
+#[test]
+fn should_return_error_when_config_file_missing() {
+    // Given
+    let path = PathBuf::from("/nonexistent/loadout.toml");
+
+    // When
+    let result = load_config(&path);
+
+    // Then
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("not found"));
+}
+```
+
+### Naming patterns for common scenarios
+
+| Scenario | Test name |
+|----------|-----------|
+| Happy path | `should_parse_valid_config` |
+| Missing input | `should_return_error_when_config_missing` |
+| Invalid input | `should_reject_name_with_uppercase` |
+| Edge case | `should_handle_empty_sources_list` |
+| Boundary | `should_reject_name_longer_than_64_chars` |
+| State-dependent | `should_skip_existing_symlink_when_unchanged` |
+
+---
+
+## Python
+
+### pytest with BDD naming
+
+```python
+class TestConfigLoader:
+
+    def test_should_parse_valid_toml_config(self, tmp_path):
+        # Given
+        config_file = tmp_path / "loadout.toml"
+        config_file.write_text('[sources]\nskills = ["~/skills"]')
+
+        # When
+        config = load_config(config_file)
+
+        # Then
+        assert config.sources.skills == ["~/skills"]
+
+    def test_should_raise_error_when_config_missing(self):
+        # Given
+        path = Path("/nonexistent/config.toml")
+
+        # When / Then
+        with pytest.raises(FileNotFoundError):
+            load_config(path)
+```
+
+### unittest style
+
+```python
+class TestConfigLoaderBehaviour(unittest.TestCase):
+
+    def test_should_expand_environment_variables(self):
+        # Given
+        os.environ["MY_DIR"] = "/custom/path"
+        raw = "$MY_DIR/skills"
+
+        # When
+        result = expand_path(raw)
+
+        # Then
+        self.assertEqual(result, Path("/custom/path/skills"))
+```
+
+---
+
+## TypeScript / JavaScript
+
+### Jest / Vitest
+
+```typescript
+describe("ConfigLoader", () => {
+  it("should parse a valid TOML config", () => {
+    // Given
+    const toml = `[sources]\nskills = ["~/skills"]`;
+
+    // When
+    const config = parseConfig(toml);
+
+    // Then
+    expect(config.sources.skills).toEqual(["~/skills"]);
+  });
+
+  it("should throw when config file is missing", async () => {
+    // Given
+    const path = "/nonexistent/config.toml";
+
+    // When / Then
+    await expect(loadConfig(path)).rejects.toThrow("not found");
+  });
+});
+```
+
+The `describe`/`it` pattern naturally produces readable specs:
+
+```
+ConfigLoader
+  - should parse a valid TOML config
+  - should throw when config file is missing
+```
+
+### Node test runner
+
+```typescript
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+describe("PathExpander", () => {
+  it("should expand tilde to home directory", () => {
+    // Given
+    const input = "~/config/app.toml";
+
+    // When
+    const result = expandPath(input);
+
+    // Then
+    assert.strictEqual(result, `${process.env.HOME}/config/app.toml`);
+  });
+});
+```
+
+---
+
+## When to Use a BDD Framework
+
+Native test tooling with Given/When/Then comments covers most
+codebases. Consider a framework when:
+
+| Signal | Framework option |
+|--------|-----------------|
+| Complex domain with many scenario permutations | `cucumber` (Rust), `pytest-bdd` (Python), `cucumber-js` (TS) |
+| Parameterized scenarios (same structure, varying data) | `rstest` (Rust), `pytest.mark.parametrize` (Python) |
+| Stakeholders need to read/write feature files | Full Gherkin: `.feature` files + step definitions |
+
+For most developer-facing libraries and CLIs, the lightweight
+approach (sentence names + Given/When/Then comments) is sufficient.
+The value of BDD is in the thinking pattern, not the framework.
+
+### Rust BDD crates
+
+| Crate | Style | Use when |
+|-------|-------|----------|
+| `rstest` | Parameterized fixtures | Many scenarios with shared setup, data-driven tests |
+| `rstest-bdd` | Given/When/Then macros on rstest | Want structured BDD syntax without Gherkin files |
+| `cucumber` | Full Gherkin with `.feature` files | Complex domain, stakeholder-readable specs |

--- a/skills/issue-craft/references/templates.md
+++ b/skills/issue-craft/references/templates.md
@@ -1,0 +1,287 @@
+# Issue Templates
+
+Concrete templates for each issue type. Copy and fill in the sections.
+All templates use GitHub-flavored markdown.
+
+## Table of Contents
+
+- [Task Issue](#task-issue)
+- [Epic Issue](#epic-issue)
+- [Bug Report](#bug-report)
+- [Spike / Investigation](#spike--investigation)
+- [Acceptance Criteria Patterns](#acceptance-criteria-patterns)
+- [Dependency Graph Notation](#dependency-graph-notation)
+
+---
+
+## Task Issue
+
+A single deliverable unit of work. Completable in one focused session.
+
+**Title format:** `<type>(<scope>): <what it does>`
+
+```markdown
+## Summary
+
+[1-3 sentences. What needs to exist and why. Reference parent epic if applicable.]
+
+Part of: #N
+
+## Scope
+
+- `src/module/file.rs` — [what changes here]
+- `src/module/other.rs` — [what changes here]
+
+## Acceptance criteria
+
+- [ ] [Observable outcome using a verb: creates, returns, validates, rejects, reports]
+- [ ] [Another observable outcome]
+- [ ] [Testing expectation: unit tests, integration tests, or both]
+
+## Dependencies
+
+Depends on: #A (reason), #B (reason)
+```
+
+### Example: task issue
+
+```markdown
+Title: feat(config): TOML parsing, path expansion, XDG resolution
+
+## Summary
+
+Implement the `config/` module: parse `loadout.toml` with serde,
+expand `~` to `$HOME`, resolve config location via XDG, and support
+`$LOADOUT_CONFIG` override.
+
+Part of: #1 (Phase 2: Rust Parity)
+
+## Scope
+
+- `src/config/mod.rs` — Config loading + path resolution
+- `src/config/types.rs` — Serde structs for `loadout.toml`
+
+## Acceptance criteria
+
+- [ ] Parses `loadout.toml` with all sections: `[sources]`, `[global]`, `[projects.*]`
+- [ ] Expands `~` and `~/` to `$HOME` in all path fields
+- [ ] Resolves config from `$LOADOUT_CONFIG`, then `$XDG_CONFIG_HOME/loadout/loadout.toml`, then `~/.config/loadout/loadout.toml`
+- [ ] Returns typed errors for missing config, parse failures, invalid paths
+- [ ] Unit tests covering path expansion and config resolution
+
+## Dependencies
+
+None — this is the first module to implement.
+```
+
+---
+
+## Epic Issue
+
+A tracking issue that decomposes into task issues. Contains no
+implementation work itself.
+
+**Title format:** `Phase N: <goal>` or `epic: <goal>`
+
+```markdown
+## Summary
+
+[2-4 sentences. The goal of this body of work and what's different
+when it's complete.]
+
+Full spec: [link to design doc or roadmap section]
+
+## Task issues
+
+### [Layer name] (e.g., Library modules, CLI commands)
+
+- [ ] #N — `module/` — [brief description]
+- [ ] #M — `other/` — [brief description]
+
+## Dependency graph
+
+```
+#A ──┬── #C
+     │
+#B ──┴── #D
+```
+
+## Acceptance criteria
+
+[System-level criteria, not per-task. What's true when the epic is done.]
+
+- [ ] [Overall behaviour that proves the epic is complete]
+- [ ] [Quality gate: no regressions, all tests pass, docs updated]
+```
+
+### Example: epic issue
+
+```markdown
+Title: Phase 2: Rust Parity (v0.2.0)
+
+## Summary
+
+Replace the three bash scripts with a single Rust binary. The
+`loadout` command should be installable via `cargo install --path .`
+with zero Python dependency at runtime.
+
+Full spec: docs/ROADMAP.md — Phase 2
+
+## Task issues
+
+### Library modules
+
+- [ ] #5 — `config/` — TOML parsing, path expansion, XDG resolution
+- [ ] #6 — `skill/frontmatter.rs` — YAML frontmatter parsing + validation
+- [ ] #7 — `skill/mod.rs` — Source directory walking, skill resolution
+- [ ] #8 — `linker/` — Symlink creation/removal, marker management
+
+### CLI commands
+
+- [ ] #9 — `loadout install` (depends on #5, #7, #8)
+- [ ] #10 — `loadout clean` (depends on #5, #8)
+
+## Dependency graph
+
+```
+#5 config ──────┬── #9 install
+#6 frontmatter ─┤
+#7 skill/mod ───┤── #10 clean
+#8 linker ──────┘
+```
+
+## Acceptance criteria
+
+- [ ] `loadout install` produces identical symlink layout to `install.sh`
+- [ ] No Python dependency at runtime
+- [ ] `cargo install --path .` places binary in `~/.cargo/bin/loadout`
+```
+
+---
+
+## Bug Report
+
+A defect with reproduction steps and expected vs actual behaviour.
+
+**Title format:** `fix(<scope>): <what's wrong>`
+
+```markdown
+## Bug
+
+[One sentence: what's broken.]
+
+## Reproduction
+
+1. [Step to reproduce]
+2. [Step to reproduce]
+3. [Observe: what actually happens]
+
+## Expected behaviour
+
+[What should happen instead.]
+
+## Environment
+
+- OS: [e.g., Ubuntu 24.04]
+- Version: [e.g., v0.2.0, commit abc123]
+- Config: [relevant config if applicable]
+
+## Acceptance criteria
+
+- [ ] [The fixed behaviour, stated as an observable outcome]
+- [ ] [Regression test covering this case]
+```
+
+---
+
+## Spike / Investigation
+
+Time-boxed research. Produces answers and follow-up issues, not code.
+
+**Title format:** `spike: <question to answer>`
+
+```markdown
+## Question
+
+[The specific question this spike answers.]
+
+## Time box
+
+[Maximum time to spend before reporting findings, e.g., "2 hours"]
+
+## Context
+
+[Why we need to investigate this. What decision depends on the answer.]
+
+## Expected output
+
+- [ ] Written summary of findings (comment on this issue)
+- [ ] Recommendation with rationale
+- [ ] Follow-up issues created if work is needed
+```
+
+---
+
+## Acceptance Criteria Patterns
+
+Good criteria describe **outcomes**, not activities.
+
+| Pattern | Example |
+|---------|---------|
+| Creates artifact | Creates `.managed-by-loadout` marker files in managed directories |
+| Returns value | Returns typed error for missing config file |
+| Validates input | Rejects skill names containing uppercase characters |
+| Handles edge case | Returns empty list when no source directories are configured |
+| Reports to user | Prints resolved skill paths during `--dry-run` |
+| Preserves invariant | Never removes content it didn't create |
+| Testing | Unit tests covering path expansion and XDG resolution |
+| Integration | Integration tests verifying end-to-end install with temp directories |
+
+### Anti-patterns
+
+| Anti-pattern | Problem | Rewrite as |
+|-------------|---------|------------|
+| "Research best approach" | Activity, not outcome | Spike issue with specific question |
+| "Clean up the code" | Vague, no verification | "Extract X into separate module with public API" |
+| "Handle errors properly" | No specific behaviour | "Returns ConfigError::NotFound when file missing" |
+| "Add tests" | No scope | "Unit tests covering path expansion and config resolution" |
+| "Update docs" | No specifics | "README install section reflects cargo install method" |
+
+---
+
+## Dependency Graph Notation
+
+Use ASCII art for dependency graphs in epic issues. Keep it simple.
+
+### Linear chain
+
+```
+#5 config → #7 skill → #9 install
+```
+
+### Fan-out (one foundation, many dependents)
+
+```
+#5 config ──┬── #9 install
+             ├── #10 clean
+             ├── #11 list
+             └── #13 new
+```
+
+### Diamond (multiple foundations merge)
+
+```
+#5 config ──────┬── #9 install
+#7 skill ───────┤
+#8 linker ──────┘
+```
+
+### Layered (with labels)
+
+```
+Foundation:   #5 config    #6 frontmatter    #8 linker
+                  │              │                │
+Integration:  #7 skill (depends on #5, #6)       │
+                  │                               │
+Commands:     #9 install (depends on #5, #7, #8) ─┘
+```

--- a/skills/issue-craft/scripts/issue_lint.py
+++ b/skills/issue-craft/scripts/issue_lint.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Deterministic lint checks for issue bodies used by issue-craft."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+HEADING_ALIASES = {
+    "acceptance criteria": "acceptance criteria",
+    "acceptance criteria:": "acceptance criteria",
+    "expected behavior": "expected behaviour",
+    "expected behavior:": "expected behaviour",
+    "expected behaviour": "expected behaviour",
+    "expected behaviour:": "expected behaviour",
+}
+
+SCHEMAS = {
+    "task": {
+        "required": ["summary", "scope", "acceptance criteria"],
+        "checklist_section": "acceptance criteria",
+    },
+    "epic": {
+        "required": ["summary", "task issues", "acceptance criteria"],
+        "checklist_section": "acceptance criteria",
+    },
+    "bug": {
+        "required": ["bug", "reproduction", "expected behaviour", "acceptance criteria"],
+        "checklist_section": "acceptance criteria",
+    },
+    "spike": {
+        "required": ["question", "time box", "expected output"],
+        "checklist_section": "expected output",
+    },
+}
+
+
+
+def load_text(path: str | None) -> str:
+    if path is None or path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+
+def normalize_heading(heading: str) -> str:
+    collapsed = re.sub(r"\s+", " ", heading.strip().lower())
+    return HEADING_ALIASES.get(collapsed, collapsed)
+
+
+
+def extract_sections(text: str) -> dict[str, str]:
+    headings = list(re.finditer(r"^##\s+(.+?)\s*$", text, re.MULTILINE))
+    sections: dict[str, str] = {}
+
+    for index, match in enumerate(headings):
+        normalized_heading = normalize_heading(match.group(1))
+        start = match.end()
+        if index + 1 < len(headings):
+            end = headings[index + 1].start()
+        else:
+            end = len(text)
+
+        # Keep first section for each heading label for deterministic behavior.
+        sections.setdefault(normalized_heading, text[start:end])
+
+    return sections
+
+
+
+def run_checks(text: str, issue_type: str | None = None) -> dict:
+    errors: list[str] = []
+    warnings: list[str] = []
+    sections = extract_sections(text)
+
+    if issue_type:
+        selected_type = issue_type
+        schema = SCHEMAS[selected_type]
+        missing = [heading for heading in schema["required"] if heading not in sections]
+        if missing:
+            errors.append(
+                f"{selected_type} issue missing headings: " + ", ".join(missing)
+            )
+    else:
+        candidates: list[tuple[str, list[str]]] = []
+        for candidate_type, schema in SCHEMAS.items():
+            missing = [heading for heading in schema["required"] if heading not in sections]
+            candidates.append((candidate_type, missing))
+
+        matches = [candidate_type for candidate_type, missing in candidates if not missing]
+        if not matches:
+            errors.append("issue does not match known template headings")
+            for candidate_type, missing in candidates:
+                errors.append(f"{candidate_type} missing headings: {', '.join(missing)}")
+            return {
+                "passed": False,
+                "issue_type": None,
+                "errors": errors,
+                "warnings": warnings,
+            }
+
+        selected_type = matches[0]
+        schema = SCHEMAS[selected_type]
+
+    checklist_section = schema["checklist_section"]
+    checklist_block = sections.get(checklist_section, "")
+    if checklist_block:
+        checklist_items = re.findall(r"^-\s+\[\s?[xX ]\]\s+.+$", checklist_block, re.MULTILINE)
+        if not checklist_items:
+            errors.append(f"{checklist_section} must include markdown checkboxes")
+
+    scope_block = sections.get("scope", "")
+    if scope_block and re.search(r"\b(various|across the codebase|misc)\b", scope_block, re.IGNORECASE):
+        warnings.append("scope contains broad wording; consider naming exact files/modules")
+
+    size_block = sections.get("size", "")
+    if size_block and not re.search(r"\bsmall\b|\bmedium\b|\blarge\b", size_block, re.IGNORECASE):
+        warnings.append("size section should declare small/medium/large")
+
+    if re.search(r"\b(depends on|parent)\b", text, re.IGNORECASE) and not re.search(r"#\d+", text):
+        warnings.append("dependencies mentioned without issue references")
+
+    passed = not errors
+    return {
+        "passed": passed,
+        "issue_type": selected_type,
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Lint issue markdown for deterministic structural checks."
+    )
+    parser.add_argument("path", nargs="?", help="Issue markdown path or '-' for stdin")
+    parser.add_argument(
+        "--type",
+        choices=sorted(SCHEMAS.keys()),
+        help="Issue type for strict schema validation",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Output machine-readable JSON report"
+    )
+    args = parser.parse_args()
+
+    text = load_text(args.path)
+    report = run_checks(text, issue_type=args.type)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print("PASS" if report["passed"] else "FAIL")
+        if report["issue_type"]:
+            print(f"Type: {report['issue_type']}")
+        for error in report["errors"]:
+            print(f"ERROR: {error}")
+        for warning in report["warnings"]:
+            print(f"WARN: {warning}")
+
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Restores `references/templates.md` and `scripts/issue_lint.py` to issue-craft (both referenced by SKILL.md but missing)
- Restores `references/language-patterns.md` to bdd and adds reference back in SKILL.md
- Source: agents repo copies, which have the complete skill directories

## Test plan
- [ ] `python skills/issue-craft/scripts/issue_lint.py --help` runs without error
- [ ] `grep language-patterns skills/bdd/SKILL.md` shows reference
- [ ] All three restored files exist and have content

🤖 Generated with [Claude Code](https://claude.com/claude-code)