### PR TITLE
fix(integration): research-record producer, harness layering, and MCP tool interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Four planning/specification protocols (survey, decompose, specify,
+  plan) now declare `may_produce = ["research-record"]` in
+  `manifest.toml`. With this wiring, an agent inside any of these
+  protocol sessions can persist a fresh research-record through runa
+  rather than producing it as a loose skill artifact.
+- Canonical reference (`docs/architecture/connecting-structure.md`)
+  gains Runtime Layers and Skill-Produced Artifacts sections that
+  document the four-layer agentd/harness/runa/groundwork model and
+  the `may_produce` bridge from skill output into runa's validated
+  artifact store. The Agent Interface section is rewritten to
+  describe the MCP-tool-per-declared-output-artifact mechanism at
+  interface level, citing runa's interface contract for the
+  internal filtering rules rather than restating them.
+
 ## [0.1.0] — 2026-04-04
 
 First release. Groundwork is a methodology plugin for

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -217,7 +217,7 @@ name = "survey"
 requires = ["request"]
 accepts = ["research-record"]
 produces = ["requirements"]
-may_produce = []
+may_produce = ["research-record"]
 trigger = { type = "on_artifact", name = "request" }
 
 [[protocols]]
@@ -225,7 +225,7 @@ name = "decompose"
 requires = ["requirements"]
 accepts = ["research-record"]
 produces = ["issue"]
-may_produce = []
+may_produce = ["research-record"]
 trigger = { type = "on_artifact", name = "requirements" }
 
 [[protocols]]
@@ -243,7 +243,7 @@ scoped = true
 requires = ["claim", "issue"]
 accepts = ["research-record"]
 produces = ["behavior-contract"]
-may_produce = []
+may_produce = ["research-record"]
 trigger = { type = "on_artifact", name = "claim" }
 
 [[protocols]]
@@ -252,7 +252,7 @@ scoped = true
 requires = ["behavior-contract"]
 accepts = ["research-record"]
 produces = ["implementation-plan"]
-may_produce = []
+may_produce = ["research-record"]
 trigger = { type = "on_artifact", name = "behavior-contract" }
 
 [[protocols]]
@@ -356,10 +356,17 @@ for all ten protocols: the trigger is always the artifact that cannot
 exist until all earlier dependencies in the chain are satisfied.
 
 **Research-record is the sole skill-produced artifact in the protocol
-graph.** No protocol produces it. The research skill (agent-managed)
-produces it. Four protocols accept it as contextual enrichment. Runa
-validates research-records against the schema when they appear but
-never orchestrates their production. Research-record may carry
+graph.** The research skill (harness-managed) cognitively produces it.
+Four protocols — survey, decompose, specify, plan — declare
+`may_produce = ["research-record"]`, so runa-mcp exposes a tool for
+writing a validated research-record during those protocols' sessions.
+Those same four protocols also `accepts` it as contextual enrichment.
+No protocol declares research-record in `produces`, because no
+protocol's completion depends on a research-record existing — the
+single-producer-at-the-`produces`-level property is preserved, and
+the skill-to-runa bridge operates at the `may_produce` level. See
+"Runtime Layers" and "Skill-Produced Artifacts and the `may_produce`
+Bridge" below for the full mechanism. Research-record may carry
 `work_unit` when the research is specific to an issue; when it does,
 runa can scope it to the relevant work unit's context. When `work_unit`
 is absent, the research is cross-cutting. This is the two-population
@@ -374,6 +381,124 @@ protocols (plan, implement, verify). issue is required by three
 protocols (begin, specify, verify). These are the central artifacts
 of the execution phase — the behavioral spec and the acceptance
 criteria it traces to.
