### PR TITLE
refactor: rename next-issue skill to begin

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,7 @@ skills/
   bdd/               behavior contract definition
   plan/              design convergence
   issue-craft/       issue lifecycle
-  next-issue/        work initiation
+  begin/             work initiation
   documentation/     documentation review/update
   land/              closeout workflow
 ```
@@ -60,7 +60,7 @@ The five stages are not a taxonomy — they are an integration architecture. Eac
 
 1. **Frame constraints** (`ground`, `research`) produces verified constraints and substantiated evidence
 2. **Define behavior** (`bdd`) produces Given/When/Then behavior contracts
-3. **Decompose** (`issue-craft`, `next-issue`, `plan`) produces executable issues and implementation designs
+3. **Decompose** (`issue-craft`, `begin`, `plan`) produces executable issues and implementation designs
 4. **Execute and verify** (curated skills) produces tested implementations and review evidence
 5. **Land** (`land`) produces closed issues, merged code, and behavior coverage records
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Five-stage methodology pipeline: frame constraints, define behavior, decompose, execute and verify, land
-- Nine core skills: `ground`, `research`, `bdd`, `issue-craft`, `next-issue`, `plan`, `documentation`, `land`, and `using-groundwork` (methodology orientation)
+- Nine core skills: `ground`, `research`, `bdd`, `issue-craft`, `begin`, `plan`, `documentation`, `land`, and `using-groundwork` (methodology orientation)
 - Six curated skills from [obra/superpowers](https://github.com/obra/superpowers): `subagent-driven-development`, `test-driven-development`, `systematic-debugging`, `verification-before-completion`, `requesting-code-review`, `receiving-code-review`
 - Rust CLI (`groundwork init`, `update`, `list`, `doctor`) with curated manifest and `sk` integration
 - Automatic `gh-issue-sync` installation during `groundwork init`
@@ -18,10 +18,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Integration manual (`WORKFLOW.md`) covering pipeline stages, BDD thread, documentation thread, issue-based development, and skill routing
 - Local issue mirroring via `gh-issue-sync`
 
-- `propose` skill (v1.0): commit strategy, push, and PR creation — the middle phase of the session lifecycle between `next-issue` and `land`. Pipeline contract, routing table, and cross-references updated.
+- `propose` skill (v1.0): commit strategy, push, and PR creation — the middle phase of the session lifecycle between `begin` and `land`. Pipeline contract, routing table, and cross-references updated.
 
 ### Changed
 
+- Renamed `next-issue` skill to `begin`; session lifecycle is now `begin` → `propose` → `land`
 - `ground` skill upgraded to v2.2.0: consolidated patterns from 17 to 12 by merging overlaps (#2+#10 → "Description as Design", #3+#4 → "Borrowed Structure", #5+BC#3+BC#5 → "Precedent as Constraint"). Merged Decision Protocol into The Move as steps 4–5 (Compare, Default). Folded backward-compat patterns into main section as "Preservation Variants" subsection. Deleted Exponential Context section. Trimmed "When to Ground" to trigger question only. 193 → 153 lines, no recognition power lost. Patch bump: structural consolidation, no behavioral change.
 - `ground` skill upgraded to v2.1.0: added Local Coherence as assumed-constraint pattern #9 — captures details that follow valid engineering patterns but contradict the purpose of the work they belong to. Renumbered Descriptive-Normative Confusion to #10.
 - `using-groundwork` skill upgraded to v2.1.0: added Entry Point section, folded routing table triggers into flow stages (single source of truth), compressed BDD/Documentation threading from enumerated arrows to principle-based guidance, consolidated corruption modes from 11 items to 5 named categories, added relationship cues to stage 4 execution skills. 108 → 70 lines, same skill coverage. Patch bump: structural refinement, no behavioral change.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There is one path, not a menu. Every piece of work flows through five stages:
 
 **2. Define behavior** — `bdd` defines the behavior contract in Given/When/Then scenarios. This contract threads through every subsequent stage — it is the integration mechanism, not a planning artifact.
 
-**3. Decompose** — `issue-craft` produces agent-executable issues with binary acceptance criteria from the behavior contract. `next-issue` selects session-sized work from the issue graph, prepares the workspace, and declares the session's direction. `plan` converges to a decision-complete implementation design. Approved designs become executable work through `issue-craft`. The issue graph is the project's working memory across sessions.
+**3. Decompose** — `issue-craft` produces agent-executable issues with binary acceptance criteria from the behavior contract. `begin` selects session-sized work from the issue graph, prepares the workspace, and declares the session's direction. `plan` converges to a decision-complete implementation design. Approved designs become executable work through `issue-craft`. The issue graph is the project's working memory across sessions.
 
 **4. Execute and verify** — `test-driven-development` implements behavior through RED-GREEN-REFACTOR — each RED test maps to a named scenario from stage 2. `systematic-debugging` finds root cause before proposing fixes. Code review and `verification-before-completion` gate completion with behavior-level evidence. `propose` packages verified changes into a PR with derived title/body and issue linkage.
 
@@ -40,7 +40,7 @@ For the concise inventory and shipped order reference, see [`skills/skills.toml`
 | `research` | Foundation | Unsubstantiated decisions, hallucinated facts |
 | `bdd` | Specification | Vague specs, testing implementation instead of behavior |
 | `issue-craft` | Decomposition | Non-executable tasks, vague acceptance criteria |
-| `next-issue` | Decomposition | Recency drift, scope creep, blocker bypass |
+| `begin` | Decomposition | Recency drift, scope creep, blocker bypass |
 | `plan` | Decomposition | Unclear scope, design choices left to implementer |
 | `test-driven-development` | Execution | Implementation-first regressions |
 | `subagent-driven-development` | Execution | Context drift in parallel work |
@@ -97,7 +97,7 @@ skills/                     # Groundwork's tracked skills and shipped inventory
   bdd/                      #   behavior contract definition
   plan/                     #   design convergence
   issue-craft/              #   issue lifecycle
-  next-issue/               #   work initiation
+  begin/                    #   work initiation
   documentation/            #   documentation review/update
   propose/                  #   commit, push, PR creation
   land/                     #   closeout workflow

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -24,7 +24,7 @@ Invoke `bdd` to define the behavior contract in Given/When/Then scenarios. Each 
 
 Use `issue-craft` to create, decompose, refine, and close issues. It produces agent-executable issues with binary acceptance criteria, explicit dependencies, and bounded scope. For epics with 4+ tasks, it builds dependency graphs with execution layers.
 
-Use `next-issue` to initiate a work session. It selects session-sized work from the issue graph, prepares the workspace (feature branch, issue context), and declares the session's starting direction with an explicit scope gate.
+Use `begin` to initiate a work session. It selects session-sized work from the issue graph, prepares the workspace (feature branch, issue context), and declares the session's starting direction with an explicit scope gate.
 
 Use `plan` to converge from exploration to a decision-complete implementation design before modifying code. It explores the codebase, resolves intent, and produces a plan where every design choice is explicit — the implementer does not need to make any decisions. Based on Codex CLI plan mode (MIT), adapted for autonomous execution.
 
@@ -42,7 +42,7 @@ Use `requesting-code-review` after implementation, before merging. Use `receivin
 
 Use `verification-before-completion` before claiming any work is complete. It requires running the actual verification command and confirming the output matches the claim. Completion evidence must be behavior-level — not just "tests pass" but explicit behavior coverage.
 
