### PR TITLE
fix(attribution): add LICENSE-UPSTREAM files for adapted skills

### DIFF
--- a/skills/plan/LICENSE-UPSTREAM
+++ b/skills/plan/LICENSE-UPSTREAM
@@ -1,0 +1,38 @@
+This skill is adapted from the plan mode implementation in OpenAI's Codex CLI
+(https://github.com/openai/codex), licensed under the Apache License 2.0
+reproduced below.
+
+The following elements are derived from the original:
+- The three-phase planning structure (ground in environment, resolve intent,
+  converge implementation)
+- The "decision-complete" concept and terminology
+- The "two kinds of unknowns" framework (discoverable facts vs. preferences/
+  tradeoffs) with its category taxonomy
+- The read-only constraint with its enumeration of allowed vs. disallowed
+  actions during planning
+- One near-verbatim sentence regarding "doing the work" vs. "planning the
+  work"
+
+The following elements are original to this adaptation:
+- Corruption Modes framework (six named failure modes)
+- Named constraint identifiers
+- The write-plan output template
+- Phase motivations and rationale
+- Skill cross-references and pipeline integration
+- Adaptation from human-interactive UI to autonomous agent execution
+
+---
+
+Copyright 2025 OpenAI
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -11,13 +11,16 @@ metadata:
   version: "1.1.0"
   updated: "2026-03-08"
   origin: >-
-    Adapted from Codex CLI plan mode (MIT license,
-    github.com/openai/codex). The original is a human-interactive UI
-    mode with 3-phase conversational workflow. This skill preserves
-    the core discipline — explore before deciding, decision-complete
-    plans, read-only until converged — and adapts it for autonomous
-    execution where ambiguity is resolved through exploration and
-    explicit assumptions rather than human conversation.
+    Adapted from OpenAI's Codex CLI plan mode (Apache-2.0 license,
+    https://github.com/openai/codex). The original is a human-interactive
+    UI mode with 3-phase conversational workflow. This skill preserves
+    the core framework — three-phase structure, decision-completeness,
+    the unknowns taxonomy, the read-only constraint enumeration — and
+    adapts it for autonomous execution where ambiguity is resolved
+    through exploration and explicit assumptions rather than human
+    conversation. Corruption modes, named constraints, write-plan
+    template, and skill cross-references are original. See
+    LICENSE-UPSTREAM for the full copyright notice and license terms.
 ---
 
 # Plan

--- a/skills/test-first/LICENSE-UPSTREAM
+++ b/skills/test-first/LICENSE-UPSTREAM
@@ -1,0 +1,34 @@
+This skill is adapted from the test-driven-development skill in
+obra/superpowers (https://github.com/obra/superpowers), pinned at commit
+e4a2375. The original skill and its testing-anti-patterns.md companion are
+licensed under the MIT License reproduced below.
+
+Substantial portions of the original are preserved in this adaptation: the
+Iron Law, the delete-and-start-over rules, the anti-rationalization table,
+the red flags list, the When Stuck table, and the testing anti-pattern gate
+functions. These have been adapted with vocabulary normalization, language-
+agnostic examples, and bidirectional pipeline integration.
+
+---
+
+MIT License
+
+Copyright (c) 2025 Jesse Vincent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/test-first/SKILL.md
+++ b/skills/test-first/SKILL.md
@@ -11,12 +11,15 @@ metadata:
   version: "1.0.0"
   updated: "2026-03-08"
   origin: >-
-    Adapted from obra/superpowers test-driven-development skill (pinned at
-    e4a2375). The original is a standalone TDD discipline with TypeScript
-    examples and superpowers-context vocabulary. This skill preserves the
-    core discipline — the Iron Law, red-green-refactor, delete-and-start-over,
-    anti-rationalization patterns — and integrates it bidirectionally with
-    groundwork's BDD, verification, debugging, and documentation skills.
+    Adapted from Jesse Vincent's test-driven-development skill in
+    obra/superpowers (https://github.com/obra/superpowers, MIT license,
+    pinned at e4a2375). The original is a standalone TDD discipline with
+    TypeScript examples and superpowers-context vocabulary. This skill
+    preserves substantial portions of the original — the Iron Law,
+    red-green-refactor, delete-and-start-over, anti-rationalization
+    patterns — and integrates them bidirectionally with groundwork's BDD,
+    verification, debugging, and documentation skills. See LICENSE-UPSTREAM
+    for the full copyright notice and license terms.
   replaces: "test-driven-development (obra/superpowers)"
 ---
 


### PR DESCRIPTION
## Summary

- Adds co-located `LICENSE-UPSTREAM` files for `test-first` (MIT, Jesse Vincent) and `plan` (Apache-2.0, OpenAI) documenting the upstream copyright notices, license terms, and honest accounting of derived vs. original elements.
- Corrects `plan` origin metadata: license was listed as MIT but is actually Apache-2.0; claim of "purely conceptual" adaptation was overstated — several structural elements are derived.
- Updates `test-first` origin metadata to name the original author (Jesse Vincent), link the pinned commit, and reference the LICENSE-UPSTREAM file.

## Changes

**`skills/test-first/`**
- New `LICENSE-UPSTREAM`: Jesse Vincent's MIT notice with documentation of preserved substantial portions (Iron Law, delete-and-start-over, anti-rationalization table, red flags, When Stuck table, testing anti-pattern gate functions)
- Updated `SKILL.md` origin metadata: names author, links repo, references LICENSE-UPSTREAM

**`skills/plan/`**
- New `LICENSE-UPSTREAM`: OpenAI's Apache-2.0 notice with honest accounting — derived elements (three-phase structure, decision-complete concept/terminology, unknowns taxonomy with category names, read-only constraint enumeration, one near-verbatim sentence) vs. original elements (corruption modes, named constraints, write-plan template, phase motivations, cross-references)
- Corrected `SKILL.md` origin metadata: MIT → Apache-2.0, "Inspired by" → "Adapted from", added specific derived elements list

## Test plan

- Verify LICENSE-UPSTREAM files contain correct license text (MIT for test-first, Apache-2.0 for plan)
- Verify SKILL.md frontmatter YAML is valid
- Verify derived/original accounting in LICENSE-UPSTREAM files is honest against actual upstream sources
- `cargo test -p groundwork-cli` (no structural changes, but confirms nothing broke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)