### PR TITLE
feat(skills): remove curated subagent-driven-development, preserve context-management guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `propose` skill (v1.0): commit strategy, push, and PR creation — the middle phase of the session lifecycle between `begin` and `land`. Pipeline contract, routing table, and cross-references updated.
 
+### Removed
+
+- Removed curated `subagent-driven-development` (obra/superpowers) — the last external skill dependency. Investigation found no real exigence: fresh-subagent isolation is default tool behavior, two-stage review is covered by CI, and remaining patterns are basic prompt engineering. Two genuinely useful insights (use fresh subagents to manage context across multi-task execution; match subagent model to task complexity) preserved as integrated guidance in `using-groundwork` stage 4 and `WORKFLOW.md` stage 4.
+
 ### Changed
 
 - Replaced curated `verification-before-completion` (obra/superpowers) with groundwork-native original (v1.0.0). Preserves core discipline (Iron Law, gate function, common-failures table, anti-rationalization patterns, red flags). Adds Lifecycle Role section establishing pipeline position, Corruption Modes section, and cross-references. Removes superpowers-specific vocabulary.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ For the concise inventory and shipped order reference, see [`skills/skills.toml`
 | `begin` | Decomposition | Recency drift, scope creep, blocker bypass |
 | `plan` | Decomposition | Unclear scope, design choices left to implementer |
 | `test-first` | Execution | Implementation-first regressions |
-| `subagent-driven-development` | Execution | Context drift in parallel work |
 | `systematic-debugging` | Cross-cutting | Thrashing and symptom-fixing |
 | `verification-before-completion` | Verification | False completion claims without evidence |
 | `documentation` | Verification | Drifted docs, missing artifact updates |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -34,7 +34,7 @@ After a design is approved, use `issue-craft` to express the implementation as a
 
 Use `test-first` to implement each plan step through RED-GREEN-REFACTOR. Each RED test corresponds to a named behavior scenario from `bdd`. Write one failing test, verify it fails for the right reason, write the simplest code to pass it, verify it passes, refactor.
 
-Use `subagent-driven-development` when the plan contains independent tasks that can run in parallel. It dispatches a fresh subagent per task with two-stage review (spec compliance, then code quality).
+When the plan contains independent tasks, dispatch a fresh subagent per task to keep execution context clean — stale context from earlier tasks pollutes later ones. Match subagent model to task complexity: use cheaper/faster models for straightforward work, reserve the most capable model for subtle or cross-cutting changes.
 
 Use `systematic-debugging` when a test fails or behavior is unexpected. It finds root cause before proposing fixes — no symptom-patching. Although listed here because most debugging occurs during execution, it is a cross-cutting discipline that fires at any pipeline stage when failures appear.
 
@@ -188,7 +188,6 @@ If `gh-issue-sync pull` fails with missing project scope (`read:project`) or `gr
 | `begin` | initiating a work session: selecting work, preparing workspace, declaring direction |
 | `plan` | implementation needs design convergence — multiple approaches, unclear scope, or cross-cutting changes |
 | `test-first` | when implementing any feature or bugfix — RED → GREEN → REFACTOR |
-| `subagent-driven-development` | when executing a plan whose tasks are independent and can run in parallel |
 | `systematic-debugging` | when a test fails or behavior is unexpected, before proposing any fix |
 | `third-force` | operational friction — missing tools, broken configs, stale conventions, undocumented requirements |
 | `documentation` | after code changes that may cause drift, at project initialization, when architectural decisions are made, or when docs fail the audience test |

--- a/agents.toml
+++ b/agents.toml
@@ -17,7 +17,6 @@ propose = { gh = "pentaxis93/groundwork", path = "skills/propose" }
 documentation = { gh = "pentaxis93/groundwork", path = "skills/documentation" }
 using_groundwork = { gh = "pentaxis93/groundwork", path = "skills/using-groundwork" }
 third_force = { gh = "pentaxis93/groundwork", path = "skills/third-force" }
-subagent_driven_development = { gh = "obra/superpowers", path = "skills/subagent-driven-development", rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a" }
 test_first = { gh = "pentaxis93/groundwork", path = "skills/test-first" }
 systematic_debugging = { gh = "pentaxis93/groundwork", path = "skills/systematic-debugging" }
 verification_before_completion = { gh = "pentaxis93/groundwork", path = "skills/verification-before-completion" }

--- a/crates/groundwork-cli/src/main.rs
+++ b/crates/groundwork-cli/src/main.rs
@@ -1923,7 +1923,6 @@ mod tests {
                 "issue_craft",
                 "begin",
                 "test_first",
-                "subagent_driven_development",
                 "systematic_debugging",
                 "third_force",
                 "documentation",

--- a/skills/skills.toml
+++ b/skills/skills.toml
@@ -57,14 +57,6 @@ repo = "pentaxis93/groundwork"
 use_when = "Use when implementing any feature or bugfix, before writing implementation code."
 
 [[skills]]
-name = "subagent-driven-development"
-path = "skills/subagent-driven-development"
-provider = "gh"
-repo = "obra/superpowers"
-rev = "e4a2375cb705ca5800f0833528ce36a3faf9017a"
-use_when = "Use when a verified plan contains independent tasks that can run in parallel."
-
-[[skills]]
 name = "systematic-debugging"
 path = "skills/systematic-debugging"
 provider = "gh"

--- a/skills/using-groundwork/SKILL.md
+++ b/skills/using-groundwork/SKILL.md
@@ -33,7 +33,7 @@ Five stages, in dependency order. Each produces what the next consumes.
 
 3. **Decompose.** Converge to a decision-complete design (`plan`), break the design into agent-executable issues (`issue-craft`), and initiate the work session (`begin`).
 
-4. **Execute and verify.** Implement through RED-GREEN-REFACTOR (`test-first`), parallelize independent tasks (`subagent-driven-development`), verify behavior-level evidence before claiming done (`verification-before-completion`), ensure documentation accuracy (`documentation`), and package verified changes into a PR (`propose`).
+4. **Execute and verify.** Implement through RED-GREEN-REFACTOR (`test-first`), verify behavior-level evidence before claiming done (`verification-before-completion`), ensure documentation accuracy (`documentation`), and package verified changes into a PR (`propose`). When a plan contains independent tasks, dispatch fresh subagents for each to keep execution context clean — stale context from earlier tasks pollutes later ones. Match subagent model to task complexity: use cheaper/faster models for straightforward work, reserve the most capable model for subtle or cross-cutting changes.
 
 5. **Land.** `land` closes the loop: merge, cleanup, behavior coverage record, documentation coverage status, and issue closure.
 


### PR DESCRIPTION
## Summary

- Removes the last `obra/superpowers` dependency (`subagent-driven-development`) — investigation found no exigence for a standalone skill
- Preserves two genuinely useful insights as integrated guidance in `using-groundwork` and `WORKFLOW.md` stage 4: fresh-subagent context management and model-selection for cost/speed optimization

## Changes

- **`agents.toml`**: removed `subagent_driven_development` entry
- **`skills/skills.toml`**: removed SDD skill block
- **`crates/groundwork-cli/src/main.rs`**: removed from CLI skill list
- **`skills/using-groundwork/SKILL.md`**: replaced SDD reference in stage 4 with context-management and model-selection guidance
- **`WORKFLOW.md`**: replaced SDD paragraph in stage 4, removed routing table entry
- **`README.md`**: removed SDD row from skills table
- **`CHANGELOG.md`**: added Removed section

Installed copies (`.claude/skills/`, `.codex/skills/`) are gitignored and will be cleaned by `sk sync`.

## Issue(s)

Closes #92

## Test plan

- [ ] `grep -r "subagent-driven-development\|subagent_driven_development" --include="*.md" --include="*.toml" --include="*.rs" skills/ agents.toml WORKFLOW.md README.md` returns zero matches
- [ ] Read `using-groundwork` stage 4 and `WORKFLOW.md` stage 4 — context-management guidance reads naturally
- [ ] `sk sync --skill-target name --non-interactive` succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)