+
+## Runtime Layers
+
+Groundwork is methodology content, not a runtime. A working agent
+session runs across four distinct layers, each with a narrow
+responsibility.
+
+**agentd.** Session lifecycle: starting and supervising the agent
+process, preparing the environment, injecting identity. Opaque to
+methodology content — agentd knows only that a given profile uses
+methodology X, not what that methodology contains.
+
+**Harness** (claude code, codex, and similar). Runs the agent loop,
+mediates tool calls, and — critically for this document —
+**loads and invokes skills**. Skills live at the harness layer
+operationally: they are markdown files the harness reads into the
+agent's context on activation, and the harness is what decides, based
+on the agent's judgment and the harness's own activation rules, when
+to invoke them. Runa does not see skills; they are not part of runa's
+contract.
+
+**Runa.** The cognitive runtime. Its interface to groundwork is three
+primitives only: artifact types, protocol declarations, and trigger
+conditions. Runa orchestrates protocols, validates artifacts against
+their schemas, and injects context when a protocol activates. It
+derives all workflow state from artifacts on disk. Runa does not know
+about skills, does not know about the harness, and does not participate
+in agent cognition.
+
+**Groundwork.** The methodology content itself: protocols (runa-managed,
+declared in the manifest), skills (harness-managed, not declared in
+the manifest), schemas (what runa validates against), and the manifest
+that wires the topology. This repository.
+
+The important boundary for the rest of this document: **skills and
+runa are disjoint worlds** — runa never sees a skill, and a skill has
+no direct channel to runa. Anything a skill produces that needs to
+enter runa's validated artifact store must cross through an active
+protocol session. The next section describes the specific mechanism.
+
+## Skill-Produced Artifacts and the `may_produce` Bridge
+
+A skill can be loaded by the harness only during an agent session,
+which always runs under some active runa protocol. The harness
+invokes the skill, the agent does the skill's cognitive work, and the
+skill may cognitively produce an artifact-shaped output — a
+research-record in the concrete case. For that output to enter runa's
+validated artifact store, runa-mcp must expose a tool that writes it,
+and runa-mcp will only expose such a tool when the active protocol
+declares the artifact type in its `may_produce` field.
+
+This is the bridge:
+
+- `produces`: the artifact a protocol's completion depends on. Runa
+  requires it before the protocol ends; runa-mcp exposes a tool for it.
+- `may_produce`: an artifact a protocol may optionally emit during
+  execution, typically by a skill invoked inside the session. Runa
+  does not require it; runa-mcp exposes a tool for it.
+
+From runa-mcp's perspective the two fields are symmetric for tool
+generation — one tool per declared output artifact, named after the
+type, with the artifact's schema as the tool's input schema. The
+distinction is semantic: `produces` is the protocol's capstone,
+`may_produce` is the protocol's sanctioned side-emission surface.
+
+### Default pattern: `accepts ⊇ may_produce`
+
+When a skill-produced artifact is intended to flow into subsequent
+protocols' context (i.e., later protocols `accepts` it), the default
+manifest pattern is:
+
+> Every protocol that `accepts` the artifact also declares it in
+> `may_produce`.
+
+This yields a verifiable correspondence between two manifest fields
+— a future reader can check it mechanically rather than reckoning
+protocol-by-protocol whether a skill should be reachable.
+
+The concrete application in this manifest: `research-record` is
+accepted by `survey`, `decompose`, `specify`, and `plan`, and those
+same four protocols declare it in `may_produce`. An agent invoking
+the research skill during any of those protocols can deliver a
+validated research-record, and that record is available to every
+downstream protocol that accepts it.
+
+### Non-default configurations
+
+The `accepts ⊇ may_produce` rule is not universal. Two exceptions
+are possible:
+
+- **Protocol-internal skill outputs.** A skill output that should
+  not flow downstream may appear in `may_produce` without appearing
+  in any protocol's `accepts`. Runa validates it, but no later
+  protocol receives it as injected context.
+- **Read-only consumers.** A protocol that `accepts` an artifact but
+  should not produce new instances of it (because the artifact is
+  structurally upstream or produced only by specific protocols) may
+  legitimately omit it from `may_produce`.
+
+The default pattern applies when a skill's output is a cross-cutting
+enrichment of the protocol topology. Deviations should be justified
+explicitly where they occur.
+
+### Authoring a new skill-produced artifact
+
+For a methodology author wiring a new skill whose output should be
+persisted through runa:
+
+1. Declare the artifact type in `[[artifact_types]]` and define its
+   schema in `schemas/`.
+2. Decide which protocols the skill's output should enrich. List the
+   artifact in each of those protocols' `accepts`.
+3. By default, mirror that set into each of those protocols'
+   `may_produce`. Deviate only with justification.
+4. The skill itself does not need to declare anything for runa's
+   sake — runa does not read skill frontmatter. (Skill frontmatter
+   serves the harness and methodology authors; see the skill-authoring
+   convention for what it should carry.)
 
 ## Agent Interface
 

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -345,7 +345,7 @@ trigger = { type = "on_artifact", name = "patch" }
 | documentation-record | document |
 | patch | submit |
 | completion-record | land |
-| research-record | research skill (agent-managed) |
+| research-record | research skill |
 
 **Every type consumed.** All artifact types have at least one consumer
 except completion-record, which is the terminal archival artifact.
@@ -356,7 +356,7 @@ for all ten protocols: the trigger is always the artifact that cannot
 exist until all earlier dependencies in the chain are satisfied.
 
 **Research-record is the sole skill-produced artifact in the protocol
-graph.** The research skill (harness-managed) cognitively produces it.
+graph.** The research skill cognitively produces it.
 Four protocols — survey, decompose, specify, plan — declare
 `may_produce = ["research-record"]`, so runa-mcp exposes a tool for
 writing a validated research-record during those protocols' sessions.
