### PR TITLE
fix(protocols): align protocol set with runa-native execution model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   describe the MCP-tool-per-declared-output-artifact mechanism at
   interface level, citing runa's interface contract for the
   internal filtering rules rather than restating them.
+- Nine PROTOCOL.md files reframed as runa-native protocols:
+  entrypoint language describes trigger-artifact activation;
+  artifact-producing protocols deliver outputs through the session's
+  MCP tool; self-description consistently uses "protocol" rather
+  than "skill" for runa-managed work. Closes #214, #216, #217, #219
+  and part of #213.
+- Forge interaction (gh CLI, git workflow, PR and forge-issue
+  management) extracted from protocol bodies. Protocols that
+  previously embedded forge mechanics (submit, land, decompose)
+  now delegate to the `forge` skill (#228). Closes #215, #218 and
+  part of #213.
 
 ## [0.1.0] — 2026-04-04
 

--- a/protocols/begin/PROTOCOL.md
+++ b/protocols/begin/PROTOCOL.md
@@ -1,9 +1,10 @@
 ---
 name: begin
 description: >-
-  Session work initiation: select issue(s), prepare workspace, declare
-  direction. Opening bookend of the session lifecycle — `land` is the closing
-  bookend. Trigger on: 'begin', 'begin work', 'start session', 'start issue'.
+  Activates on an `issue` artifact and produces the `claim` artifact — the
+  threading root that carries work-unit identity into the execution-phase
+  chain. Opening bookend of the session lifecycle; `land` is the closing
+  bookend.
 requires: ["issue"]
 accepts: []
 produces: ["claim"]
@@ -12,172 +13,38 @@ trigger:
   on_artifact: "issue"
 ---
 
-# Begin — Work Selection & Initiation
+# Begin
 
-## Overview
+The `begin` protocol activates on an `issue` artifact and produces the `claim`
+artifact — the threading root that carries work-unit identity into the
+execution-phase chain (`specify` → `plan` → `implement` → `verify` →
+`document` → `submit` → `land`).
 
-Use this skill to start a work session: choose what to work on, prepare the
-workspace, and declare the session's direction.
+By the time `begin` activates, runa has already resolved selection: the issue
+being worked is in injected context. Begin's substantive work is
+acknowledging that issue as active, distilling it into work-unit scope, and
+delivering the `claim`.
 
-`begin` is the opening bookend of the session lifecycle:
-`begin` (select + prepare) → implement → `submit` (package for review) →
-review → `land` (merge and close).
+Begin is the opening bookend of the session lifecycle; `land` is the closing
+bookend.
 
-Plan from the issue graph, not from memory. Agent sessions end and context
-windows close, but the issue graph persists — it is the only working memory
-that survives across sessions.
+## Procedure
 
-For issue decomposition and boundary contracts, use `decompose`.
-For first-principles design decisions, use `reckon`.
+1. **Orient.** If the methodology map has not been loaded this session,
+   invoke the `orient` skill. This retains the methodology-loading value of
+   the prior four-phase opening — the subsequent protocols in the chain
+   operate as one connected system, not in isolation.
 
-## Procedures
+2. **Read the injected `issue` artifact.** Runa has delivered the issue
+   being worked. Read its fields — title, description, acceptance criteria,
+   dependencies. Confirm every hard dependency is closed; if any remain
+   open, the session should not have activated. Distill the issue into a
+   brief `scope` — a single statement of what is being claimed this session.
 
-### session-open
-
-#### Phase 0: Opening
-
-The opening ceremony equips the session with everything subsequent phases need:
-the methodology context that connects skills into a coherent system, awareness
-of the current workspace state, a directional frame that guides selection, and
-a clean starting surface. Each step builds on the previous — orient loads the
-methodology, observe reads the workspace, frame sets direction, banish clears
-the path.
-
-Follows the LBRP sequence: orient → observe → frame → banish.
-
-##### 0a. Orient
-
-The agent receives its operating methodology — the connected system that makes
-later skills work together rather than in isolation. `begin` opens individual
-work sessions; `orient` establishes the methodology those sessions operate
-within. If `orient` has not been loaded this session, load it now before
-proceeding.
-
-```
-◈ ORIENT
-Methodology: loaded
-```
-
-Implementation: invoke the `orient` skill via the Skill tool.
-
-##### 0b. Observe
-
-Compact workspace snapshot. This is the only status check — do not repeat these
-commands in later phases.
-
-```
-◈ STATUS
-Git: [clean/dirty] | Branch: [name] | Last: [commit-oneline]
-```
-
-Implementation: `git status --short`, `git log --oneline -1`,
-`git branch --show-current`. Report in one block.
-
-##### 0c. Frame
-
-Establish the session's purpose using the Four Touches:
-
-| Touch | Question |
-|-------|----------|
-| **Purpose** | Why does this session exist? |
-| **Success** | What does a completed increment look like? |
-| **In scope** | What boundaries contain this work? |
-| **Out of scope** | What nearby work is explicitly excluded? |
-
-Frame depth varies by what is known at invocation. When issue number(s) are
-provided, derive all four touches from the issue body — purpose from the
-summary, success from acceptance criteria, scope from the issue boundary. This
-yields a full frame. When invoked with a topic or no arguments, frame
-directionally — purpose is "advance the project," success is "one session-sized
-increment," scope sharpens after selection. A partial frame is expected; do not
-block here.
-
-```
-◈ FRAME
-Purpose: [one sentence]
-Success: [verifiable outcome]
-Scope: [in] / [out]
-```
-
-##### 0d. Banish
-
-Evaluate workspace state (observed in 0b) against the frame (established in
-0c). Clear debris so selection starts clean.
-
-- **Clean workspace** → proceed.
-- **Changes relevant to frame** → keep and note.
-- **Stale or unrelated changes** → stash or discard (confirm with user before
-  destructive action).
-
-```
-◈ BANISH
-[CLEAN | kept: reason | stashed: reason]
-```
-
-#### Phase 1: Selection
-
-Determine what to work on. Use observations from Phase 0b — do not re-run
-status checks.
-
-**If issue number(s) provided:** selection is already resolved. Fetch issue
-thread(s) via `gh issue view`, confirm they are open and unblocked, then
-proceed to Phase 2. When multiple issue numbers are given, they may be batched:
-2-3 cohesive issues can be addressed in a single session and packaged as one PR
-when they share a concern boundary.
-
-**If topic string provided:**
-
-1. List open issues: `gh issue list --state open`.
-2. Identify open issues related to the topic (title, labels, body content).
-3. Shortlist 3-5 matches, rank by relevance and impact.
-4. Select one issue (or a cohesive batch of 2-3).
-5. Proceed to Phase 2.
-
-**If no arguments:**
-
-1. List open issues: `gh issue list --state open`.
-2. Identify all ready (unblocked) candidate issues — an issue is ready when its
-   body is agent-executable and every hard dependency is closed.
-3. Apply force filters first: a direct operator request or hard deadline wins
-   immediately.
-4. Shortlist 3-5 candidates from the lowest available execution layer. Rank by
-   value, time criticality, and unblock leverage relative to effort. Be
-   decisive — selection should not consume significant session time.
-5. If candidates tie: choose the one that unblocks the most downstream work.
-6. Select one issue (or a cohesive batch of 2-3).
-
-#### Phase 2: Preparation
-
-Set up the workspace for the selected work.
-
-1. Ensure on `main` and up-to-date: `git checkout main && git pull --ff-only`.
-2. Create a feature branch:
-   - Single issue: `issue-<N>/<slug>`
-   - Issue batch: `issues-<N>-<M>-.../<slug>` (unbounded)
-   - Topic without issue: `feat/<slug>`, `fix/<slug>`, or `chore/<slug>`
-
-   Where slug is the issue title (or topic string, when no issue) — lowercase,
-   hyphenated, truncated to 40 chars.
-3. Load issue context: read issue body, comments, and linked issues to build
-   working understanding.
-
-#### Phase 3: Declaration
-
-Declare the session's direction. The frame from Phase 0c feeds directly into
-this — refine it with what you learned during selection and preparation.
-
-- **Starting direction**: what you intend to accomplish (a direction, not a
-  rigid prediction — this will sharpen as you work).
-- **Scope gate**: specific nearby work intentionally excluded this session.
-- **Issue(s) in scope**: which issue(s) this session addresses.
-
-### session-close
-
-1. Reach a stable checkpoint (done increment or explicit WIP note).
-2. Update issue state and leave a concise progress comment.
-3. Record decisions, blockers, and the exact next step.
-4. Ensure any follow-up work is represented as issue(s).
-5. Sync workspace and close.
+3. **Deliver the `claim`** through the session's MCP tool named `claim`.
+   Runa supplies `work_unit` from execution context; the agent supplies
+   `instance_id` and `scope`. The MCP server validates the payload against
+   the artifact schema and writes it to the artifact store.
 
 ## Key Terms
 
@@ -197,51 +64,31 @@ Brief definitions for self-contained use. See
 
 ## Operating Principles
 
-- **Issue tracker is the source of truth.** Planning state lives in forge
-  issues, not local task trackers or agent memory. Sessions end; the graph
-  doesn't. Issue status and comments reflect actual implementation state —
-  inaccurate state is planning debt.
-- **Direction over prediction.** Capture starting direction at session open.
-  Goals sharpen through implementation — rigid upfront done conditions are
-  premature precision. The closing handoff matters more than the opening
-  prediction.
-- **One session, one increment.** Commit to one independently verifiable
-  increment. Fewer, sharper goals beat broad, vague activity — this keeps
-  work finishable and reviewable.
-- **Dependencies are hard blockers.** Do not start work whose dependencies are
-  still open — blocked work produces partial results that complicate the graph.
-- **Every session closes with a handoff.** Either finish the increment or
-  clearly frame unfinished state. End with an honest state update and a
-  concrete, actionable next step. The next session (same or different agent)
-  should be able to pick up without guessing.
-- **Next actions are executable.** Each next action names an artifact, a command,
-  and a done condition — not a vague intention.
-- **Prioritize by impact.** Rank by value delivered, time criticality, and
-  unblock leverage (how much downstream work this frees), weighed against
-  expected effort.
+- **Direction over prediction.** Capture starting direction in the `scope`
+  field of the `claim`. Goals sharpen through implementation — rigid upfront
+  done conditions are premature precision.
+- **One session, one increment.** The claim commits to one independently
+  verifiable increment. Fewer, sharper goals beat broad, vague activity — this
+  keeps work finishable and reviewable.
+- **Dependencies are hard blockers.** If any hard dependency on the injected
+  issue is open, the session should not have activated. Blocked work produces
+  partial results that complicate the graph.
 
 ## Corruption Modes
 
-- `recency-drift`: picking last-touched work instead of highest leverage.
-- `scope-creep`: crossing concern boundaries mid-session.
-- `blocker-bypass`: beginning blocked work anyway.
-- `state-lag`: issue tracker not reflecting real implementation state.
-- `open-loop-close`: ending session without a concrete next step.
-- `skip-preparation`: jumping from selection to implementation without setting
-  up a feature branch — loses workspace isolation and makes `submit` harder.
+- `scope-creep`: the claim's `scope` field widens beyond what the issue's
+  acceptance criteria actually cover, carrying unrelated work into the
+  execution chain.
+- `blocker-bypass`: activating on an issue whose hard dependencies are still
+  open, on the reasoning that "we can sort them out mid-session."
 
 ## Cross-References
 
-- `submit`: the next lifecycle phase — commit, push, and PR creation after
-  implementation.
-- `land`: the closing bookend — closing ceremony and mechanical merge after
-  review. `begin`'s opening ceremony (orient, observe, frame, banish) prepares
-  the agent for work; `land`'s closing ceremony (gather, verify, review, seal)
-  prepares the work for delivery. Parallel structure, inverse direction.
-- `decompose`: decomposition, issue boundaries, acceptance criteria contracts.
-- `reckon`: validate assumptions before committing to an approach.
-- `specify`: behavior-first contract definition for implementation increments.
-- `orient`: the methodology map — activates the connected skill
-  system that `begin` operates within. Loaded during orient (Phase 0a).
-- Opening ceremony pattern adapted from LBRP (`aiandi-dev-environment`) —
-  internalized, no runtime dependency.
+- `specify`: the next protocol in the chain — activates on the `claim`
+  this protocol produces.
+- `decompose`: the protocol that produces the `issue` artifacts this
+  protocol activates on.
+- `land`: the closing bookend of the session lifecycle.
+- `orient`: the methodology-map skill, invoked in step 1.
+- `reckon`: first-principles constraint skill; invoke when the issue's
+  framing needs validation before a claim is delivered.

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -1,9 +1,10 @@
 ---
 name: decompose
 description: >-
-  Transfer problem understanding across context boundaries through well-formed
-  issues. Use for creating, decomposing, refining, triaging, and closing issues
-  in GitHub projects.
+  Transfer problem understanding across context boundaries. Produces `issue`
+  artifacts — well-formed work units with scope, acceptance criteria, and
+  dependencies — that `begin` can claim and downstream execution protocols
+  thread through their work-unit chain.
 requires: ["requirements"]
 accepts: ["research-record"]
 produces: ["issue"]
@@ -155,21 +156,6 @@ A well-bounded task has:
 5. Flag stale issues (no progress for 14+ days) for review. Resolution:
    resume, split, or close as wont-fix with rationale.
 
-### close-issue
-
-1. Verify all acceptance criteria against implementation.
-2. Check scope deviations — split unintended extra work into new issues.
-3. Update parent epic checklist.
-4. Close with commit/PR reference (`Closes #N`).
-
-## Triggers
-
-- creating or refining issues
-- decomposing large goals into executable work
-- triaging or prioritizing a backlog
-- closing completed work
-- planning milestones or releases
-
 ## Corruption Modes
 
 - `implicit-how`: implementation prescription leaks into scope or criteria.
@@ -214,6 +200,6 @@ A well-bounded task has:
 - `begin`: session-level prioritization and execution discipline.
 - `specify`: behavior framing and test naming discipline.
 - `plan`: design convergence before implementation.
-- `land`: merge-and-close completion events.
+- `land`: the terminal protocol that records completion and closes the loop.
 - `document`: documentation updates as acceptance criteria for user-facing
   changes.

--- a/protocols/document/PROTOCOL.md
+++ b/protocols/document/PROTOCOL.md
@@ -62,8 +62,12 @@ Fires after verification, before `submit`.
    references, or explicitly verify and trace any remaining dynamic numbers.
 6. **Apply audience test.** For each updated or created doc: "Would the
    intended reader know what to do after reading this?"
-7. **Record coverage.** In the PR or commit, state which docs were updated,
-   which were verified accurate, and which were flagged with tracking issues.
+7. **Deliver the `documentation-record`** through the session's MCP tool
+   named `documentation-record`. Runa supplies `work_unit` from execution
+   context; the agent supplies `instance_id` and the cognitive content —
+   `updated_docs`, `verified_accurate_docs`, and `tracking_issues`. The MCP
+   server validates the payload against the artifact schema and writes it to
+   the artifact store.
 
 ### evaluate-existing-docs
 

--- a/protocols/implement/PROTOCOL.md
+++ b/protocols/implement/PROTOCOL.md
@@ -1,12 +1,11 @@
 ---
 name: implement
 description: >-
-  Use when implementing any feature or bugfix, before writing implementation
-  code. Enforces test-driven development through RED-GREEN-REFACTOR with
-  delete-and-start-over discipline. Fires when implementing behavior-contract-defined
-  behaviors, fixing bugs, refactoring, or any time production code is about
-  to be written. If you are about to write implementation code, this skill
-  applies.
+  Activates on an `implementation-plan` artifact and produces the
+  `test-evidence` artifact — per-scenario RED-GREEN-REFACTOR cycle results
+  mapped to behavior-contract scenarios. The protocol's substantive work is
+  executing TDD with delete-and-start-over discipline when the cycle is
+  violated.
 metadata:
   version: "1.0.0"
   updated: "2026-03-08"
@@ -43,7 +42,7 @@ Implement fresh from tests. No exceptions.
 
 ## Lifecycle Role
 
-This skill is the execution discipline in groundwork's topology. It sits
+This protocol is the execution discipline in groundwork's topology. It sits
 between behavior identification and completion verification:
 
 1. `specify` identifies what behaviors the system needs — sentence-named scenarios
@@ -53,9 +52,9 @@ between behavior identification and completion verification:
 3. `verify` gates the completion claim with
    behavior-level evidence.
 
-This skill owns per-test cycle evidence: each test was watched failing, then
-passing. It does not own aggregate completion evidence — that belongs to
-`verify`.
+This protocol owns per-test cycle evidence: each test was watched failing,
+then passing. It does not own aggregate completion evidence — that belongs
+to `verify`.
 
 ## Discipline
 
@@ -221,7 +220,7 @@ Execute the RED-GREEN-REFACTOR cycle for a behavior identified by `specify`.
 
 Enter the RED-GREEN-REFACTOR cycle from a bug report.
 
-1. If the root cause is unclear, invoke `debug` first — it owns
+1. If the root cause is unclear, invoke the `debug` skill first — it owns
    root-cause analysis methodology.
 2. Write a failing test that reproduces the bug. The test name describes the
    corrected behavior, not the bug.
@@ -339,13 +338,13 @@ skip the `implement` discipline are slower, not faster.
 
 ## Cross-References
 
-- `specify`: identifies behaviors before this skill executes the cycle. Each
-  RED test corresponds to a named behavior scenario from `specify`.
-- `verify`: owns behavior-level completion evidence.
-  This skill owns per-test cycle evidence (watched it fail, watched it pass).
-- `debug`: owns root-cause analysis. This skill provides the
-  entry point ("write a failing test reproducing the bug") but defers
-  methodology to `debug` when root cause is unclear.
+- `specify`: identifies behaviors before this protocol executes the cycle.
+  Each RED test corresponds to a named behavior scenario from `specify`.
+- `verify`: owns behavior-level completion evidence. This protocol owns
+  per-test cycle evidence (watched it fail, watched it pass).
+- `debug`: the root-cause analysis skill. This protocol provides the entry
+  point ("write a failing test reproducing the bug") but defers methodology
+  to `debug` when root cause is unclear.
 - `document`: doc comments and type annotations are written alongside
   code during GREEN and REFACTOR phases — they are implementation work,
   not afterthought.

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -1,10 +1,12 @@
 ---
 name: land
 description: >-
-  One-word closeout: land this branch. Closing ceremony verifies completion and
-  documentation before mechanical merge. Merge to main, sync, delete feature
-  branch, close satisfied issues, comment progress on partial issues.
-  Trigger on: 'land', 'land this', 'merge and close', 'ship it'.
+  Activates on a `patch` artifact and produces the `completion-record`
+  artifact — the terminal archival record of the work unit, carrying
+  criterion coverage summary, gaps, merge reference, and documentation
+  status. The protocol's substantive work is confirming the packaged change
+  is ready to land, obtaining the merge reference via the `forge` skill,
+  and delivering the `completion-record`.
 requires: ["patch"]
 accepts: ["completion-evidence", "behavior-contract", "documentation-record", "issue"]
 produces: ["completion-record"]
@@ -13,39 +15,27 @@ trigger:
   on_artifact: "patch"
 ---
 
-# Land — Close, Verify, Merge
+# Land
 
 ## Overview
 
-Use this skill when the user wants full delivery closure in one command.
+The `land` protocol activates on a `patch` artifact and produces the
+`completion-record` artifact — the terminal archival record of the work
+unit. By the time land activates, the full execution chain has already
+delivered its artifacts: `patch`, `completion-evidence`,
+`documentation-record`, `behavior-contract`, and `issue` are all in
+injected context.
 
-`land` operates in two phases:
+Land operates in two phases:
 
-- **Phase 0: Closing** — a ceremony that prepares the work for delivery. Four
-  steps mirror `begin`'s opening ceremony in reverse: gather context, verify
+- **Phase 0: Closing** — a ceremony that prepares the work for delivery.
+  Four steps mirror `begin`'s opening in reverse: gather context, verify
   acceptance, review documentation, seal the gate.
-- **Phase 1: Mechanical** — the merge-and-close sequence, gated by Phase 0.
+- **Phase 1: Mechanical** — the forge-delegated merge and the
+  `completion-record` delivery, gated by Phase 0.
 
-Phase 0 (gather, verify, review, seal) is to `land` what Phase 0 (orient,
-observe, frame, banish) is to `begin`. The opening ceremony prepares the agent
-for work; the closing ceremony prepares the work for delivery.
-
-Do not stop after merge — stopping leaves branches dangling and issues unclosed. The full sequence is atomic: ceremony through close.
-
-Do not ask for confirmation before landing. Invoking `land` IS the user's approval to execute the entire workflow.
-
----
-
-## Preconditions
-
-- Working tree must be clean before starting.
-- Current branch must not be `main`.
-- Issue numbers are optional:
-  - Prefer explicit user-provided issue number(s).
-  - Else infer from branch name using one of:
-    - `issue-<number>/<slug>` (single issue)
-    - `issues-<number>-<number>-.../<slug>` (multi-issue, unbounded)
-  - If no issue numbers are available, continue with the no-issue closeout path.
+Phase 0 prepares the work for delivery; `begin`'s opening prepares the
+agent for work. Parallel structure, inverse direction.
 
 ---
 
@@ -53,89 +43,52 @@ Do not ask for confirmation before landing. Invoking `land` IS the user's approv
 
 ### Phase 0: Closing
 
-The closing ceremony equips the landing with everything the mechanical phase
-needs: context about what was built and why, verification that acceptance
-criteria are met, confirmation that documentation reflects reality, and a gate
-that blocks merge until readiness is confirmed. Each step builds on the
-previous — gather loads context, verify checks acceptance, review checks
-documentation, seal confirms the gate.
+The closing ceremony equips the landing with everything the mechanical
+phase needs: context about what was built, verification that acceptance
+criteria are met, confirmation that documentation reflects reality, and a
+gate that blocks the mechanical merge until readiness is confirmed.
 
 Follows the closing sequence: gather → verify → review → seal.
 
 #### 0a. Gather
 
-Collect the full context of the work being landed.
-
-```
-◈ GATHER
-Branch: [name] | Issues: [numbers or none]
-Diff: [file count] files, [insertions]+/[deletions]-
-Commits: [count] ([oneline summaries])
-CHANGELOG: [present | missing — needs entry | not needed]
-```
-
-Implementation:
-- Confirm the current branch is not `main` and the working tree is clean. Record the feature branch name.
-- Extract issue numbers from the branch name:
-  - `issue-42/fix-login` → issue 42
-  - `issues-5-8/license-cleanup` → issues 5 and 8
-  - If neither the user nor the branch name provides issue numbers, mark the landing as no-issue.
-- Summarize the branch diff: `git diff origin/main...HEAD --stat`.
-- Summarize the commit log: `git log origin/main..HEAD --oneline`.
-- Check whether `CHANGELOG.md` appears in the branch diff (`git diff origin/main...HEAD --name-only`). The changelog is how users discover what changed between versions. Evaluate whether the branch changes are significant enough to warrant an entry. New features, behavior changes, bug fixes, and breaking changes generally belong in the changelog. Internal refactoring, typo fixes, and CI tweaks generally don't. If the changes look user-visible but no entry exists, flag it to the user before proceeding.
+Read the injected `patch` to recover the packaging context —
+`pr_reference`, `branch`, `commit`. In forge-targeting contexts, the
+`forge` skill can inspect branch state, diff, and commit history when the
+ceremony needs detail beyond what the `patch` carries.
 
 #### 0b. Verify
 
-Evaluate whether the branch changes satisfy acceptance criteria and all
-verification checks pass. This step runs pre-merge while the branch diff is
-available.
+Read the injected `completion-evidence`. Classify each acceptance criterion
+as `satisfied` (all covering scenarios pass) or `partial` (gap or failing
+scenario remains). The artifact already carries criterion-level coverage;
+no re-verification is needed here — that is `verify`'s work, upstream.
 
-```
-◈ VERIFY
-Criteria: [all met | partial — list remaining]
-```
-
-Implementation: invoke the `verify` skill. For
-issue-linked branches, fetch each target issue (`gh issue view`) and evaluate
-acceptance criteria against the branch diff. Classify each issue as satisfied
-(all criteria met) or partial (some remain). If no acceptance criteria can be
-extracted from the issue body, classify as partial — an issue without explicit
-criteria may have unstated requirements. If an issue fetch fails, treat that
-issue as partial and log a warning. For no-issue landings, skip acceptance
-criteria evaluation — `verify` still runs to confirm
-the work itself is complete. Store classifications for Phase 1e.
+If `completion-evidence` shows failures or uncovered criteria, the seal
+will block the mechanical phase until the upstream evidence is corrected.
 
 #### 0c. Review
 
-Confirm documentation reflects the changes being landed. This is mandatory —
-documentation drift blocks the seal.
+Read the injected `documentation-record`. Confirm coverage is present and
+drift is either fixed or tracked — the `updated_docs`,
+`verified_accurate_docs`, and `tracking_issues` fields tell the story. If
+a user-visible change lacks a CHANGELOG entry, flag before proceeding;
+the seal blocks on this.
 
-```
-◈ REVIEW
-Docs: [clean | fixed: list | tracked: issue numbers]
-```
-
-Implementation: invoke the `document` protocol's documentation-review
-procedure via the Skill tool. Check whether changed files affect areas with documentation artifacts
-(README, ARCHITECTURE, API docs). Fix drift directly and commit;
-file tracking issues for anything deeper. Record a coverage summary: each
-artifact checked, its status, and any action taken.
+Documentation review itself is `document`'s work, upstream. This step
+reads the record, does not re-run the review.
 
 #### 0d. Seal
 
-Gate check before mechanical merge. All three conditions must hold:
+Gate check before the mechanical phase. All three conditions must hold:
 
-1. Verification passed or all issues classified (Phase 0b complete)
-2. Documentation reviewed — drift fixed or tracked (Phase 0c complete)
-3. CHANGELOG entry present if changes are user-visible (Phase 0a flagged)
+1. Verification showed no failing scenarios and no uncovered criteria.
+2. Documentation record shows drift fixed or tracked.
+3. CHANGELOG entry present if the change is user-visible.
 
-```
-◈ SEAL
-[PASSED — proceed to Phase 1 | BLOCKED — list failures]
-```
-
-If the seal fails, fix the blocking issue(s) and re-evaluate. Do not proceed to
-Phase 1 until the seal passes.
+If the seal fails, the `completion-record` cannot be delivered. Report
+the blocking condition; the upstream protocol that produced the offending
+artifact must correct it before `land` can proceed.
 
 ### Phase 1: Mechanical
 
@@ -143,119 +96,74 @@ Gated by Phase 0. Do not enter this phase until the seal passes.
 
 #### 1a. Evaluate commit history for squash
 
-Examine the branch's commit history to decide whether to squash on merge. Use `git log origin/main..HEAD` variants to inspect commit subjects and touched files.
+Examine the branch's commit history to decide whether to squash on merge.
+Apply the cognitive framework, not mechanical rules:
 
-**Decision framework** (apply judgment, not mechanical rules):
+- **Squash when** the history is iterative refinement — a feature commit
+  followed by fix-ups that revise the same change: majority of commits are
+  fixes of the initial change, commits touch the same files, all share the
+  same scope/component.
+- **Preserve when** commits represent distinct work units — single-commit
+  branches, different components/scopes, multi-step features where each
+  step is meaningful independently.
 
-- **Squash when** the history is iterative refinement — a feature commit followed by fix-ups that revise the same change: majority of commits are fixes of the initial change, commits touch the same files, all share the same scope/component.
-- **Preserve when** commits represent distinct work units — single-commit branches, different components/scopes, multi-step features where each step is meaningful independently.
+Record the squash decision. If squashing, also draft a consolidated commit
+message using the conventional-commit prefix/scope from the initial
+commit.
 
-**When squashing**, draft a consolidated commit message: use the conventional-commit prefix/scope from the initial commit, summarize the consolidated change, don't enumerate squashed commits.
+#### 1b. Obtain the merge reference
 
-Record the squash decision. If squashing, also record the drafted commit message.
+In forge-targeting contexts, invoke the `forge` skill to:
 
-#### 1b. Discover PR number
+- Look up the PR for the feature branch.
+- Execute the merge through the forge's PR API (applying the squash
+  decision from step 1a).
+- Delete the feature branch.
+- Close or comment on the related forge issues — satisfied issues close;
+  partial issues get a progress comment listing remaining criteria.
 