-Use `propose` to package verified changes into a PR: ensure feature branch, analyze and commit changes, push, and create PR with derived title/body linked to issue(s). This produces the open PR that `land` will merge in stage 5. The session lifecycle is: `next-issue` (initiate session) → implement → `propose` (package for review) → review → `land` (merge and close).
+Use `propose` to package verified changes into a PR: ensure feature branch, analyze and commit changes, push, and create PR with derived title/body linked to issue(s). This produces the open PR that `land` will merge in stage 5. The session lifecycle is: `begin` (initiate session) → implement → `propose` (package for review) → review → `land` (merge and close).
 
 ### 5. Land
 
@@ -173,7 +173,7 @@ If `gh-issue-sync pull` fails with missing project scope (`read:project`) or `gr
 | `research` | when reliable external evidence is needed for decisions |
 | `bdd` | when defining or refining behavior expectations |
 | `issue-craft` | creating/refining task/epic/bug/spike issues |
-| `next-issue` | initiating a work session: selecting work, preparing workspace, declaring direction |
+| `begin` | initiating a work session: selecting work, preparing workspace, declaring direction |
 | `plan` | implementation needs design convergence — multiple approaches, unclear scope, or cross-cutting changes |
 | `test-driven-development` | when implementing any feature or bugfix — RED → GREEN → REFACTOR |
 | `subagent-driven-development` | when executing a plan whose tasks are independent and can run in parallel |

--- a/agents.toml
+++ b/agents.toml
@@ -9,7 +9,7 @@ opencode = false
 ground = { gh = "pentaxis93/groundwork", path = "skills/ground" }
 research = { gh = "pentaxis93/groundwork", path = "skills/research" }
 bdd = { gh = "pentaxis93/groundwork", path = "skills/bdd" }
-next_issue = { gh = "pentaxis93/groundwork", path = "skills/next-issue" }
+begin = { gh = "pentaxis93/groundwork", path = "skills/begin" }
 plan = { gh = "pentaxis93/groundwork", path = "skills/plan" }
 issue_craft = { gh = "pentaxis93/groundwork", path = "skills/issue-craft" }
 land = { gh = "pentaxis93/groundwork", path = "skills/land" }

--- a/crates/groundwork-cli/src/main.rs
+++ b/crates/groundwork-cli/src/main.rs
@@ -1921,14 +1921,16 @@ mod tests {
                 "bdd",
                 "plan",
                 "issue_craft",
-                "next_issue",
+                "begin",
                 "test_driven_development",
                 "subagent_driven_development",
                 "systematic_debugging",
                 "requesting_code_review",
                 "receiving_code_review",
+                "third_force",
                 "documentation",
                 "verification_before_completion",
+                "propose",
                 "land",
             ]
         );
@@ -1947,8 +1949,10 @@ mod tests {
                 "skills/bdd",
                 "skills/plan",
                 "skills/issue-craft",
-                "skills/next-issue",
+                "skills/begin",
+                "skills/third-force",
                 "skills/documentation",
+                "skills/propose",
                 "skills/land",
             ]
         );
@@ -1983,7 +1987,7 @@ external_dep = { gh = "org/repo", path = "y" }
         assert!(deps.contains_key("ground"));
         assert!(deps.contains_key("research"));
         assert!(deps.contains_key("bdd"));
-        assert!(deps.contains_key("next_issue"));
+        assert!(deps.contains_key("begin"));
         assert!(deps.contains_key("plan"));
         assert!(deps.contains_key("issue_craft"));
         assert!(deps.contains_key("land"));

--- a/docs/architecture/pipeline-contract.md
+++ b/docs/architecture/pipeline-contract.md
@@ -7,7 +7,7 @@ This file defines the canonical integration contract for Groundwork's methodolog
 Groundwork has one coherent path:
 1. `ground` frames constraints.
 2. `bdd` defines and maintains behavior contract.
-3. `plan` converges from exploration to a decision-complete implementation design. `issue-craft` decomposes that design into agent-executable issues. `next-issue` initiates the work session: selects session-sized work, prepares the workspace, and declares direction.
+3. `plan` converges from exploration to a decision-complete implementation design. `issue-craft` decomposes that design into agent-executable issues. `begin` initiates the work session: selects session-sized work, prepares the workspace, and declares direction.
 4. Curated middle skills implement and verify the same behavior contract.
 5. `land` closes work with behavior coverage visibility.
 

--- a/skills/bdd/SKILL.md
+++ b/skills/bdd/SKILL.md
@@ -237,7 +237,7 @@ cycle for each behavior.
 
 ## Cross-References
 
-- `next-issue`: session-level prioritization and execution sequencing.
+- `begin`: session-level prioritization and execution sequencing.
 - `issue-craft`: acceptance-criteria rigor, issue decomposition, and behavior traceability.
 - `test-driven-development`: executes RED-GREEN-REFACTOR for BDD-defined behaviors.
 - `verification-before-completion`: requires fresh evidence for behavior-level completion claims.

--- a/skills/begin/SKILL.md
+++ b/skills/begin/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: next-issue
+name: begin
 description: >-
   Session work initiation: select issue(s), prepare workspace, declare
   direction. Opening bookend of the session lifecycle — `land` is the closing
-  bookend. Trigger on: 'next-issue', 'next issue', 'start issue', 'begin work'.
+  bookend. Trigger on: 'begin', 'begin work', 'start session', 'start issue'.
 ---
 
-# Next Issue — Work Selection & Initiation
+# Begin — Work Selection & Initiation
 
 **Version 2.1**
 
@@ -15,8 +15,8 @@ description: >-
 Use this skill to start a work session: choose what to work on, prepare the
 workspace, and declare the session's direction.
 
-`next-issue` is the opening bookend of the session lifecycle:
-`next-issue` (select + prepare) → implement → `propose` (package for review) →
+`begin` is the opening bookend of the session lifecycle:
+`begin` (select + prepare) → implement → `propose` (package for review) →
 review → `land` (merge and close).
 
 Plan from the issue graph, not from memory. Agent sessions end and context
@@ -229,7 +229,7 @@ this — refine it with what you learned during selection and preparation.
 - `propose`: the next lifecycle phase — commit, push, and PR creation after
   implementation.
 - `land`: the closing bookend — merge, cleanup, and issue closure after review.
-  `next-issue` opens the session lifecycle; `land` closes it.
+  `begin` opens the session lifecycle; `land` closes it.
 - `issue-craft`: decomposition, issue boundaries, acceptance criteria contracts.
 - `ground`: validate assumptions before committing to an approach.
 - `bdd`: behavior-first test strategy for implementation increments.

--- a/skills/issue-craft/SKILL.md
+++ b/skills/issue-craft/SKILL.md
@@ -191,7 +191,7 @@ A well-bounded task has:
 
 ## Cross-References
 
-- `next-issue`: session-level prioritization and execution discipline.
+- `begin`: session-level prioritization and execution discipline.
 - `bdd`: behavior framing and test naming discipline.
 - `plan`: design convergence before implementation.
 - `land`: merge-and-close completion events.

--- a/skills/land/SKILL.md
+++ b/skills/land/SKILL.md
@@ -223,4 +223,4 @@ Report the final state including:
 - `propose` for the preceding phase: commit, push, and PR creation
 - `documentation` for deeper documentation review beyond the drift scan in step 3
 - `issue-craft` for issue lifecycle patterns and tracking issues from doc review
-- `next-issue` for work initiation and session opening — the opening bookend to `land`'s closing bookend
+- `begin` for work initiation and session opening — the opening bookend to `land`'s closing bookend

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -155,7 +155,7 @@ When producing a plan for handoff to another agent, write it to a file.
   the problem space itself is unclear.
 - `bdd`: behavior contract — provides the behavior statements the plan
   must implement.
-- `next-issue`: work initiation — selects which issue to plan for and prepares the session.
+- `begin`: work initiation — selects which issue to plan for and prepares the session.
 - `issue-craft`: executable work-unit decomposition and issue quality —
   turns a decision-complete design into agent-executable issues with
   binary acceptance criteria.

--- a/skills/propose/SKILL.md
+++ b/skills/propose/SKILL.md
@@ -3,7 +3,7 @@ name: propose
 description: >-
   Package working changes into a PR: ensure feature branch, analyze and commit
   changes, push, create PR with derived title/body linked to issue(s).
-  The middle phase of the session lifecycle between next-issue and land.
+  The middle phase of the session lifecycle between begin and land.
   Trigger on: 'propose', 'submit pr', 'create pr', 'open pr',
   'send for review', 'package this up'.
 ---
@@ -24,7 +24,7 @@ Use this skill when implementation is complete and changes need to become a PR.
 5. Create a PR with derived title/body and issue linkage
 6. Report the result and suggest next steps
 
-The session lifecycle is: `next-issue` (initiate session) → implement → `propose`
+The session lifecycle is: `begin` (initiate session) → implement → `propose`
 (package for review) → review → `land` (merge and close). `propose` is the
 transition from execution to review.
 
@@ -212,7 +212,7 @@ Output:
 
 ## Related Skills
 
-- `next-issue` for work initiation — select issue(s), prepare workspace, declare direction (the preceding phase)
+- `begin` for work initiation — select issue(s), prepare workspace, declare direction (the preceding phase)
 - `land` for merge, cleanup, and issue closure (the following phase)
 - `requesting-code-review` for dispatching review after the PR exists
 - `verification-before-completion` — should fire before `propose`

--- a/skills/skills.toml
+++ b/skills/skills.toml
@@ -43,8 +43,8 @@ repo = "pentaxis93/groundwork"
 use_when = "Use when creating, decomposing, refining, or closing issues."
 
 [[skills]]
-name = "next-issue"
-path = "skills/next-issue"
+name = "begin"
+path = "skills/begin"
 provider = "gh"
 repo = "pentaxis93/groundwork"
 use_when = "Use when starting a work session: selecting issue(s), preparing the workspace (feature branch), and declaring session direction."

--- a/skills/using-groundwork/SKILL.md
+++ b/skills/using-groundwork/SKILL.md
@@ -31,7 +31,7 @@ Five stages, in dependency order. Each produces what the next consumes.
 
 2. **Define behavior.** `bdd` defines the behavior contract in Given/When/Then scenarios. This contract threads through every subsequent stage.
 
-3. **Decompose.** Converge to a decision-complete design (`plan`), break the design into agent-executable issues (`issue-craft`), and initiate the work session (`next-issue`).
+3. **Decompose.** Converge to a decision-complete design (`plan`), break the design into agent-executable issues (`issue-craft`), and initiate the work session (`begin`).
 
 4. **Execute and verify.** Implement through RED-GREEN-REFACTOR (`test-driven-development`), parallelize independent tasks (`subagent-driven-development`), find root cause before fixing (`systematic-debugging`), review code (`requesting-code-review`, `receiving-code-review`), verify behavior-level evidence before claiming done (`verification-before-completion`), ensure documentation accuracy (`documentation`), and package verified changes into a PR (`propose`).
 


### PR DESCRIPTION
## Summary

- Renames `next-issue` skill to `begin` so the session lifecycle reads naturally: `begin` → `propose` → `land`
- Updates all cross-references across skills, documentation, configuration, and CLI tests

## Changes

**Skill rename**: `skills/next-issue/` → `skills/begin/`, frontmatter name and triggers updated

**Configuration**: `agents.toml` dependency key `next_issue` → `begin`, `skills.toml` name and path updated

**Cross-references updated in 6 skills**: propose, land, plan, issue-craft, bdd, using-groundwork

**Documentation updated**: ARCHITECTURE.md, README.md, WORKFLOW.md, pipeline-contract.md

**CHANGELOG**: added rename entry, updated 2 non-historical references (line 39 historical rename from `planning` left unchanged)

**CLI tests**: updated alias, path, and key assertions; also fixed pre-existing stale test expectations (missing `third_force` and `propose` entries)

**Installed copies**: `.claude/skills/` and `.codex/skills/` directories renamed and content synced

## Issue(s)

Closes #80

## Test plan

- `cargo test` in `crates/groundwork-cli/` — all 35 tests pass
- `grep -r 'next.issue\|next_issue' skills/ agents.toml ARCHITECTURE.md README.md WORKFLOW.md docs/architecture/ crates/` returns only CHANGELOG historical entries
- `ls skills/begin/SKILL.md` succeeds; `ls skills/next-issue/` fails