@@ -411,9 +411,9 @@ about skills, does not know about the harness, and does not participate
 in agent cognition.
 
 **Groundwork.** The methodology content itself: protocols (runa-managed,
-declared in the manifest), skills (harness-managed, not declared in
-the manifest), schemas (what runa validates against), and the manifest
-that wires the topology. This repository.
+declared in the manifest), skills (not declared in the manifest),
+schemas (what runa validates against), and the manifest that wires
+the topology. This repository.
 
 The important boundary for the rest of this document: **skills and
 runa are disjoint worlds** — runa never sees a skill, and a skill has
@@ -446,14 +446,12 @@ type, with the artifact's schema as the tool's input schema. The
 distinction is semantic: `produces` is the protocol's capstone,
 `may_produce` is the protocol's sanctioned side-emission surface.
 
-### Default pattern: `accepts ⊇ may_produce`
+### Default pattern: accepts and may_produce move together
 
 When a skill-produced artifact is intended to flow into subsequent
 protocols' context (i.e., later protocols `accepts` it), the default
-manifest pattern is:
-
-> Every protocol that `accepts` the artifact also declares it in
-> `may_produce`.
+manifest pattern is mirrored declarations: a protocol either carries
+the artifact in both `accepts` and `may_produce`, or in neither.
 
 This yields a verifiable correspondence between two manifest fields
 — a future reader can check it mechanically rather than reckoning
@@ -468,7 +466,7 @@ downstream protocol that accepts it.
 
 ### Non-default configurations
 
-The `accepts ⊇ may_produce` rule is not universal. Two exceptions
+The mirrored-declarations default is not universal. Two exceptions
 are possible:
 
 - **Protocol-internal skill outputs.** A skill output that should
@@ -501,6 +499,10 @@ persisted through runa:
    convention for what it should carry.)
 
 ## Agent Interface
+
+*This section is pending revision in #221 to reflect the may_produce
+bridge mechanism described above. Some statements below may not yet
+match the new model.*
 
 Two interfaces connect the agent to the artifact system. Both are
 owned by runa. The agent touches neither directly.

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -345,7 +345,7 @@ trigger = { type = "on_artifact", name = "patch" }
 | documentation-record | document |
 | patch | submit |
 | completion-record | land |
-| research-record | research skill |
+| research-record | research skill (via `may_produce`; see below) |
 
 **Every type consumed.** All artifact types have at least one consumer
 except completion-record, which is the terminal archival artifact.

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -504,8 +504,7 @@ persisted through runa:
    `may_produce` if yes. This decision is independent of step 2.
 4. The skill itself does not need to declare anything for runa's
    sake — runa does not read skill frontmatter. (Skill frontmatter
-   serves the harness and methodology authors; see the skill-authoring
-   convention for what it should carry.)
+   serves the harness and methodology authors, not runa.)
 
 ## Agent Interface
 

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -500,70 +500,102 @@ persisted through runa:
 
 ## Agent Interface
 
-*This section is pending revision in #221 to reflect the may_produce
-bridge mechanism described above. Some statements below may not yet
-match the new model.*
-
 Two interfaces connect the agent to the artifact system. Both are
 owned by runa. The agent touches neither directly.
 
 ### Input: Context injection as prompt
 
-Runa constructs a prompt with all context pre-integrated. The skill
+Runa constructs a prompt with all context pre-integrated. The agent
 reads natural language, not JSON. The behavior-contract, implementation-
 plan, research-records are already woven into the context window.
-The skill doesn't parse artifacts or know about schemas.
+The agent doesn't parse artifacts or know about schemas.
 
-### Output: MCP tool for artifact production
+### Output: MCP tools for artifact production
 
-An MCP server exposes a tool the agent calls to deliver work products.
-Instead of constructing JSON and placing files, the agent calls:
+Runa-mcp exposes one MCP tool per declared output artifact for the
+active protocol — the union of `produces` and viable `may_produce`.
+Each tool is derived mechanically from the artifact type:
+
+- **Name:** the artifact type name (e.g., `behavior-contract`,
+  `research-record`).
+- **Description:** auto-generated as
+  `"Validate and write a {type_name} artifact to the workspace"`.
+- **Input schema:** the artifact's JSON Schema with `work_unit`
+  removed from `properties` and `required`, plus a required
+  `instance_id` string that names the artifact file.
+
+Two classes of artifact type are filtered out during tool generation:
+those with non-object root schemas, and those using composition
+keywords (`allOf`, `anyOf`, `oneOf`, `$ref`). A `may_produce` type is
+also filtered when the session has no `work_unit` and the schema
+requires one; a required `produces` type in the same situation causes
+the session to refuse to start rather than silently omit the tool.
+
+The agent calls one of these tools by its type name. Concretely, an
+agent inside a specify session producing a behavior-contract calls:
 
 ```
-produce("behavior-contract", {
+behavior-contract({
+  instance_id: "issue-221",
   title: "User authentication",
   scenarios: [
-    { name: "valid login", criterion: "users can log in",
-      given: "...", when: "...", then: "..." }
+    { name: "valid login",
+      criterion: "users can log in",
+      given: "a registered account",
+      when: "credentials are submitted",
+      then: "a session is established" }
   ]
 })
 ```
 
