### PR TITLE
docs(contributing): codify upstream attribution convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Documented upstream attribution convention in CONTRIBUTING.md: LICENSE-UPSTREAM requirements for adapted skills, origin metadata standard, curated-skills attribution reasoning, and attribution checklist at the skill-authoring boundary
 - Replaced curated `test-driven-development` (obra/superpowers) with groundwork-native `test-first` skill (v1.0.0). Preserves core discipline (Iron Law, red-green-refactor, delete-and-start-over, anti-rationalization patterns) while adding bidirectional composition with `bdd`, `verification-before-completion`, `systematic-debugging`, and `documentation`. Lifecycle Role section establishes pipeline position. Corruption Modes section added. Language-agnostic examples replace TypeScript-only. Companion `testing-anti-patterns.md` migrated to `references/`.
 - `ground` skill upgraded to v3.0.0: broadened from design-only to full first-principles cognitive discipline covering strategic analysis, cost decomposition, and problem reframing. Added Active Excavation section (Socratic Drilling, Recursive Why). Decompose step now supports three modes (requirements, constituent, process) with Orient determining which applies. Orient step broadened with mode-specific questions. New "Structure survey as analysis" corruption mode. All existing patterns and corruption modes retained.
 - Renamed `next-issue` skill to `begin`; session lifecycle is now `begin` → `propose` → `land`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,35 @@ To add a shipped skill maintained upstream:
 1. Add the skill entry to `skills/skills.toml` with its pinned `rev`
 2. Run `groundwork update` to sync
 
+Curated skills fetched via `sk sync` from external `gh` references are not stored in this repo's tree — no `LICENSE-UPSTREAM` file is needed here. The upstream repo's own license governs the fetched content. To verify a curated skill's license, check its upstream repository directly.
+
+## Upstream Attribution
+
+Any skill in `skills/` that adapts, derives from, or reproduces substantial portions of upstream work must include a `LICENSE-UPSTREAM` file co-located with `SKILL.md`.
+
+### When LICENSE-UPSTREAM is required
+
+If the skill preserves structural frameworks, tables, terminology, enumerated lists, or near-verbatim text from an upstream source, it requires a `LICENSE-UPSTREAM` file. Skills that are merely "inspired by" a concept without reproducing protected expression do not.
+
+### What LICENSE-UPSTREAM must contain
+
+1. **Prose preamble** identifying the upstream project name, URL, and pinned revision (commit hash), plus an honest accounting of which elements are derived from the original and which are original to this adaptation.
+2. **Full upstream copyright notice and license text** — the complete notice as it appears in the upstream project, not a summary or paraphrase.
+
+### Origin metadata standard
+
+The `origin:` field in `SKILL.md` frontmatter must:
+
+- Name the upstream author or organization
+- Identify the correct license (verify — do not assume)
+- Reference `LICENSE-UPSTREAM` when one exists
+- Honestly characterize the degree of derivation (e.g. "preserves substantial portions" vs. "adapted from" vs. "inspired by")
+
+### Reference examples
+
+- `skills/plan/LICENSE-UPSTREAM` — adapted from OpenAI Codex (Apache-2.0), with itemized derived vs. original elements
+- `skills/test-first/LICENSE-UPSTREAM` — adapted from obra/superpowers (MIT), with description of preserved portions
+
 ## Skill Authoring Boundary
 
 Groundwork stores the skills it ships, but it does not ship its own
@@ -61,7 +90,8 @@ documentation:
 
 1. Do the authoring or regeneration work in `skill-creator`
 2. Bring the resulting `SKILL.md` content or curation change back into this repo
-3. Update `skills/skills.toml`, `agents.toml`, README/WORKFLOW entries,
+3. If the skill adapts upstream material, add a `LICENSE-UPSTREAM` file alongside `SKILL.md` and include an `origin:` field in frontmatter referencing it. See [Upstream Attribution](#upstream-attribution).
+4. Update `skills/skills.toml`, `agents.toml`, README/WORKFLOW entries,
    ADRs, and CHANGELOG only if the shipped Groundwork inventory or methodology
    changes
 


### PR DESCRIPTION
## Summary

- Documents the LICENSE-UPSTREAM convention for adapted skills in CONTRIBUTING.md, making the pattern established by PR #97 discoverable and repeatable
- Adds attribution checklist step to the Skill Authoring Boundary so compliance is structural, not dependent on manual review
- Explains why curated skills fetched via `sk sync` don't need LICENSE-UPSTREAM files

## Changes

**CONTRIBUTING.md** — three additions:
- New "Upstream Attribution" section: when LICENSE-UPSTREAM is required, what it must contain, origin metadata standard, reference examples
- Curated-skills attribution note after the "shipped skill maintained upstream" steps
- New step 3 in Skill Authoring Boundary: add LICENSE-UPSTREAM and `origin:` metadata when adapting upstream material

**CHANGELOG.md** — one entry in `[Unreleased] ### Changed`

**GitHub issue #99** filed separately: remove curated skill references after all are replaced (blocked by #20, #92, #93, #94)

## Issue(s)

Closes #98

## Test plan

- [x] `cargo test -p groundwork-cli` passes (137 tests, documentation-only change)
- [ ] Walk through a hypothetical "adapt a new skill from upstream" scenario using only CONTRIBUTING.md — steps should be unambiguous
- [ ] Verify all five acceptance criteria from #98 are addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)