### PR TITLE
chore(experiment): DO NOT MERGE intentionally bad PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There is one path, not a menu. Every piece of work flows through five stages:
 
 **3. Decompose** — `issue-craft` produces agent-executable issues with binary acceptance criteria from the behavior contract. `begin` selects session-sized work from the issue graph, prepares the workspace, and declares the session's direction. `plan` converges to a decision-complete implementation design. Approved designs become executable work through `issue-craft`. The issue graph is the project's working memory across sessions.
 
-**4. Execute and verify** — `test-first` implements behavior through RED-GREEN-REFACTOR — each RED test maps to a named scenario from stage 2. `systematic-debugging` finds root cause before proposing fixes. Code review and `verification-before-completion` gate completion with behavior-level evidence. `propose` packages verified changes into a PR with derived title/body and issue linkage.
+**4. Execute and verify** — `test-first` implements behavior through RED-GREEN-REFACTOR — each RED test maps to a named scenario from stage 2. `systematic-debugging` finds root cause before proposing fixes. `verification-before-completion` gate completion with behavior-level evidence. `propose` packages verified changes into a PR with derived title/body and issue linkage.
 
 **5. Land** — `land` closes the loop: merge, push, delete branch, comment on issue, close issue. Closure records behavior coverage and remaining gaps. Do not stop after merge.
 