-Look up the open PR for the feature branch (`gh pr list --head <branch> --state open`). This must happen before merge because `gh pr merge` requires the PR number. If no PR is found, fall back to local merge (step 1c fallback).
+The skill returns `merge_reference` (merge commit SHA or PR URL) and
+owns the gh/git cognitive method. The protocol-level contract is that a
+value for `merge_reference` exists after this step; without it, the
+`completion-record` cannot be delivered.
 
-#### 1c. Merge via PR API
+#### 1c. Deliver the `completion-record`
 
-Merge through GitHub's PR API so the PR is recorded as "merged," not just "closed." This is the primary merge path.
-
-1. Run `gh pr merge <number>` with the appropriate strategy flag: `--squash` if squashing (with `--subject` and `--body` for the drafted commit message), `--merge` if preserving history.
-2. Include `--delete-branch` to let GitHub clean up the remote branch.
-3. After the API merge completes, sync local state: `git checkout main`, `git pull --ff-only origin main`.
-4. Record the merge commit SHA from the local main HEAD for use in issue comments.
-
-**Why not local merge:** A local `git merge` + `git push` lands the code on main but bypasses GitHub's PR merge tracking. GitHub sees the PR's commits already on main and auto-closes the PR as "closed" rather than "merged" when the branch is deleted. This loses PR merge metadata and breaks PR history.
-
-##### 1c fallback: local merge (no PR exists)
-
-This path is only for branches that never had a PR — not a fallback for when `gh pr merge` fails. If the API merge fails, the failure policy applies (stop, don't retry locally).
-
-If no PR was found in step 1b, merge locally:
-
-1. Fetch and fast-forward `main` to match origin (`git fetch origin --prune`, `git checkout main`, `git pull --ff-only origin main`).
-2. Merge the feature branch. If squashing: `git merge --squash`, then `git commit` with the drafted message. If preserving: `git merge --no-ff`.
-3. Push `main` to origin.
-4. Record the merge commit SHA.
-
-#### 1d. Delete feature branch
-
-Delete any remaining branch references:
-- Remote: skip if `--delete-branch` was used in step 1c. Otherwise, `git push origin --delete <branch>` (tolerate failure if already gone).
-- Local: `git branch -D <branch>`. The `-D` flag (force delete) is required because squash merges don't record merge parentage, so `-d` refuses even though the content is safely on `main`.
-- Prune stale remote-tracking references: `git fetch origin --prune`.
-
-#### 1e. Comment and close issue(s) (issue-linked branches only)
-
-If no issues were provided or inferred, skip this step.
-
-Apply the classifications from Phase 0b.
-
-**For satisfied issues**, post a close comment and close the issue:
-
-> Implemented and merged in PR #`<number>` (commit `<sha>`). Closing as complete.
->
-> *(If no PR was found, omit the PR reference.)*
-
-Then close: `gh issue close <number> --reason completed`.
-
-**For partial issues**, post a progress comment but leave the issue open:
-
-> Progress from PR #`<number>` (commit `<sha>`):
->
-> **Delivered:**
-> - criterion 1
-> - criterion 2
->
-> **Remaining:**
-> - criterion 3
-
-If any comment or close operation fails, continue processing remaining issues, then report which operations failed.
-
-#### 1f. Verify and report
-
-Confirm success conditions:
-- Current branch is `main`
-- Working tree is clean
-- Feature branch absent on origin
-- PR state is `MERGED` (not just `CLOSED`)
-- For issue-linked landings: every satisfied issue state is `CLOSED`
-- For issue-linked landings: every partial issue has a progress comment listing remaining criteria
-- Documentation coverage summary reported
-
-Report the final state including:
-- Issue disposition:
-  - Issue-linked: satisfied (closed) and partial (open with remaining criteria)
-  - No-issue: explicitly report "no issue linked"
-- Documentation coverage summary from Phase 0c
-- Any warnings or failed operations from earlier steps
+Deliver the `completion-record` artifact through the session's MCP tool
+named `completion-record`. Runa supplies `work_unit` from execution
+context; the agent supplies `instance_id` and the cognitive content —
+`criterion_summary` (how the acceptance criteria were met), `gaps`
+(known gaps or deferred work, empty if none), `merge_reference` from
+step 1b, and `documentation_status` (summary of documentation coverage).
+The MCP server validates the payload against the artifact schema and
+writes it to the artifact store.
 
 ---
 
 ## Failure Policy
 
-- **Seal failure blocks Phase 1.** If the seal (Phase 0d) fails, fix the blocking issue(s) and re-enter the ceremony from the failed step. Do not proceed to mechanical merge until the seal passes.
-- If `gh pr merge` fails: stop immediately, do not close issue. If the failure is transient (network), retry once. If structural (merge conflict, check failure), report and stop. Do not fall back to local merge — the whole point of using the API is to preserve PR merge metadata.
-- If branch deletion fails after successful merge: warn about the deletion failure and continue to issue close/comment steps. The code is safely on `main`; branch cleanup is not a prerequisite for issue closure.
-- If issue comment/close API fails for one issue: continue processing remaining issues, then report failed issue number(s) explicitly.
-- If acceptance criteria evaluation fails in Phase 0b (issue fetch error, criteria unparseable): the inline handling applies — treat the issue as partial, log a warning. Partial classification does not block the seal; it flows through to Phase 1e where the issue is left open with a progress comment.
-- **Documentation drift blocks the seal.** Drift discovered in Phase 0c must be fixed directly or tracked via issue before the seal can pass. Do not proceed with unresolved drift.
-- If no issue numbers are available: do not prompt for issue IDs during `land`; proceed with merge/sync/cleanup and report a no-issue landing.
-- If commit history evaluation is uncertain: default to preserve (`--no-ff`). Squashing is an optimization; when in doubt, keep the original history.
+- **Seal failure blocks Phase 1.** If the seal (Phase 0d) fails, the
+  blocking condition must be corrected upstream. Do not proceed to the
+  mechanical phase.
+- **No merge reference available.** If the `forge` skill cannot produce
+  `merge_reference`, the `completion-record` cannot be delivered. Stop
+  and report.
+- **Documentation drift blocks the seal.** Drift discovered in Phase 0c
+  must be fixed or tracked before the seal can pass. Unresolved drift
+  blocks delivery.
 
 ---
 
 ## Cross-References
 
-- `begin`: the opening bookend — opening ceremony and session initiation before
-  implementation. `begin`'s opening ceremony (orient, observe, frame, banish)
-  prepares the agent for work; `land`'s closing ceremony (gather, verify, review,
-  seal) prepares the work for delivery. Parallel structure, inverse direction.
-- `submit` for the preceding phase: commit, push, and PR creation
-- `verify`: invoked during Phase 0b to evaluate
-  acceptance criteria and verify completion evidence before merge
-- `document`: invoked during Phase 0c for documentation-review — confirms
-  documentation reflects the changes being landed
-- `decompose` for issue lifecycle patterns and tracking issues from doc review
+- `submit`: the preceding protocol; `patch` is the trigger artifact this
+  protocol activates on.
+- `begin`: the opening bookend of the session lifecycle.
+- `verify`: produces the `completion-evidence` this protocol reads from
+  injected context for Phase 0b.
+- `document`: produces the `documentation-record` this protocol reads
+  from injected context for Phase 0c.
+- `decompose`: produces the `issue` artifact that thread-roots every
+  work unit this protocol finalizes.
+- `forge`: the skill that owns gh/git cognitive methods — invoked from
+  Phase 1b to produce the merge reference.