-The MCP server validates against the schema, writes to the workspace,
-and reports success or failure.
+The server validates `instance_id` against path-safety rules, injects
+`work_unit` from the session context if the artifact schema mentions
+it, validates the full payload against the original schema, writes
+`{type_name}/{instance_id}.json` into the workspace, and records the
+artifact in runa's store. The agent never constructs filenames,
+writes to disk, or supplies `work_unit` for scoped artifacts.
 
 ### Schema vs tool interface
 
-The schema and the MCP tool interface are related but not identical.
+The artifact schema and the MCP tool input schema are related but
+not identical. The artifact schema is the full structure on disk —
+what runa validates and tracks. The tool input schema is that schema
+with one subtraction and one addition:
 
-The schema is the full artifact structure on disk — what runa validates
-and tracks. The tool interface is the schema minus what runa can infer
-from the active execution context.
+- **Server-supplied — `work_unit`.** Stripped from the tool's input
+  schema. When the artifact schema mentions `work_unit`, runa-mcp
+  injects the session's work unit before validation. The agent never
+  supplies it.
+- **Agent-supplied — `instance_id`.** Added to the tool's input
+  schema as a required string. Names the artifact instance; becomes
+  the filename `{type_name}/{instance_id}.json`. Not part of the
+  artifact's on-disk content.
 
-**work_unit** is the one field runa can always infer for protocol-
-produced artifacts. Runa activated this protocol for a specific work
-unit. The MCP server auto-populates work_unit from the execution
-context. The agent never supplies it.
-
-Skill-produced artifacts are the exception. Research-record is produced
-by the research skill, not by a protocol — no execution context exists
-for runa to infer from. When the agent produces a work-unit-scoped
-research-record, it supplies work_unit directly. When it produces
-cross-cutting research, it omits the field.
-
-Everything else in the schemas is the agent's cognitive output — runa
-cannot know it, the agent must supply it. The schemas work as tool
-interfaces with that one subtraction for protocol-produced artifacts.
+Everything else is cognitive output: the agent supplies it and runa
+validates it. The same mechanism applies to skill-produced artifacts
+— they reach runa's validated store through the active protocol's
+`may_produce` (see *Skill-Produced Artifacts and the `may_produce`
+Bridge* above). For a research-record produced during a scoped
+protocol session the server injects `work_unit` the same way; because
+`research-record.work_unit` is optional in the schema, an unscoped
+session can still expose the tool and the agent simply omits the
+field.
 
 ### The liberation insight at the interface level
 
 The agent never touches the artifact system. Runa owns both input
 (context injection) and output (MCP validation and placement). The
-skill is liberated from infrastructure — free to do its cognitive
-work without fighting JSON Schema internals, file placement conventions,
-or state management.
+agent is liberated from infrastructure — free to do its cognitive
+work without fighting JSON Schema internals, file placement
+conventions, or state management.
 
 ## The MCP Server as Methodology Interface
+
+*The subsections below extrapolate where the MCP server could go —
+progressive authoring, pre-populated scaffolds, structured queries,
+richer inference from execution context. They are not current
+`runa-mcp` behavior; they are design directions taken from the
+interface pattern above.*
 
 The MCP server is not just an artifact I/O layer. It is the agent's
 entire interface to the methodology. The agent doesn't know about runa,

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -360,8 +360,8 @@ graph.** The research skill cognitively produces it. For each of
 survey, decompose, specify, and plan, two independent decisions
 happen to land the same way: the protocol `accepts` a research-record
 (so any existing instance is injected as context on activation), and