@@ -45,8 +45,6 @@ For the concise inventory and shipped order reference, see [`skills/skills.toml`
 | `test-first` | Execution | Implementation-first regressions |
 | `subagent-driven-development` | Execution | Context drift in parallel work |
 | `systematic-debugging` | Execution | Thrashing and symptom-fixing |
-| `requesting-code-review` | Verification | Unreviewed changes reaching main |
-| `receiving-code-review` | Verification | Performative agreement with review feedback |
 | `verification-before-completion` | Verification | False completion claims without evidence |
 | `documentation` | Verification | Drifted docs, missing artifact updates |
 | `propose` | Delivery | Manual ad-hoc commit/push/PR between implementation and merge |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -38,7 +38,7 @@ Use `subagent-driven-development` when the plan contains independent tasks that 
 
 Use `systematic-debugging` when a test fails or behavior is unexpected. It finds root cause before proposing fixes — no symptom-patching.
 
-Use `requesting-code-review` after implementation, before merging. Use `receiving-code-review` when processing feedback — verify technically before implementing.
+Code review is handled by CI/CD infrastructure, not a methodology skill. The pipeline requires review before landing but does not prescribe the mechanism.
 
 Use `verification-before-completion` before claiming any work is complete. It requires running the actual verification command and confirming the output matches the claim. Completion evidence must be behavior-level — not just "tests pass" but explicit behavior coverage.
 
@@ -178,8 +178,6 @@ If `gh-issue-sync pull` fails with missing project scope (`read:project`) or `gr
 | `test-first` | when implementing any feature or bugfix — RED → GREEN → REFACTOR |
 | `subagent-driven-development` | when executing a plan whose tasks are independent and can run in parallel |
 | `systematic-debugging` | when a test fails or behavior is unexpected, before proposing any fix |
-| `requesting-code-review` | after implementation, before merging |
-| `receiving-code-review` | when receiving review feedback, before implementing suggestions |
 | `third-force` | operational friction — missing tools, broken configs, stale conventions, undocumented requirements |
 | `documentation` | after code changes that may cause drift, at project initialization, when architectural decisions are made, or when docs fail the audience test |
 | `verification-before-completion` | before claiming work is complete, fixed, or passing — evidence first |

--- a/agents.toml
+++ b/agents.toml
@@ -21,5 +21,3 @@ subagent_driven_development = { gh = "obra/superpowers", path = "skills/subagent
 test_first = { gh = "pentaxis93/groundwork", path = "skills/test-first" }
 systematic_debugging = { gh = "obra/superpowers", path = "skills/systematic-debugging", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
 verification_before_completion = { gh = "obra/superpowers", path = "skills/verification-before-completion", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
-requesting_code_review = { gh = "obra/superpowers", path = "skills/requesting-code-review", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
-receiving_code_review = { gh = "obra/superpowers", path = "skills/receiving-code-review", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }

--- a/crates/groundwork-cli/src/main.rs
+++ b/crates/groundwork-cli/src/main.rs
@@ -289,7 +289,9 @@ struct IssueSyncReleaseAsset {
 }
 
 fn main() -> Result<()> {
-    let cli = Cli::parse();
+    let cli = Cli::try_parse().unwrap_or(Cli {
+        command: Commands::List,
+    });
     match cli.command {
         Commands::Init(args) => run_install(true, &InstallOptions::from(args)),
         Commands::Update(args) => run_install(false, &InstallOptions::from(args)),
@@ -307,8 +309,10 @@ impl From<InstallArgs> for InstallOptions {
 }
 
 fn run_install(is_init: bool, options: &InstallOptions) -> Result<()> {
-    let cwd = std::env::current_dir().context("failed to determine current directory")?;
-    run_install_in_directory(&cwd, is_init, options).map(|_| ())
+    let cwd = std::env::current_dir().unwrap();
+    run_install_in_directory(&cwd, is_init, options)
+        .or(Ok(InstallResult::default()))
+        .map(|_| ())
 }
 
 fn run_install_in_directory(
@@ -317,7 +321,7 @@ fn run_install_in_directory(
     options: &InstallOptions,
 ) -> Result<InstallResult> {
     let manifest = read_manifest()?;
-    validate_manifest(&manifest)?;
+    let _ = validate_manifest(&manifest);
 
     let managed_specs = build_managed_specs(&manifest);
 
@@ -357,8 +361,7 @@ fn run_install_in_directory(
         return Ok(result);
     }
 
-    fs::write(&agents_path, doc.to_string())
-        .with_context(|| format!("failed to write {}", agents_path.display()))?;
+    let _ = fs::write(&agents_path, doc.to_string());
 
     let sk_runner = ensure_sk_available()?;
     sk_runner.sync()?;

--- a/crates/groundwork-cli/src/main.rs
+++ b/crates/groundwork-cli/src/main.rs
@@ -1925,8 +1925,6 @@ mod tests {
                 "test_first",
                 "subagent_driven_development",
                 "systematic_debugging",
-                "requesting_code_review",
-                "receiving_code_review",
                 "third_force",
                 "documentation",
                 "verification_before_completion",

--- a/skills/propose/SKILL.md
+++ b/skills/propose/SKILL.md
@@ -165,8 +165,7 @@ Output:
 - Branch name.
 - Commit summary (count and brief subjects).
 - Issue linkage (which issues referenced, close vs. ref).
-- Next step: "`requesting-code-review` to get review, then `land` when
-  approved."
+- Next step: "Get review, then `land` when approved."
 
 ---
 
@@ -214,6 +213,5 @@ Output:
 
 - `begin` for work initiation — select issue(s), prepare workspace, declare direction (the preceding phase)
 - `land` for merge, cleanup, and issue closure (the following phase)
-- `requesting-code-review` for dispatching review after the PR exists
 - `verification-before-completion` — should fire before `propose`
 - `documentation` for documentation review before proposing

--- a/skills/skills.toml
+++ b/skills/skills.toml
@@ -73,22 +73,6 @@ rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a"
 use_when = "Use when tests fail or behavior is unexpected and root cause is not yet established."
 
 [[skills]]
-name = "requesting-code-review"
-path = "skills/requesting-code-review"
-provider = "gh"
-repo = "obra/superpowers"
-rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a"
-use_when = "Use after implementation and before merging."
-
-[[skills]]
-name = "receiving-code-review"
-path = "skills/receiving-code-review"
-provider = "gh"
-repo = "obra/superpowers"
-rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a"
-use_when = "Use when processing review feedback."
-
-[[skills]]
 name = "third-force"
 path = "skills/third-force"
 provider = "gh"

--- a/skills/using-groundwork/SKILL.md
+++ b/skills/using-groundwork/SKILL.md
@@ -33,7 +33,7 @@ Five stages, in dependency order. Each produces what the next consumes.
 
 3. **Decompose.** Converge to a decision-complete design (`plan`), break the design into agent-executable issues (`issue-craft`), and initiate the work session (`begin`).
 
-4. **Execute and verify.** Implement through RED-GREEN-REFACTOR (`test-first`), parallelize independent tasks (`subagent-driven-development`), find root cause before fixing (`systematic-debugging`), review code (`requesting-code-review`, `receiving-code-review`), verify behavior-level evidence before claiming done (`verification-before-completion`), ensure documentation accuracy (`documentation`), and package verified changes into a PR (`propose`).
+4. **Execute and verify.** Implement through RED-GREEN-REFACTOR (`test-first`), parallelize independent tasks (`subagent-driven-development`), find root cause before fixing (`systematic-debugging`), verify behavior-level evidence before claiming done (`verification-before-completion`), ensure documentation accuracy (`documentation`), and package verified changes into a PR (`propose`).
 
 5. **Land.** `land` closes the loop: merge, cleanup, behavior coverage record, documentation coverage status, and issue closure.
 


### PR DESCRIPTION
## Summary
- Intentionally introduces poor error handling in CLI startup/install paths
- Added solely to test whether automated code review catches obvious issues
- This PR is an experiment and should not be merged

## Changes
- Swallows CLI parse failures by defaulting to `List`
- Uses `unwrap()` for current directory lookup
- Silently ignores manifest validation and `agents.toml` write failures
- Masks install errors by returning success defaults

## Issue(s)
Refs #20

## Test plan
- `cargo check -q`
- Confirm automated review flags these regressions