--- a/protocols/plan/PROTOCOL.md
+++ b/protocols/plan/PROTOCOL.md
@@ -127,9 +127,12 @@ dangerous.
 Omit repeated repo facts and edge cases that cannot cause implementation
 mistakes.
 
-In interactive sessions, present the plan in the conversation for review.
-When producing a plan for handoff to another agent, write it to a file.
-(The topology contract will formalize artifact routing when implemented.)
+Deliver the `implementation-plan` artifact through the session's MCP tool
+named `implementation-plan`. Runa supplies `work_unit` from execution context;
+the agent supplies `instance_id` and the cognitive content — summary, design
+decisions, affected files, and the behavior mapping from scenarios to
+implementation steps. The MCP server validates the payload against the
+artifact schema and writes it to the artifact store.
 
 ## Corruption Modes
 

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -1,11 +1,10 @@
 ---
 name: submit
 description: >-
-  Package working changes into a PR: ensure feature branch, analyze and commit
-  changes, push, create PR with derived title/body linked to issue(s).
-  The middle phase of the session lifecycle between begin and land.
-  Trigger on: 'submit', 'submit pr', 'create pr', 'open pr',
-  'send for review', 'package this up'.
+  Activates on a `documentation-record` artifact and produces the `patch`
+  artifact — the packaged change ready for review. The protocol's substantive
+  work is analyzing changes, planning commit structure, and obtaining the
+  forge values (`pr_reference`, `branch`, `commit`) that the `patch` requires.
 requires: ["completion-evidence", "documentation-record"]
 accepts: []
 produces: ["patch"]
