### PR TITLE
fix(skills): add "via the Skill tool" to sub-skill invocation directives

### DIFF
--- a/skills/land/SKILL.md
+++ b/skills/land/SKILL.md
@@ -95,7 +95,7 @@ available.
 Criteria: [all met | partial — list remaining]
 ```
 
-Implementation: invoke the `verification-before-completion` skill. For
+Implementation: invoke the `verification-before-completion` skill via the Skill tool. For
 issue-linked branches, fetch each target issue (`gh issue view`) and evaluate
 acceptance criteria against the branch diff. Classify each issue as satisfied
 (all criteria met) or partial (some remain). If no acceptance criteria can be
@@ -116,7 +116,7 @@ Docs: [clean | fixed: list | tracked: issue numbers]
 ```
 
 Implementation: invoke the `documentation` skill's documentation-review
-procedure. Check whether changed files affect areas with documentation artifacts
+procedure via the Skill tool. Check whether changed files affect areas with documentation artifacts
 (README, ARCHITECTURE, CONTRIBUTING, API docs). Fix drift directly and commit;
 file tracking issues for anything deeper. Record a coverage summary: each
 artifact checked, its status, and any action taken.

--- a/skills/test-first/SKILL.md
+++ b/skills/test-first/SKILL.md
@@ -223,7 +223,7 @@ Execute the RED-GREEN-REFACTOR cycle for a behavior identified by `bdd`.
 
 Enter the RED-GREEN-REFACTOR cycle from a bug report.
 
-1. If the root cause is unclear, invoke `systematic-debugging` first — it owns
+1. If the root cause is unclear, invoke `systematic-debugging` via the Skill tool first — it owns
    root-cause analysis methodology.
 2. Write a failing test that reproduces the bug. The test name describes the
    corrected behavior, not the bug.

--- a/skills/using-groundwork/SKILL.md
+++ b/skills/using-groundwork/SKILL.md
@@ -68,7 +68,7 @@ These thread across the pipeline. They aren't phases — they're disciplines tha
 
 **Research fires at any stage.** `research` provides reliable external evidence when decisions depend on facts outside the codebase — framing, design, decomposition, and implementation can all require it.
 
-**Root cause before fixes.** When a test fails or behavior is unexpected, do not guess. Investigate root cause before proposing any fix. `systematic-debugging` provides the investigation methodology — a cross-cutting discipline that fires at any pipeline stage, not only during execution. Once root cause is established, `test-first` fix-bug owns the execution cycle. After 3 failed fix attempts, stop fixing and invoke `ground` to question the architecture.
+**Root cause before fixes.** When a test fails or behavior is unexpected, do not guess. Investigate root cause before proposing any fix. `systematic-debugging` provides the investigation methodology — a cross-cutting discipline that fires at any pipeline stage, not only during execution. Once root cause is established, `test-first` fix-bug owns the execution cycle. After 3 failed fix attempts, stop fixing and invoke `ground` via the Skill tool to question the architecture.
 
 **Introduce third force on friction.** Friction is a two-force collision: task momentum vs obstacle. Routing around is the collapsed triad — both forces lose. When operational friction appears — a missing tool, broken config, stale convention, undocumented requirement — stop and introduce the reconciling move: resolve it structurally before continuing. `third-force` provides the assessment methodology and scope guidance. Friction that exceeds side-quest scope becomes an issue via `issue-craft`. Unresolved friction compounds.
 


### PR DESCRIPTION
## Summary

- Adds "via the Skill tool" suffix to 4 invocation directives across `land`, `test-first`, and `using-groundwork` skills
- Without the suffix, agents read these as descriptive prose and manually approximate the sub-skill instead of loading it through the Skill tool
- Matches the existing pattern in `begin` skill (line 61)

## Test plan

- [x] Grep all SKILL.md files for "invoke" — every instance now includes "via the Skill tool"
- [ ] Confirm no surrounding context was disrupted in each modified file

🤖 Generated with [Claude Code](https://claude.com/claude-code)