### PR TITLE
docs(topology): clean up residual old-name references

### DIFF
--- a/protocols/begin/SKILL.md
+++ b/protocols/begin/SKILL.md
@@ -27,7 +27,7 @@ Plan from the issue graph, not from memory. Agent sessions end and context
 windows close, but the issue graph persists — it is the only working memory
 that survives across sessions.
 
-For issue decomposition and boundary contracts, use `issue-craft`.
+For issue decomposition and boundary contracts, use `decompose`.
 For first-principles design decisions, use `ground`.
 
 ## Procedures
@@ -49,16 +49,16 @@ Follows the LBRP sequence: orient → observe → frame → banish.
 
 The agent receives its operating methodology — the connected system that makes
 later skills work together rather than in isolation. `begin` opens individual
-work sessions; `using-groundwork` establishes the methodology those sessions
-operate within. If `using-groundwork` has not been loaded this session, load it
-now before proceeding.
+work sessions; `orient` establishes the methodology those sessions operate
+within. If `orient` has not been loaded this session, load it now before
+proceeding.
 
 ```
 ◈ ORIENT
 Methodology: loaded
 ```
 
-Implementation: invoke the `using-groundwork` skill via the Skill tool.
+Implementation: invoke the `orient` skill via the Skill tool.
 
 ##### 0b. Observe
 
@@ -238,10 +238,10 @@ Brief definitions for self-contained use. See
   review. `begin`'s opening ceremony (orient, observe, frame, banish) prepares
   the agent for work; `land`'s closing ceremony (gather, verify, review, seal)
   prepares the work for delivery. Parallel structure, inverse direction.
-- `issue-craft`: decomposition, issue boundaries, acceptance criteria contracts.
+- `decompose`: decomposition, issue boundaries, acceptance criteria contracts.
 - `ground`: validate assumptions before committing to an approach.
-- `bdd`: behavior-first test strategy for implementation increments.
-- `using-groundwork`: the methodology map — activates the connected skill
+- `specify`: behavior-first contract definition for implementation increments.
+- `orient`: the methodology map — activates the connected skill
   system that `begin` operates within. Loaded during orient (Phase 0a).
 - Opening ceremony pattern adapted from LBRP (`aiandi-dev-environment`) —
   internalized, no runtime dependency.

--- a/protocols/decompose/SKILL.md
+++ b/protocols/decompose/SKILL.md
@@ -200,7 +200,7 @@ A well-bounded task has:
 ## Cross-References
 
 - `begin`: session-level prioritization and execution discipline.
-- `bdd`: behavior framing and test naming discipline.
+- `specify`: behavior framing and test naming discipline.
 - `plan`: design convergence before implementation.
 - `land`: merge-and-close completion events.
 - `documentation`: documentation updates as acceptance criteria for user-facing