@@ -14,245 +13,123 @@ trigger:
   on_artifact: "documentation-record"
 ---
 
-# Submit — Commit, Push, PR
+# Submit
 
 ## Overview
 
-Use this skill when implementation is complete and changes need to become a PR.
+The `submit` protocol activates on a `documentation-record` artifact and
+produces the `patch` artifact — the packaged change ready for review. By the
+time submit activates, `completion-evidence` and `documentation-record` are
+both in injected context, confirming the work is verified and its
+documentation is covered.
 
-`submit` means:
-1. Resolve the working context (branch, changes, linked issues)
-2. Ensure a feature branch exists (guard rail if on `main`)
-3. Analyze changes and produce well-formed commits
-4. Push to remote
-5. Create a PR with derived title/body and issue linkage
-6. Report the result and suggest next steps
+Submit's substantive work is:
 
-The session lifecycle is: `begin` (initiate session) → implement → `submit`
-(package for review) → review → `land` (merge and close). `submit` is the
-transition from execution to review.
+1. Analyzing changes and planning commit structure (the cognitive
+   discipline).
+2. Obtaining the forge values the `patch` requires — `pr_reference`,
+   `branch`, `commit` — via the `forge` skill in forge-targeting contexts.
+3. Delivering the `patch`.
 
-Do not stop after creating the PR — the report step (step 6) is part of the
-skill. Invoking `submit` IS the operator's approval to execute the full
-sequence.
+Submit is the transition from execution to review. It comes after `document`
+and before `land`.
 
 ---
 
 ## Preconditions
 