-the protocol declares `may_produce = ["research-record"]` (so runa-mcp
-exposes a tool to write a fresh instance during the session). These
+the protocol declares `may_produce = ["research-record"]` (so the
+session's MCP server exposes a tool to write a fresh instance). These
 are separate per-protocol judgments, not the application of a mirroring
 rule. No protocol declares research-record in `produces`, because no
 protocol's completion depends on a research-record existing — the
@@ -430,23 +430,28 @@ which always runs under some active runa protocol. The harness
 invokes the skill, the agent does the skill's cognitive work, and the
 skill may cognitively produce an artifact-shaped output — a
 research-record in the concrete case. For that output to enter runa's
-validated artifact store, runa-mcp must expose a tool that writes it,
-and runa-mcp will only expose such a tool when the active protocol
-declares the artifact type in its `may_produce` field.
+validated artifact store, the active protocol must declare the
+artifact type in its `may_produce` field. Runa's interface contract
+then guarantees that each declared output artifact is exposed as an
+MCP tool during the protocol session.
 
 This is the bridge:
 
 - `produces`: the artifact a protocol's completion depends on. Runa
-  requires it before the protocol ends; runa-mcp exposes a tool for it.
+  requires it before the protocol ends; the session's MCP server
+  exposes a tool for it.
 - `may_produce`: an artifact a protocol may optionally emit during
   execution, typically by a skill invoked inside the session. Runa
-  does not require it; runa-mcp exposes a tool for it.
+  does not require it; the session's MCP server exposes a tool for it.
 
-From runa-mcp's perspective the two fields are symmetric for tool
-generation — one tool per declared output artifact, named after the
-type, with the artifact's schema as the tool's input schema. The
-distinction is semantic: `produces` is the protocol's capstone,
-`may_produce` is the protocol's sanctioned side-emission surface.
+At the interface level, the two fields are symmetric: one tool per
+declared output artifact, named after the type, with the artifact's
+schema as the tool's input schema. The distinction is semantic:
+`produces` is the protocol's capstone, `may_produce` is the
+protocol's sanctioned side-emission surface. (See
+[runa's interface contract](https://github.com/tesserine/runa/blob/main/docs/interface-contract.md)
+for the derivation rules runa's MCP server applies to artifact
+schemas when generating tool input schemas.)
 
 ### `accepts` and `may_produce` as independent declarations
 
@@ -456,7 +461,7 @@ answer two different questions:
 - `accepts` answers: "if a valid instance of this artifact exists when
   I activate, inject it into my context."
 - `may_produce` answers: "during my session, the agent may need to
-  produce a fresh instance of this — expose a runa-mcp tool for it."
+  produce a fresh instance of this — expose an MCP tool for it."
 
 For any protocol/artifact pair, the two decisions are made separately.
 All four combinations are legitimate:
@@ -516,24 +521,23 @@ The agent doesn't parse artifacts or know about schemas.
 
 ### Output: MCP tools for artifact production
 
-Runa-mcp exposes one MCP tool per declared output artifact for the
-active protocol — the union of `produces` and viable `may_produce`.
-Each tool is derived mechanically from the artifact type:
+Runa's MCP server exposes one MCP tool per declared output artifact
+for the active protocol — the union of `produces` and `may_produce`,
+subject to runa's tool-generation rules. Each tool is derived from
+the artifact type:
 
 - **Name:** the artifact type name (e.g., `behavior-contract`,
   `research-record`).
-- **Description:** auto-generated as
-  `"Validate and write a {type_name} artifact to the workspace"`.
+- **Description:** runa's MCP server supplies a default description
+  naming the artifact type.
 - **Input schema:** the artifact's JSON Schema with `work_unit`
   removed from `properties` and `required`, plus a required
   `instance_id` string that names the artifact file.
 
-Two classes of artifact type are filtered out during tool generation:
-those with non-object root schemas, and those using composition
-keywords (`allOf`, `anyOf`, `oneOf`, `$ref`). A `may_produce` type is
-also filtered when the session has no `work_unit` and the schema
-requires one; a required `produces` type in the same situation causes
-the session to refuse to start rather than silently omit the tool.
+Not every artifact type is eligible for tool exposure — see
+[runa's interface contract](https://github.com/tesserine/runa/blob/main/docs/interface-contract.md)
+for the eligibility rules and how unscoped sessions interact with
+`work_unit`-bearing schemas.
 
 The agent calls one of these tools by its type name. Concretely, an
 agent inside a specify session producing a behavior-contract calls:
@@ -552,12 +556,10 @@ behavior-contract({
 })
 ```
 
-The server validates `instance_id` against path-safety rules, injects
-`work_unit` from the session context if the artifact schema mentions
-it, validates the full payload against the original schema, writes
-`{type_name}/{instance_id}.json` into the workspace, and records the
-artifact in runa's store. The agent never constructs filenames,
-writes to disk, or supplies `work_unit` for scoped artifacts.
+The MCP server validates the payload, writes the artifact to the
+workspace under the chosen `instance_id`, and records it in runa's
+store. The agent never constructs filenames, writes to disk, or
+supplies `work_unit` for scoped artifacts.
 
 ### Schema vs tool interface
 
@@ -567,8 +569,8 @@ what runa validates and tracks. The tool input schema is that schema
 with one subtraction and one addition:
 
 - **Server-supplied — `work_unit`.** Stripped from the tool's input
-  schema. When the artifact schema mentions `work_unit`, runa-mcp
-  injects the session's work unit before validation. The agent never
+  schema. When the artifact schema mentions `work_unit`, runa's MCP
+  server supplies it from the session context. The agent never
   supplies it.
 - **Agent-supplied — `instance_id`.** Added to the tool's input
   schema as a required string. Names the artifact instance; becomes
@@ -580,10 +582,9 @@ validates it. The same mechanism applies to skill-produced artifacts
 — they reach runa's validated store through the active protocol's
 `may_produce` (see *Skill-Produced Artifacts and the `may_produce`
 Bridge* above). For a research-record produced during a scoped
-protocol session the server injects `work_unit` the same way; because
-`research-record.work_unit` is optional in the schema, an unscoped
-session can still expose the tool and the agent simply omits the
-field.
+protocol session, runa's MCP server supplies `work_unit` the same
+way. Because `research-record.work_unit` is optional in the schema,
+the artifact also writes cleanly from an unscoped session.
 
 ### The liberation insight at the interface level
 
@@ -598,8 +599,8 @@ conventions, or state management.
 *The subsections below extrapolate where the MCP server could go —
 progressive authoring, pre-populated scaffolds, structured queries,
 richer inference from execution context. They are not current
-`runa-mcp` behavior; they are design directions taken from the
-interface pattern above.*
+behavior of runa's MCP server; they are design directions taken from
+the interface pattern above.*
 
 The MCP server is not just an artifact I/O layer. It is the agent's
 entire interface to the methodology. The agent doesn't know about runa,

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -356,18 +356,11 @@ for all ten protocols: the trigger is always the artifact that cannot
 exist until all earlier dependencies in the chain are satisfied.
 
 **Research-record is the sole skill-produced artifact in the protocol
-graph.** The research skill cognitively produces it. For each of
-survey, decompose, specify, and plan, two independent decisions
-happen to land the same way: the protocol `accepts` a research-record
-(so any existing instance is injected as context on activation), and
-the protocol declares `may_produce = ["research-record"]` (so the
-session's MCP server exposes a tool to write a fresh instance). These
-are separate per-protocol judgments, not the application of a mirroring
-rule. No protocol declares research-record in `produces`, because no
-protocol's completion depends on a research-record existing — the
-single-producer-at-the-`produces`-level property is preserved, and
-the skill-to-runa bridge operates at the `may_produce` level. See
-"Runtime Layers" and "Skill-Produced Artifacts and the `may_produce`
+graph.** No protocol declares it in `produces`, because no protocol's
+completion depends on a research-record existing. Four protocols
+declare it in `may_produce` so that, when an agent's research skill
+emits one mid-session, runa exposes a tool to validate and persist it.
+See "Runtime Layers" and "Skill-Produced Artifacts and the `may_produce`
 Bridge" below for the full mechanism. Research-record may carry
 `work_unit` when the research is specific to an issue; when it does,
 runa can scope it to the relevant work unit's context. When `work_unit`
@@ -481,12 +474,9 @@ author. There is no mirroring rule between the two fields; a future
 reader verifies the wiring by checking each declaration against the
 protocol's actual needs, not against the other field.
 
-In this manifest, research-record happens to fall into the "both" case
-for survey, decompose, specify, and plan — by per-protocol judgment
-about each one. Each of those protocols plausibly benefits from prior
-research as context and plausibly has reason to emit fresh research
-during its session. The other six protocols land differently by their
-own judgments: the artifact is neither accepted nor produced there.
+In the current manifest, research-record falls into the "both" case
+for survey, decompose, specify, and plan, and into "neither" for the
+other six.
 
 ### Authoring a new skill-produced artifact
 
@@ -503,8 +493,7 @@ persisted through runa:
    that protocol's session. Add the artifact to that protocol's
    `may_produce` if yes. This decision is independent of step 2.
 4. The skill itself does not need to declare anything for runa's
-   sake — runa does not read skill frontmatter. (Skill frontmatter
-   serves the harness and methodology authors, not runa.)
+   sake — runa does not read skill frontmatter.
 
 ## Agent Interface
 
@@ -595,11 +584,11 @@ conventions, or state management.
 
 ## The MCP Server as Methodology Interface
 
-*The subsections below extrapolate where the MCP server could go —
-progressive authoring, pre-populated scaffolds, structured queries,
-richer inference from execution context. They are not current
-behavior of runa's MCP server; they are design directions taken from
-the interface pattern above.*
+*The subsections below extend the interface pattern above. The
+inference of `work_unit` from execution context is today's behavior
+(see "Schema vs tool interface"). The simplifications it enables —
+`deliver(content)`, structured queries, cross-reference validation,
+progressive authoring — are design directions, not current behavior.*
 
 The MCP server is not just an artifact I/O layer. It is the agent's
 entire interface to the methodology. The agent doesn't know about runa,

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -356,12 +356,14 @@ for all ten protocols: the trigger is always the artifact that cannot
 exist until all earlier dependencies in the chain are satisfied.
 
 **Research-record is the sole skill-produced artifact in the protocol
-graph.** The research skill cognitively produces it.
-Four protocols — survey, decompose, specify, plan — declare
-`may_produce = ["research-record"]`, so runa-mcp exposes a tool for
-writing a validated research-record during those protocols' sessions.
-Those same four protocols also `accepts` it as contextual enrichment.
-No protocol declares research-record in `produces`, because no
+graph.** The research skill cognitively produces it. For each of
+survey, decompose, specify, and plan, two independent decisions
+happen to land the same way: the protocol `accepts` a research-record
+(so any existing instance is injected as context on activation), and
+the protocol declares `may_produce = ["research-record"]` (so runa-mcp
+exposes a tool to write a fresh instance during the session). These
+are separate per-protocol judgments, not the application of a mirroring
+rule. No protocol declares research-record in `produces`, because no
 protocol's completion depends on a research-record existing — the
 single-producer-at-the-`produces`-level property is preserved, and
 the skill-to-runa bridge operates at the `may_produce` level. See
@@ -446,41 +448,40 @@ type, with the artifact's schema as the tool's input schema. The
 distinction is semantic: `produces` is the protocol's capstone,
 `may_produce` is the protocol's sanctioned side-emission surface.
 
-### Default pattern: accepts and may_produce move together
+### `accepts` and `may_produce` as independent declarations
 
-When a skill-produced artifact is intended to flow into subsequent
-protocols' context (i.e., later protocols `accepts` it), the default
-manifest pattern is mirrored declarations: a protocol either carries
-the artifact in both `accepts` and `may_produce`, or in neither.
+`accepts` and `may_produce` are two independent declarations that
+answer two different questions:
 
-This yields a verifiable correspondence between two manifest fields
-— a future reader can check it mechanically rather than reckoning
-protocol-by-protocol whether a skill should be reachable.
+- `accepts` answers: "if a valid instance of this artifact exists when
+  I activate, inject it into my context."
+- `may_produce` answers: "during my session, the agent may need to
+  produce a fresh instance of this — expose a runa-mcp tool for it."
 
-The concrete application in this manifest: `research-record` is
-accepted by `survey`, `decompose`, `specify`, and `plan`, and those
-same four protocols declare it in `may_produce`. An agent invoking
-the research skill during any of those protocols can deliver a
-validated research-record, and that record is available to every
-downstream protocol that accepts it.
+For any protocol/artifact pair, the two decisions are made separately.
+All four combinations are legitimate:
 
-### Non-default configurations
+- **Neither.** The protocol neither reads the artifact on activation
+  nor writes a fresh instance during its session.
+- **`accepts` only.** The protocol reads an existing instance as
+  context but does not produce new instances — a read-only consumer.
+- **`may_produce` only.** The protocol writes a fresh instance during
+  its session but does not read prior instances into its activation
+  context — a protocol-internal emission.
+- **Both.** The protocol reads prior instances and may also emit
+  fresh ones.
 
-The mirrored-declarations default is not universal. Two exceptions
-are possible:
+Each protocol/artifact pair is a separate judgment by the methodology
+author. There is no mirroring rule between the two fields; a future
+reader verifies the wiring by checking each declaration against the
+protocol's actual needs, not against the other field.
 
-- **Protocol-internal skill outputs.** A skill output that should
-  not flow downstream may appear in `may_produce` without appearing
-  in any protocol's `accepts`. Runa validates it, but no later
-  protocol receives it as injected context.
-- **Read-only consumers.** A protocol that `accepts` an artifact but
-  should not produce new instances of it (because the artifact is
-  structurally upstream or produced only by specific protocols) may
-  legitimately omit it from `may_produce`.
-
-The default pattern applies when a skill's output is a cross-cutting
-enrichment of the protocol topology. Deviations should be justified
-explicitly where they occur.
+In this manifest, research-record happens to fall into the "both" case
+for survey, decompose, specify, and plan — by per-protocol judgment
+about each one. Each of those protocols plausibly benefits from prior
+research as context and plausibly has reason to emit fresh research
+during its session. The other six protocols land differently by their
+own judgments: the artifact is neither accepted nor produced there.
 
 ### Authoring a new skill-produced artifact
 
@@ -489,10 +490,13 @@ persisted through runa:
 
 1. Declare the artifact type in `[[artifact_types]]` and define its
    schema in `schemas/`.
-2. Decide which protocols the skill's output should enrich. List the
-   artifact in each of those protocols' `accepts`.
-3. By default, mirror that set into each of those protocols'
-   `may_produce`. Deviate only with justification.
+2. For each protocol, judge separately whether prior instances of the
+   artifact should enrich its activation context. Add the artifact to
+   that protocol's `accepts` if yes.
+3. For each protocol, judge separately whether the agent could
+   plausibly need to produce a fresh instance of the artifact during
+   that protocol's session. Add the artifact to that protocol's
+   `may_produce` if yes. This decision is independent of step 2.
 4. The skill itself does not need to declare anything for runa's
    sake — runa does not read skill frontmatter. (Skill frontmatter
    serves the harness and methodology authors; see the skill-authoring

--- a/manifest.toml
+++ b/manifest.toml
@@ -54,7 +54,7 @@ name = "survey"
 requires = ["request"]
 accepts = ["research-record"]
 produces = ["requirements"]
-may_produce = []
+may_produce = ["research-record"]
 trigger = { type = "on_artifact", name = "request" }
 
 [[protocols]]
@@ -62,7 +62,7 @@ name = "decompose"
 requires = ["requirements"]
 accepts = ["research-record"]
 produces = ["issue"]
-may_produce = []
+may_produce = ["research-record"]
 trigger = { type = "on_artifact", name = "requirements" }
 
 [[protocols]]
@@ -80,7 +80,7 @@ scoped = true
 requires = ["claim", "issue"]
 accepts = ["research-record"]
 produces = ["behavior-contract"]
-may_produce = []
+may_produce = ["research-record"]
 trigger = { type = "on_artifact", name = "claim" }
 
 [[protocols]]
@@ -89,7 +89,7 @@ scoped = true
 requires = ["behavior-contract"]
 accepts = ["research-record"]
 produces = ["implementation-plan"]
-may_produce = []
+may_produce = ["research-record"]
 trigger = { type = "on_artifact", name = "behavior-contract" }
 
 [[protocols]]


### PR DESCRIPTION
## Summary

Phase A of the runa-native-execution epic (#220). Two paired fixes to the canonical connecting-structure reference and the manifest, sized to ship together because they both touch the same doc.

- **#224** — wire the research-record producer via `may_produce`, and articulate the four-layer methodology/runtime architecture so skill-produced artifacts have a documented path into runa's validated store.
- **#221** — rewrite the `## Agent Interface` section to describe runa-mcp's actual tool generation (one tool per declared output artifact; tool name = type; input schema = artifact schema minus `work_unit` plus `instance_id`). Replace the fictional `produce("type", {...})` API with a real behavior-contract call.

## Changes

### `manifest.toml` (#224)

- `may_produce = ["research-record"]` on survey, decompose, specify, plan.
- Other six protocols keep `may_produce = []`.

### `docs/architecture/connecting-structure.md`

**From #224:**
- New section **Runtime Layers**: agentd, harness, runa, groundwork and their boundaries. Key boundary: skills live at the harness layer; runa does not see them.
- New section **Skill-Produced Artifacts and the `may_produce` Bridge**: describes how skill output crosses into runa's validated store via the active protocol's `may_produce`. Default pattern `accepts ⊇ may_produce`, with explicit non-default configurations.
- Synthesis Verification paragraph on research-record rewritten to state the new wiring directly.
- Consolidated manifest example updated to mirror the real manifest.

**From #221:**
- `## Agent Interface` rewritten: Output subsection describes the actual tool-per-artifact mechanism, including the `work_unit`-strip / `instance_id`-add derivation and the filters (non-object root, composition keywords, unscoped sessions requiring `work_unit`). Example replaced with a `behavior-contract` call that validates against the current schema.
- Schema-vs-tool-interface subsection restructured around server-supplied (`work_unit`) vs agent-supplied (`instance_id`) fields.
- "the skill" replaced with "the agent" in the section's prose — "skill" remains only where referring to actual skills.
- `## The MCP Server as Methodology Interface` framed as forward-looking so `deliver(content)` speculation isn't mistaken for current behavior.

## Scope

Deferred: skill-frontmatter changes → #223. Protocol prose edits → #222. Babbie integration test → Phase E of #220.

## Issue(s)

Closes #224
Closes #221
Part of #220

## Test plan

- [ ] `manifest.toml` parses (TOML syntax intact).
- [ ] `may_produce` entries match: survey, decompose, specify, plan carry `["research-record"]`; others `[]`.
- [ ] Canonical reference articulates the four-layer model and the `may_produce` bridge with `accepts ⊇ may_produce` as the stated default pattern.
- [ ] `## Agent Interface` derives the MCP tool mechanism from the actual `runa-mcp` behavior (one tool per artifact; `work_unit` server-supplied; `instance_id` agent-supplied; filters for non-object and composed schemas).
- [ ] Example in the Output subsection is a valid call shape for `behavior-contract` — validates against `schemas/behavior-contract.schema.json` once the server injects `work_unit`.
- [ ] Cold-read test: given a protocol manifest entry, a reader using only this doc can list the tools the session will expose and their input schemas.
- [ ] Cold-read test: a new methodology author can derive how to wire a new skill-produced artifact — declare type, add to accepts, mirror to may_produce by default.
- [ ] "the skill" appears in `## Agent Interface` only where cross-referencing skill-produced artifacts; all execution-context references use "the agent".