--- a/protocols/decompose/scripts/issue_lint.py
+++ b/protocols/decompose/scripts/issue_lint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Deterministic lint checks for issue bodies used by issue-craft."""
+"""Deterministic lint checks for issue bodies used by decompose."""
 
 from __future__ import annotations
 

--- a/protocols/land/SKILL.md
+++ b/protocols/land/SKILL.md
@@ -95,14 +95,14 @@ available.
 Criteria: [all met | partial — list remaining]
 ```
 
-Implementation: invoke the `verification-before-completion` skill. For
+Implementation: invoke the `verify` skill. For
 issue-linked branches, fetch each target issue (`gh issue view`) and evaluate
 acceptance criteria against the branch diff. Classify each issue as satisfied
 (all criteria met) or partial (some remain). If no acceptance criteria can be
 extracted from the issue body, classify as partial — an issue without explicit
 criteria may have unstated requirements. If an issue fetch fails, treat that
 issue as partial and log a warning. For no-issue landings, skip acceptance
-criteria evaluation — `verification-before-completion` still runs to confirm
+criteria evaluation — `verify` still runs to confirm
 the work itself is complete. Store classifications for Phase 1e.
 
 #### 0c. Review
@@ -254,8 +254,8 @@ Report the final state including:
   prepares the agent for work; `land`'s closing ceremony (gather, verify, review,
   seal) prepares the work for delivery. Parallel structure, inverse direction.
 - `propose` for the preceding phase: commit, push, and PR creation
-- `verification-before-completion`: invoked during Phase 0b to evaluate
+- `verify`: invoked during Phase 0b to evaluate
   acceptance criteria and verify completion evidence before merge
 - `documentation`: invoked during Phase 0c for documentation-review — confirms
   documentation reflects the changes being landed
-- `issue-craft` for issue lifecycle patterns and tracking issues from doc review
+- `decompose` for issue lifecycle patterns and tracking issues from doc review

--- a/protocols/plan/SKILL.md
+++ b/protocols/plan/SKILL.md
@@ -27,9 +27,9 @@ implementer — every approach, interface, data flow, edge case, and test
 strategy is resolved.
 
 For first-principles constraint framing, use `ground`.
-For behavior contracts, use `bdd`.
+For behavior contracts, use `specify`.
 For executable work-unit decomposition after design convergence, use
-`issue-craft`.
+`decompose`.
 
 ## Goal
 
@@ -152,9 +152,9 @@ When producing a plan for handoff to another agent, write it to a file.
 
 - `ground`: first-principles constraint framing — runs before plan when
   the problem space itself is unclear.
-- `bdd`: behavior contract — provides the behavior statements the plan
+- `specify`: behavior contract — provides the behavior statements the plan
   must implement.
 - `begin`: work initiation — selects which issue to plan for and prepares the session.
-- `issue-craft`: executable work-unit decomposition and issue quality —
+- `decompose`: executable work-unit decomposition and issue quality —
   turns a decision-complete design into agent-executable issues with
   binary acceptance criteria.

--- a/protocols/propose/SKILL.md
+++ b/protocols/propose/SKILL.md
@@ -254,5 +254,5 @@ Output:
 
 - `begin` for work initiation — select issue(s), prepare workspace, declare direction (the preceding phase)
 - `land` for merge, cleanup, and issue closure (the following phase)
-- `verification-before-completion` — should fire before `propose`
+- `verify` — should fire before `propose`
 - `documentation` for documentation review before proposing

--- a/protocols/test/SKILL.md
+++ b/protocols/test/SKILL.md
@@ -2,8 +2,8 @@
 name: test
 description: >-
   Use when implementing any feature or bugfix, before writing implementation
-  code. Enforces test-first development through RED-GREEN-REFACTOR with
-  delete-and-start-over discipline. Fires when implementing BDD-identified
+  code. Enforces test-driven development through RED-GREEN-REFACTOR with
+  delete-and-start-over discipline. Fires when implementing behavior-contract-defined
   behaviors, fixing bugs, refactoring, or any time production code is about
   to be written. If you are about to write implementation code, this skill
   applies.
@@ -21,7 +21,7 @@ trigger:
     - on_signal: "implement"
 ---
 
-# Test-First
+# Test
 
 Write the test first. Watch it fail. Write minimal code to pass.
 
@@ -48,16 +48,16 @@ Implement fresh from tests. No exceptions.
 This skill is the execution discipline in groundwork's topology. It sits
 between behavior identification and completion verification:
 
-1. `bdd` identifies what behaviors the system needs — sentence-named scenarios
+1. `specify` identifies what behaviors the system needs — sentence-named scenarios
    in Given/When/Then form.
-2. **`test-first` executes** those behaviors through RED-GREEN-REFACTOR. Each
-   RED test corresponds to a named behavior scenario from `bdd`.
-3. `verification-before-completion` gates the completion claim with
+2. **`test` executes** those behaviors through RED-GREEN-REFACTOR. Each RED
+   test corresponds to a named behavior scenario from `specify`.
+3. `verify` gates the completion claim with
    behavior-level evidence.
 
 This skill owns per-test cycle evidence: each test was watched failing, then
 passing. It does not own aggregate completion evidence — that belongs to
-`verification-before-completion`.
+`verify`.
 
 ## Discipline
 
@@ -86,7 +86,7 @@ behavior during refactor.
 **Delete-and-start-over.** If you wrote implementation code before the test:
 delete the code and start with a failing test. No keeping it as reference. No
 adapting it. The sunk cost is already gone. The choice is between code you can
-trust (test-first) and code you cannot (implementation-first).
+trust (test-driven) and code you cannot (implementation-first).
 
 ## Red-Green-Refactor
 
@@ -209,9 +209,9 @@ Next failing test for the next behavior.
 
 ### implement-behavior
 
-Execute the RED-GREEN-REFACTOR cycle for a behavior identified by `bdd`.
+Execute the RED-GREEN-REFACTOR cycle for a behavior identified by `specify`.
 
-1. Take the next behavior scenario from `bdd`'s priority ranking.
+1. Take the next behavior scenario from `specify`'s priority ranking.
 2. Write a failing test whose name is the behavior statement.
 3. **Verify RED** — run the test, confirm it fails for the right reason.
 4. Write minimal code to pass.
@@ -242,7 +242,7 @@ When you realize you wrote implementation code before a test:
 4. Implement from the test.
 
 This feels wasteful. It is not. The time spent writing code-first is already
-gone. The choice now is between trusted code (test-first) and untrusted code
+gone. The choice now is between trusted code (test-driven) and untrusted code
 (implementation-first with tests bolted on). Trusted code is faster in the
 long run.
 
@@ -261,13 +261,13 @@ untrusted code.
 | "Keep as reference, write tests first" | You will adapt it. That is testing-after. Delete means delete. |
 | "Need to explore first" | Fine. Throw away exploration, start with a test. |
 | "Test hard = skip TDD" | Listen to the test. Hard to test means hard to use. |
-| "TDD will slow me down" | Test-first is faster than debugging. |
+| "TDD will slow me down" | Test-driven execution is faster than debugging. |
 | "Manual test is faster" | Manual testing does not prove edge cases. You will re-test every change. |
 | "Existing code has no tests" | You are improving it. Add tests for existing code. |
 
 ## Red Flags — Stop and Start Over
 
-Any of these means: delete code, start over with test-first.
+Any of these means: delete code, start over with the `test` discipline.
 
 - Code written before test
 - Test written after implementation
@@ -314,34 +314,36 @@ what the failing test requires.
 *Recognition:* Your GREEN implementation does more than the test asks for. You
 added parameters, configuration, or error handling that no test requires.
 
-**BDD bypass.** Starting RED tests without identified behavior scenarios.
+**Behavior-contract bypass.** Starting RED tests without identified behavior
+scenarios.
 *Recognition:* You are writing tests from implementation convenience —
 "test this function" — rather than from behavior contract — "this behavior
-should exist." The handoff from `bdd` was skipped.
+should exist." The handoff from `specify` was skipped.
 
 ## Principles
 
 **Order matters.** Tests written after code pass immediately. Passing
 immediately proves nothing — you might test the wrong thing, test
-implementation instead of behavior, or miss edge cases. Test-first forces you
+implementation instead of behavior, or miss edge cases. Testing from the first
+cycle forces you
 to see the test fail, proving it actually tests something.
 
 **Delete is faster than debug.** Sunk cost fallacy says keep the code you
-wrote. Reality says rewriting with test-first is faster than debugging
+wrote. Reality says rewriting from tests is faster than debugging
 untested code later.
 
 **Hard to test means hard to use.** When testing is difficult, the test is
 telling you the design needs work. Listen to the test.
 
-**Test-first IS pragmatic.** It finds bugs before commit, prevents
+**Test-driven execution is pragmatic.** It finds bugs before commit, prevents
 regressions, documents behavior, and enables safe refactoring. Shortcuts that
-skip test-first are slower, not faster.
+skip the `test` discipline are slower, not faster.
 
 ## Cross-References
 
-- `bdd`: identifies behaviors before this skill executes the cycle. Each RED
-  test corresponds to a named behavior scenario from `bdd`.
-- `verification-before-completion`: owns behavior-level completion evidence.
+- `specify`: identifies behaviors before this skill executes the cycle. Each
+  RED test corresponds to a named behavior scenario from `specify`.
+- `verify`: owns behavior-level completion evidence.
   This skill owns per-test cycle evidence (watched it fail, watched it pass).
 - `debug`: owns root-cause analysis. This skill provides the
   entry point ("write a failing test reproducing the bug") but defers

--- a/protocols/verify/SKILL.md
+++ b/protocols/verify/SKILL.md
@@ -18,7 +18,7 @@ trigger:
   on_artifact: "test-evidence"
 ---
 
-# Verification Before Completion
+# Verify
 
 Evidence before claims, always.
 
@@ -52,7 +52,7 @@ Skip any step = the claim has no basis
 This skill owns **aggregate completion claims** — the moment before you say
 "done." It fires after execution, before packaging work for review.
 
-It does not own per-test cycle evidence (that belongs to the test-first
+It does not own per-test cycle evidence (that belongs to the `test`
 discipline — each test watched failing, then passing). It owns the final
 gate: all tests pass, all requirements met, the build succeeds, the work is
 actually complete.
@@ -164,7 +164,7 @@ the claim — the claim does not select the evidence.
 
 ## Cross-References
 
-- `test-first` owns per-test cycle evidence (each test watched failing, then
+- `test` owns per-test cycle evidence (each test watched failing, then
   passing). This skill owns aggregate completion claims.
 - `documentation` review fires after code changes, before this skill's gate.
   Documentation accuracy is completion evidence.

--- a/skills/debug/LICENSE-UPSTREAM
+++ b/skills/debug/LICENSE-UPSTREAM
@@ -9,8 +9,7 @@ Iron Law, the four-phase investigation model, the 3-fix architectural
 escalation rule, the anti-rationalization table, and the red flags list.
 These have been restructured as a cross-cutting discipline with vocabulary
 normalization, language-agnostic examples, and bidirectional pipeline
-integration with groundwork's test-first, verification, ground, and
-third-force skills.
+integration with groundwork's test, verify, ground, and resolve skills.
 
 ---
 

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -41,16 +41,16 @@ Investigate from evidence. No exceptions.
 ## Lifecycle Role
 
 This skill is a cross-cutting discipline in groundwork's topology, alongside
-`ground` (first-principles on creation) and `third-force` (structural
-resolution on friction). It fires at any stage when failures appear — not
-only during execution.
+`ground` (first-principles on creation) and `resolve` (structural resolution on
+friction). It fires at any stage when failures appear — not only during
+execution.
 
 All three share the same cognitive shape:
 
 | Discipline | Default Impulse | Interrupt |
 |---|---|---|
 | `ground` | Start from what exists | Stop. What is actually needed? |
-| `third-force` | Route around friction | Stop. What is the structural cause? |
+| `resolve` | Route around friction | Stop. What is the structural cause? |
 | `debug` | Guess and fix | Stop. What is the root cause? |
 
 Debugging is not a phase. Failures surface during grounding (constraint
@@ -59,15 +59,14 @@ around), execution (test failure, integration failure), and landing
 (regression discovered during merge). The trigger is the failure, not the
 stage.
 
-**Handoff with test-first:** This skill owns investigation methodology.
-`test-first`'s fix-bug procedure owns the execution cycle — write failing
-test, implement fix, verify green. The boundary: once root cause is
-established, hand off to `test-first` fix-bug. This skill does not write
+**Handoff with `test`:** This skill owns investigation methodology.
+`test`'s fix-bug procedure owns the execution cycle — write failing test,
+implement fix, verify green. The boundary: once root cause is established,
+hand off to `test` fix-bug. This skill does not write
 tests or implement fixes.
 
-**Handoff with verification-before-completion:** This skill does not verify
-fixes. Once a fix is implemented through `test-first`, `verification-before-
-completion` gates the completion claim.
+**Handoff with `verify`:** This skill does not verify fixes. Once a fix is
+implemented through `test`, `verify` gates the completion claim.
 
 ## The Investigation Move
 
@@ -137,7 +136,7 @@ Five steps. Always the same.
    - State it clearly: "The root cause is X because evidence Y shows Z."
    - Make the smallest possible change to test the hypothesis.
    - One variable at a time. Do not fix multiple things at once.
-   - If the hypothesis is confirmed: hand off to `test-first` fix-bug.
+   - If the hypothesis is confirmed: hand off to `test` fix-bug.
    - If the hypothesis is wrong: form a new hypothesis from the evidence.
      Do not stack fixes on top of a failed hypothesis.
 
@@ -166,7 +165,7 @@ When this fires:
 3. **If the architecture is sound**, the investigation was incomplete — return
    to Step 0 with the new evidence from your three attempts.
 4. **If the architecture is unsound**, the fix is architectural. File an issue
-   via `issue-craft` — this exceeds debugging scope.
+   via `decompose` — this exceeds debugging scope.
 
 This rule is the debugging equivalent of `ground`'s "infinite decomposition"
 corruption mode — it catches the failure of continuing to apply the skill's
@@ -297,18 +296,18 @@ rationalizing, not investigating.
 
 ## Cross-References
 
-- `test-first`: owns the execution cycle for bug fixes. This skill
-  establishes root cause; `test-first` fix-bug writes the failing test and
+- `test`: owns the execution cycle for bug fixes. This skill
+  establishes root cause; `test` fix-bug writes the failing test and
   implements the fix. The handoff: root cause established, hand off to
-  `test-first`.
-- `verification-before-completion`: owns fix verification. This skill does
+  `test`.
+- `verify`: owns fix verification. This skill does
   not verify — it investigates.
 - `ground`: the 3-fix escalation rule invokes `ground` to re-examine
   architectural assumptions. The investigation move shares `ground`'s
   discipline of establishing truth before acting.
-- `third-force`: when investigation reveals the failure is caused by
+- `resolve`: when investigation reveals the failure is caused by
   operational friction (missing tool, broken config, stale convention), hand
-  off to `third-force` — the root cause is environmental, not logical.
-- `bdd`: behavior contracts define what "unexpected" means. When behavior is
+  off to `resolve` — the root cause is environmental, not logical.
+- `specify`: behavior contracts define what "unexpected" means. When behavior is
   unexpected, check it against the behavior contract first — "unexpected" is
   only meaningful relative to a defined expectation.

--- a/skills/resolve/SKILL.md
+++ b/skills/resolve/SKILL.md
@@ -22,7 +22,7 @@ trigger:
   on_signal: "friction-detected"
 ---
 
-# Third Force
+# Resolve
 
 *When two forces collide, introduce the third.*
 
@@ -143,5 +143,5 @@ When filing an issue, still apply a **minimum viable workaround** for the curren
 
 - `ground`: Step 2 of the move uses `ground`'s Orient to assess what the environment should enable. Full grounding is rarely needed for friction resolution, but the orient question is essential.
 - `documentation`: Structural fixes frequently involve documentation updates. The `documentation` skill's review mode applies when the fix involves creating or updating docs.
-- `issue-craft`: When friction exceeds side-quest scope, file an issue using `issue-craft`. The issue is the structural fix at the meta-level.
-- `using-groundwork`: `third-force` is an integration principle in `using-groundwork`, alongside "Ground re-fires" and "Research fires at any stage." It fires at any stage.
+- `decompose`: When friction exceeds side-quest scope, file an issue using `decompose`. The issue is the structural fix at the meta-level.
+- `orient`: `resolve` is an integration principle in `orient`, alongside "Ground re-fires" and "Research fires at any stage." It fires at any stage.


### PR DESCRIPTION
## Summary

- Update scoped Groundwork protocol and skill docs to use the current post-separation internal names.
- Clean up the related issue-linter docstring and current-project adaptation note without changing allowed historical attribution.
- Keep the explicitly excluded external and historical references unchanged.

## Changes

- Replace stale internal references like `bdd`, `test-first`, `verification-before-completion`, `third-force`, `using-groundwork`, and `issue-craft` with the current protocol and skill names in the scoped SKILL docs.
- Rename the decompose issue-linter docstring to match the current protocol name.
- Update the Groundwork adaptation note in `skills/debug/LICENSE-UPSTREAM` to reference the current internal names while preserving upstream attribution.

## Issue(s)

Closes #172

## Test plan

- Run `rg -n "\\bbdd\\b|test-first|verification-before-completion|systematic-debugging|third-force|using-groundwork|issue-craft" protocols/begin/SKILL.md protocols/plan/SKILL.md protocols/test/SKILL.md protocols/verify/SKILL.md protocols/land/SKILL.md protocols/propose/SKILL.md protocols/decompose/SKILL.md protocols/decompose/scripts/issue_lint.py skills/debug/SKILL.md skills/resolve/SKILL.md skills/debug/LICENSE-UPSTREAM protocols/verify/LICENSE-UPSTREAM protocols/specify/SKILL.md skills/orient/SKILL.md skills/contract/SKILL.md skills/ground/SKILL.md skills/research/SKILL.md docs/architecture/topology-contract.md docs/architecture/issue-model.md` and confirm only the allowed matches remain.
- Run `git diff --check`.