-- Uncommitted changes OR unpushed commits on a feature branch must exist. If
-  the working tree is clean and no unpushed commits exist, there is nothing to
-  submit — report and stop.
-- If the current feature branch already has an open PR, report the PR URL and
-  stop. The PR already exists; the operator likely wants `land`, not `submit`.
-- `gh` CLI must be authenticated and the remote accessible.
+- The working tree must carry uncommitted or unpushed work. If there is
+  nothing to package, the protocol should not have activated; report and
+  stop.
+- If an open PR already exists for the current branch, report and stop —
+  the operator likely wants `land`, not `submit`.
 
 ---
 
 ## Procedure
 
-### 1. Resolve context
+### 1. Receive injected context
 
-Determine:
-- Current branch name.
-- Whether on `main` or a feature branch.
-- Whether uncommitted changes exist (`git status`).
-- Whether unpushed commits exist (`git log origin/main..HEAD` or
-  `git log main..HEAD`).
-- Issue number(s), resolved in priority order:
-  1. Explicit operator-provided issue number(s).
-  2. Branch name pattern: `issue-<N>/<slug>` (single) or
-     `issues-<N>-<M>-.../<slug>` (multi).
-  3. None — proceed without issue linkage.
+Runa has delivered `completion-evidence` and `documentation-record`. Read
+both. The criterion-level coverage and the documentation-coverage status
+together frame what the packaged change carries.
 
