### PR TITLE
fix(codex): align skill install path with Codex discovery model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-.claude/
 # Agent-local workspace; canonical skills are tracked under skills/ and manifests/.
+.agents/
+.claude/
 .codex/
 .groundwork/
 .issues/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Dependencies are declared in `agents.toml`. Skills with `gh = "pentaxis93/ground
 ### Primary source vs installed copies
 
 - Primary source: `skills/<skill-name>/SKILL.md`
-- Installed copies: `.claude/skills/<skill-name>/SKILL.md`, `.codex/skills/<skill-name>/SKILL.md`
+- Installed copies: `.claude/skills/<skill-name>/SKILL.md`, `.agents/skills/<skill-name>/SKILL.md`
 - Installed copies are managed by `sk sync` — do not edit them directly.
 
 ## Local Issue Mirror

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,10 +104,10 @@ actually ships.
 
 ## Agent Workspace Policy
 
-- `.codex/` is agent-local runtime/workspace state and is intentionally gitignored.
-- Do not add or edit canonical project content under `.codex/`.
+- `.agents/`, `.claude/`, and `.codex/` are agent-local runtime/workspace state and are intentionally gitignored.
+- Do not add or edit canonical project content under these directories.
 - Canonical skill content belongs in tracked project paths (`skills/`) and the shipped-skill manifest at `skills/skills.toml`.
-- When a `.codex/**` path is accidentally tracked, remove it from git index (`git rm --cached <path>`) and move/preserve canonical content in tracked locations.
+- When an agent-local path is accidentally tracked, remove it from git index (`git rm --cached <path>`) and move/preserve canonical content in tracked locations.
 
 ## PR Process
 

--- a/crates/groundwork-cli/src/main.rs
+++ b/crates/groundwork-cli/src/main.rs
@@ -15,8 +15,8 @@ const ARTIFACTS_DIR: &str = ".groundwork/artifacts";
 const LOCK_PATH: &str = ".groundwork/installed.lock.toml";
 const GROUNDWORK_REPO: &str = "pentaxis93/groundwork";
 const SKILLS_SUPPLY_FORK_URL: &str = "https://github.com/pentaxis93/skills-supply";
-const SKILLS_SUPPLY_FORK_REF: &str = "groundwork-v1";
-const SKILLS_SUPPLY_FORK_COMMIT: &str = "ec257c4057c32230478e5c1b86347177134e1469";
+const SKILLS_SUPPLY_FORK_REF: &str = "main";
+const SKILLS_SUPPLY_FORK_COMMIT: &str = "254dc8002caea8f063f368d6b1299f92b358a704";
 const GH_ISSUE_SYNC_REPO: &str = "mitsuhiko/gh-issue-sync";
 const GH_ISSUE_SYNC_RELEASE_TAG: &str = "v0.3.0";
 const SHIPPED_SKILLS_TOML: &str = include_str!("../../../skills/skills.toml");
@@ -2834,8 +2834,8 @@ No local changes
     #[test]
     fn trusted_commit_check_accepts_exact_match() {
         assert!(check_trusted_commit(
-            "ec257c4057c32230478e5c1b86347177134e1469",
-            "ec257c4057c32230478e5c1b86347177134e1469"
+            "254dc8002caea8f063f368d6b1299f92b358a704",
+            "254dc8002caea8f063f368d6b1299f92b358a704"
         )
         .is_ok());
     }
@@ -2844,7 +2844,7 @@ No local changes
     fn trusted_commit_check_rejects_mismatch() {
         let err = check_trusted_commit(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "ec257c4057c32230478e5c1b86347177134e1469",
+            "254dc8002caea8f063f368d6b1299f92b358a704",
         )
         .expect_err("must reject mismatch");
         assert!(err.to_string().contains("trusted commit mismatch"));

--- a/docs/research/existing-skill-implementations.md
+++ b/docs/research/existing-skill-implementations.md
@@ -231,7 +231,7 @@ Then `sk sync` installs skills into the agent's skill directory.
 
 sk installs SKILL.md files into each agent's native skill directory:
 - Claude Code: `.claude/skills/`
-- Codex: `.codex/skills/` or equivalent
+- Codex: `.agents/skills/`
 - Amp, OpenCode, Factory: their respective skill dirs
 
 A Superpowers user on Claude Code already has skills in `.claude/skills/`.


### PR DESCRIPTION
## Summary

- Codex discovers repo-native skills at `.agents/skills/`, not `.codex/skills/` per [official docs](https://developers.openai.com/codex/skills). Fixed the sk fork's agent registry to use `.agents` as the Codex local base path, then updated all groundwork references.

## Changes

**sk fork** (pentaxis93/skills-supply@254dc80):
- `registry.ts`: changed Codex `localBasePath` from `.codex` to `.agents`
- `registry.test.ts`: updated expectations, added asymmetric path test

**groundwork** (this PR):
- `.gitignore`: added `.agents/` to agent-local workspace entries
- `AGENTS.md` (→ `CLAUDE.md` symlink): installed copies path updated
- `CONTRIBUTING.md`: generalized agent workspace policy to cover all agent directories
- `main.rs`: pinned updated sk fork commit (254dc80)
- `docs/research/existing-skill-implementations.md`: corrected Codex path

## Issue(s)

Closes #134

## Test plan

- [x] sk registry tests pass (23/23) — `vitest run packages/sk/agents/registry.test.ts`
- [x] groundwork CLI tests pass (146/146) — `cargo test -p groundwork-cli`
- [x] `sk sync --skill-target name --non-interactive` populates `.agents/skills/` with 14 skills
- [ ] In a clean test repo: `groundwork init` → Codex discovers skills at `.agents/skills/`
