### PR TITLE
docs(history): remove remaining internal-history noise

### DIFF
--- a/docs/architecture/pipeline-design.md
+++ b/docs/architecture/pipeline-design.md
@@ -10,7 +10,7 @@ This document uses three status labels to separate descriptive truth from normat
 - `Designed` — agreed target design, not fully implemented.
 - `Pending` — open question or research-dependent area.
 
-As of **March 6, 2026**, Epic 1 tasks `#33`, `#34`, `#35`, and `#36` are closed; Epic issue `#32` remains open for later epics.
+Epic 1 schema and CLI integration work is implemented; later pipeline work remains in the designed and pending sections below.
 
 ## As-Built Baseline (`Implemented`)
 

--- a/skills/begin/SKILL.md
+++ b/skills/begin/SKILL.md
@@ -8,8 +8,6 @@ description: >-
 
 # Begin — Work Selection & Initiation
 
-**Version 2.1**
-
 ## Overview
 
 Use this skill to start a work session: choose what to work on, prepare the

--- a/skills/land/SKILL.md
+++ b/skills/land/SKILL.md
@@ -9,8 +9,6 @@ description: >-
 
 # Land — Merge, Sync, Cleanup, Close
 
-**Version 1.9**
-
 ## Overview
 
 Use this skill when the user wants full delivery closure in one command.

--- a/skills/propose/SKILL.md
+++ b/skills/propose/SKILL.md
@@ -10,8 +10,6 @@ description: >-
 
 # Propose — Commit, Push, PR
 
-**Version 1.0**
-
 ## Overview
 
 Use this skill when implementation is complete and changes need to become a PR.


### PR DESCRIPTION
## Summary

- remove body-level skill version markers that duplicate canonical frontmatter state
- rewrite the pipeline design status snapshot to durable, atemporal wording
- confirm the repo-wide ADR-0004 audit found no remaining tracked `replaces:` fields to remove

## Changes

- clean `skills/begin`, `skills/land`, and `skills/propose` so `version:` frontmatter remains the only version source
- replace the dated Epic 1 issue-status sentence in `docs/architecture/pipeline-design.md` with current-state language
- preserve the rest of the skill and architecture content unchanged

## Issue(s)

Refs #128

## Test plan

- `rg -n '^\*\*Version |As of \*\*|^replaces:' skills docs`
- `cargo test -p groundwork-cli`