-If issue number(s) are available, fetch issue title(s) and body(ies) via
-`gh issue view` for use in steps 3 and 5.
+### 2. Analyze changes and plan commit structure
 
-Check for an existing open PR on the current branch
-(`gh pr list --head <branch> --state open`). If one exists, report its URL and
-stop.
+This step is the protocol's core cognitive work: understanding the change
+well enough to produce meaningful commit structure, not just staging
+everything at once.
 
-### 2. Ensure feature branch
+**2a. Understand intent.** Examine all uncommitted modifications and
+cross-reference them against the acceptance criteria carried in
+`completion-evidence`.
 
-If already on a feature branch: record the branch name and continue.
+**2b. Identify logical groups.** Find related changes that belong in the
+same atomic commit. Apply the Complete Feature Rule: implementation,
+documentation, and tests for one feature belong in one commit — never split
+docs from the code they document.
 
-If on `main` (or detached HEAD):
-1. Derive a branch name:
-   - If issue number(s) known: `issue-<N>/<slug>` (single) or
-     `issues-<N>-<M>/<slug>` (multi), where slug is the issue title —
-     lowercase, hyphenated, truncated to 40 chars.
-   - If no issue: `feat/<slug>`, `fix/<slug>`, or `chore/<slug>` based on
-     change classification, where slug summarizes the changes.
-2. Create and switch to the branch: `git checkout -b <branch>`.
-
-### 3. Analyze changes and commit
-
-This step is the skill's core analytical value: understanding changes well
-enough to produce meaningful commit structure, not just staging everything at
-once.
-
-If all changes are already committed (only unpushed commits exist), skip to
-step 4.
-
-**3a. Understand intent.** Examine all uncommitted modifications
-(`git diff`, `git diff --staged`). If issue context is available,
-cross-reference changes against acceptance criteria.
-
-**3b. Identify logical groups.** Find related changes that belong in the same
-atomic commit. Apply the Complete Feature Rule: implementation, documentation,
-and tests for one feature belong in one commit — never split docs from the code
-they document.
-
-**3c. Plan commits.** Design atomic commits, each serving a single purpose.
-Use conventional commit format: `type(scope): description` where type is
-`feat`, `fix`, `refactor`, `docs`, `test`, or `chore`. If issue number(s) are
-known, reference them in the commit body (not the title): `Refs #N`. Commit
-messages explain **why**, not just what.
-
-**3d. Execute commits.** Stage and commit each logical group using
-`git add <paths>`. When a single file contains changes for different commits,
-stage it with the dominant change set and note the grouping compromise in the
-commit message — intra-file splitting (`git add -p`) requires interactive input
-and may not be available in agent environments. Verify each commit leaves the
-working tree in a valid state.
+**2c. Plan commits.** Design atomic commits, each serving a single purpose.
+Use conventional commit format: `type(scope): description`, where type is
+`feat`, `fix`, `refactor`, `docs`, `test`, or `chore`. Reference relevant
+issues in the commit body (not the title). Commit messages explain **why**,
+not just what.
 
 If analysis produces no clear grouping (one tangled change), fall back to a
-single commit with a comprehensive message. A single honest commit is better
-than artificial splitting.
+single commit with a comprehensive message. A single honest commit is
+better than artificial splitting.
 
-### 4. Push
+### 3. Obtain forge values
 
-Push the feature branch to origin:
-- No upstream set: `git push -u origin <branch>`.
-- Upstream exists: `git push`.
+The `patch` artifact requires `pr_reference`, `branch`, and `commit`. In
+forge-targeting contexts, invoke the `forge` skill to produce the commit
+series, push the branch, and create the PR; the skill returns the three
+values and owns the gh/git cognitive method.
 
-### 5. Create PR
+### 4. Deliver the `patch`
 
-Create a pull request via `gh pr create`.
-
-**Title** (under 70 chars):
-- Single issue: use the issue title, condensed if needed. Prefix with
-  conventional commit type if not already present.
-- Multi-issue: synthesize a title capturing the combined scope.
-- No issue: derive from commit message(s).
-
-**Body:**
-
-```
-## Summary
-
-[1-3 bullet points: what this PR does and why]
-
-## Changes
-
-[Grouped description derived from commit messages]
-
-## Issue(s)
-
-Closes #N
-[or "Refs #N" for partial progress]
-
-## Test plan
-
-[How to verify — derived from acceptance criteria if available]
-```
-
-**Shell-safe transport (required):**
-- Build multiline Markdown body content in a file and pass it with
-  `--body-file <path>`.
-- Acceptable file creation patterns:
-  - direct write to a temporary file
-  - single-quoted heredoc redirected to a file (no interpolation)
-- Never pass multiline Markdown bodies inline with double quotes (for example:
-  ``gh pr create --body "...\`cmd\`..."``) because shells can evaluate
-  backticks as command substitution.
-
-Safe examples:
-
-```bash
-# Create
-cat > /tmp/pr-body.md <<'EOF'
-## Summary
-- ...
-EOF
-gh pr create --title "fix(propose): shell-safe PR body handling" --body-file /tmp/pr-body.md
-
-# Edit
-cat > /tmp/pr-body.md <<'EOF'
-## Summary
-- updated after review
-EOF
-gh pr edit <pr-number-or-url> --body-file /tmp/pr-body.md
-```
-
-**Flags:**
-- Do NOT use `--draft` by default. The operator invoked `submit` because the
-  work is ready for review. If the operator explicitly says "draft" or "submit
-  as draft," use `--draft`.
-
-### 6. Report
-
-Output:
-- PR URL.
-- Branch name.
-- Commit summary (count and brief subjects).
-- Issue linkage (which issues referenced, close vs. ref).
-- Next step: "Get review, then `land` when approved."
+Deliver the `patch` artifact through the session's MCP tool named `patch`.
+Runa supplies `work_unit` from execution context; the agent supplies
+`instance_id` and the values obtained in step 3. The MCP server validates
+the payload against the artifact schema and writes it to the artifact
+store.
 
 ---
 
 ## Failure Policy
 
-- **`gh` not authenticated or remote unreachable:** Stop immediately. This is
-  infrastructure the operator must fix.
-- **Branch creation fails** (name collision, unresolvable dirty state): Stop
-  and report. Do not force-create or silently choose an alternate name.
-- **Push rejected** (remote diverged): Stop and report. Do not force-push. Do
-  not rebase automatically. Commits are safely local; the operator decides how
-  to reconcile.
-- **Push network error:** Retry once. If still failing, report.
-- **`gh pr create` fails:**
-  - Branch already has an open PR: report the existing PR URL (not an error).
-  - Permissions error: stop and report.
-  - Other: report. The branch is pushed; the operator can retry or create
-    manually.
-- **PR body corruption from shell interpolation:** If generated content appears
-  corrupted or command output is injected, rebuild the body in a file and
-  repair using `gh pr edit --body-file <path>`. Do not retry with inline
-  double-quoted multiline `--body`.
-- **Issue fetch fails:** Continue without issue context. Derive PR title/body
-  from commits alone. Warn that issue linkage is manual.
+- **Nothing to submit:** Clean working tree with no unpushed work — the
+  protocol should not have activated; report and stop.
+- **No forge values:** If the forge skill cannot produce `pr_reference`,
+  `branch`, and `commit`, the `patch` cannot be delivered. Stop and report.
 
 ---
 
 ## Corruption Modes
 
-- `premature-submit`: invoking before verification. Recognition: tests not
-  run, WIP markers in code (TODO, FIXME, incomplete stubs). `submit` is not a
-  verification gate, but it should warn on obvious signs of incomplete work.
+- `premature-submit`: the protocol activates with incomplete work.
+  Recognition: tests not run, WIP markers in code (TODO, FIXME, incomplete
+  stubs). Submit is not a verification gate, but obvious signs of
+  incomplete work should block delivery.
 - `empty-submit`: nothing to submit. Recognition: clean tree, no unpushed
   commits. Report and stop.
 - `split-avoidance`: dumping all changes into one commit to skip analysis.
-  Recognition: single commit touching many unrelated files with a vague
-  message. The analysis phase exists to prevent this.
-- `orphan-pr`: no issue linkage when issues are clearly relevant. Recognition:
-  branch name contains an issue number but the PR body omits it. Detect issue
-  numbers from branch names automatically.
-- `title-shrug`: uninformative PR title ("Update files", "Changes"). The title
-  is the first thing reviewers see — it must communicate the change's purpose.
-- `submit-as-land`: treating the PR as the end of the workflow. `submit` is
-  the middle of the lifecycle. The report step suggests next actions explicitly.
-- `shell-interpolation-corruption`: passing Markdown via inline double-quoted
-  `--body` causes backtick command substitution or other shell interpolation.
-  Recognition: unexpected command output in PR text, shell errors from tokens in
-  the body, or missing literal Markdown. Remediation: regenerate body via file
-  and use `--body-file`; repair with `gh pr edit --body-file`.
+  Recognition: a single commit touching many unrelated files with a vague
+  message. Step 2 exists to prevent this.
+- `submit-as-land`: treating the `patch` as the end of the workflow.
+  Submit is the middle of the lifecycle — `land` produces the
+  `completion-record` that closes the chain.
 
 ---
 
-## Related Skills
+## Cross-References
 
-- `begin` for work initiation — select issue(s), prepare workspace, declare direction (the preceding phase)
-- `land` for merge, cleanup, and issue closure (the following phase)
-- `verify` — should fire before `submit`
-- `document` for documentation review before submission
+- `document`: the preceding protocol; `documentation-record` is the trigger
+  artifact this protocol activates on.
+- `land`: the next protocol; activates on the `patch` this protocol
+  produces.
+- `verify`: produces the `completion-evidence` this protocol reads from
+  injected context.
+- `begin`: the opening bookend of the session lifecycle.
+- `forge`: the skill that owns gh/git cognitive methods — invoked from
+  step 3 to produce forge values.

--- a/protocols/survey/PROTOCOL.md
+++ b/protocols/survey/PROTOCOL.md
@@ -20,9 +20,11 @@ trigger:
 
 # Survey
 
-Survey is the entry point for the autonomous groundwork pipeline. It is the one
-protocol the agent chooses to invoke for itself. The agent pulls the starter
-cord; once `requirements` exists, runa manages the downstream cascade.
+The `survey` protocol activates on a `request` artifact and produces the
+`requirements` artifact — the declaration of what needs doing for `decompose`
+to turn into issue-sized work units. The `request` artifact is the starter
+cord that sets the groundwork pipeline in motion; once `requirements` exists,
+runa carries the cascade downstream.
 
 Survey exists because "what needs doing here?" is the most dangerous judgment
 an unsupervised agent makes. This is where anchoring, pattern-matching, and
@@ -199,17 +201,14 @@ judgment about what should move forward first.
 
 ### write-requirements
 
-Write the `requirements` artifact using the required fields. The artifact is
-valid only if it preserves the inquiry that produced it. If the writing hides
-the reasoning, the survey has not been transmitted.
+Deliver the `requirements` artifact through the session's MCP tool named
+`requirements`. The agent supplies `instance_id` and the cognitive content —
+the surveyed territory, descriptive state, normative needs, chosen exigence,
+and the reasoning that produced them. The MCP server validates the payload
+against the artifact schema and writes it to the artifact store.
 
-## Invocation Pattern
-
-Survey triggers on a `request` artifact — an external input that enters the
-system as a change request, question, bug report, or feature idea. This is the
-entry point to the managed pipeline. Once `requirements` is produced, runa
-manages the downstream cascade through decompose and the execution-phase
-protocols.
+The artifact is valid only if it preserves the inquiry that produced it. If
+the writing hides the reasoning, the survey has not been transmitted.
 
 ## Corruption Modes
 

--- a/protocols/verify/PROTOCOL.md
+++ b/protocols/verify/PROTOCOL.md
@@ -1,11 +1,11 @@
 ---
 name: verify
 description: >-
-  Use when about to claim work is complete, fixed, or passing. Use before
-  committing, creating PRs, or moving to the next task. Requires running
-  verification commands and confirming output before making any success
-  claims. Evidence before assertions, always. If you are about to say
-  something is done, working, fixed, or passing, this skill applies.
+  Activates on a `test-evidence` artifact and produces the
+  `completion-evidence` artifact — the aggregate behavior-coverage status
+  that gates downstream `document` and `submit`. The protocol's substantive
+  work is verifying that each acceptance criterion is actually met by fresh
+  evidence before any completion claim is made.
 metadata:
   version: "1.0.0"
   updated: "2026-03-09"
@@ -49,11 +49,12 @@ Skip any step = the claim has no basis
 
 ## Lifecycle Role
 
-This skill owns **aggregate completion claims** — the moment before you say
-"done." It fires after execution, before packaging work for review.
+This protocol owns **aggregate completion claims** — the moment before
+saying "done." It activates after `implement`, before `document` and
+`submit` package the work for review.
 
 It does not own per-test cycle evidence (that belongs to the `implement`
-discipline — each test watched failing, then passing). It owns the final
+protocol — each test watched failing, then passing). It owns the final
 gate: all tests pass, all requirements met, the build succeeds, the work is
 actually complete.
 
@@ -165,10 +166,10 @@ the claim — the claim does not select the evidence.
 ## Cross-References
 
 - `implement` owns per-test cycle evidence (each test watched failing, then
-  passing). This skill owns aggregate completion claims.
-- `document` review fires after code changes, before this skill's gate.
-  Documentation accuracy is completion evidence.
-- `submit` consumes this skill's output — work must be verified before
+  passing). This protocol owns aggregate completion claims.
+- `document` activates on the `completion-evidence` this protocol produces
+  and reviews documentation before packaging.
+- `submit` consumes this protocol's output — work must be verified before
   packaging for review.
 
 ## The Bottom Line


### PR DESCRIPTION
## Summary

- Aligns nine `PROTOCOL.md` files with the runa-native execution model documented in `docs/architecture/connecting-structure.md` — closing the six coherence findings filed by audit #213.
- Extracts forge-side mechanics (gh CLI, git workflow, PR and forge-issue management) from protocol bodies; bodies now delegate to the `forge` skill (#228) by name.
- Converges every artifact-producing protocol on the same MCP-tool delivery vocabulary, so the protocol set reads as one coherent methodology rather than a collection of skills with drifted framing.

## Changes

**Self-framing (reframe protocols as runa-native, not harness-loaded skills).**
- `survey`: activation now starts at the `request` artifact (not self-invocation); Invocation Pattern section removed as redundant with the rewritten opening.
- `begin`: four-phase LBRP ceremony (orient/observe/frame/banish) collapsed to a 3-step procedure (orient, synthesize claim, deliver); 247 → 95 lines.
- `implement`, `verify`: self-descriptions consistently use "this protocol" rather than "this skill".
- `submit`, `land`: "Use this skill" openings replaced with protocol self-descriptions.

**Artifact delivery.** `survey` (`requirements`), `plan` (`implementation-plan`), `document` (`documentation-record`), `begin` (`claim`), `submit` (`patch`), `land` (`completion-record`) all describe output as delivery through the session's MCP tool named after the capstone type. Routing through prose, file handoff, or PR body text is removed.

**Forge extraction.** `submit` and `land` no longer embed `gh`/`git` procedure. Both delegate to the `forge` skill (#228) for `pr_reference`/`branch`/`commit` (submit) and `merge_reference` (land). The forge skill is forward-referenced by name; per #228's dependency note, "brief overlap is acceptable if this PR's prose can refer to the skill's intended existence during a small window."

**Issue-management cleanup.** `decompose`'s frontmatter description rewritten forge-neutrally. The `close-issue` procedure and Triggers section are deleted entirely — experimental methodology material, not core runa-native contract for v0.1.x. If this cognitive content returns later, it returns as a dedicated skill under a separate issue.

**Cross-reference coherence.** `land.0b` no longer says "invoke the verify skill" (verify is a protocol; it reads injected `completion-evidence`). `land.0c` no longer re-invokes `document` via the Skill tool (it reads injected `documentation-record`). Both fall under #219's third acceptance criterion.

**Scope discipline.** Only the `description` frontmatter field is edited, and only where the current wording violated an in-scope issue. Other frontmatter fields (`trigger`, `requires`, `produces`, `accepts`, `may_produce`, `metadata`) are left for #223 (the broader frontmatter audit).

**CHANGELOG.** Two new bullets under `[Unreleased] > Changed`, mirroring Phase A's substance/alignment split: one for the runa-native reframe, one for the forge extraction.

## Issue(s)

Closes #214, #215, #216, #217, #218, #219.
Refs #213 (audit), #228 (forge skill — forward-referenced).

## Test plan

- [ ] `rg "this skill" protocols/*/PROTOCOL.md` → 0 matches.
- [ ] `rg "\bgh (pr|issue|auth|repo) " protocols/*/PROTOCOL.md` → 0 matches.
- [ ] `rg "verify skill" protocols/*/PROTOCOL.md` → 0 matches.
- [ ] All six artifact-producing protocols (survey, plan, document, begin, submit, land) contain "through the session's MCP tool".
- [ ] `manifest.toml` is unchanged; no protocol's `requires`/`produces`/`trigger` is touched (scope respect for #223).
- [ ] CHANGELOG `[Unreleased] > Changed` carries two new bullets describing the set.
- [ ] `skills/forge/` does not exist in this PR (forward-referenced by name only per #228).
- [ ] End-to-end chain reads coherently: `request → survey → requirements → decompose → issue → begin → claim → specify → behavior-contract → plan → implementation-plan → implement → test-evidence → verify → completion-evidence → document → documentation-record → submit → patch → land → completion-record` — each protocol's self-description matches its manifest-declared trigger and capstone.
