### PR TITLE
chore(org-move): propagate tesserine repo references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 Study the following before working in this project:
 
 Orientation: `README.md`
-Conventions, rules, code of conduct: [commons](https://github.com/pentaxis93/commons)
+Conventions, rules, code of conduct: [commons](https://github.com/tesserine/commons)
 
 **CLAUDE.md and AGENTS.md are the same file** — CLAUDE.md is a symlink to AGENTS.md. Edit AGENTS.md. Never break the symlink.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Canonical repository references now point at the `tesserine` organization
+  across schema `$id` values, documentation links, and artifact fixtures,
+  replacing stale pre-migration repository URLs left behind by the org move.
 - Breaking vocabulary rename: artifact type `issue` becomes `work-unit`, and
   protocol `begin` becomes `take`. Consumers using the old vocabulary must
   update manifests, schema paths, protocol references, and fixture names.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Groundwork
 
-Groundwork is a methodology plugin for [runa](https://github.com/pentaxis93/runa),
+Groundwork is a methodology plugin for [runa](https://github.com/tesserine/runa),
 a cognitive runtime for AI coding agents.
 It encodes opinions about how software should be built into protocols, skills,
 and artifact schemas that a runa instance orchestrates. It is not a runtime, a
@@ -12,7 +12,7 @@ work traces from requirement to merged code, completion claims require evidence,
 and progress survives session boundaries.
 
 For what methodology plugins are and how runa executes them, see runa's
-[core concepts](https://github.com/pentaxis93/runa#core-concepts).
+[core concepts](https://github.com/tesserine/runa#core-concepts).
 
 ## The Shape of the Methodology
 
@@ -47,7 +47,7 @@ not completeness.
 → [`skills/orient/SKILL.md`](skills/orient/SKILL.md)
 
 For how runa orchestrates this topology at runtime, see the
-[interface contract](https://github.com/pentaxis93/runa/blob/main/docs/interface-contract.md).
+[interface contract](https://github.com/tesserine/runa/blob/main/docs/interface-contract.md).
 
 ## What Groundwork Believes
 
@@ -122,7 +122,7 @@ becomes a work unit.
 | [`docs/architecture/`](docs/architecture/) | Topology design rationale and work-unit state model |
 
 For how these pieces compose into a methodology plugin, see runa's
-[methodology authoring guide](https://github.com/pentaxis93/runa/blob/main/docs/methodology-authoring-guide.md).
+[methodology authoring guide](https://github.com/tesserine/runa/blob/main/docs/methodology-authoring-guide.md).
 
 ## License
 

--- a/schemas/behavior-contract.schema.json
+++ b/schemas/behavior-contract.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/behavior-contract.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/behavior-contract.schema.json",
   "title": "Behavior Contract",
   "description": "Validates the content of a behavior-contract artifact. Defines expected system behavior as Given/When/Then scenarios that trace to acceptance criteria.",
   "type": "object",

--- a/schemas/claim.schema.json
+++ b/schemas/claim.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/claim.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/claim.schema.json",
   "title": "Claim",
   "description": "Validates the content of a claim artifact. The threading root of a work unit — establishes work-unit identity for all downstream artifacts.",
   "type": "object",

--- a/schemas/completion-evidence.schema.json
+++ b/schemas/completion-evidence.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/completion-evidence.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/completion-evidence.schema.json",
   "title": "Completion Evidence",
   "description": "Validates the content of a completion-evidence artifact. Reports coverage at the acceptance-criterion level by joining work-unit criteria, behavior-contract scenarios, and test results.",
   "type": "object",

--- a/schemas/completion-record.schema.json
+++ b/schemas/completion-record.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/completion-record.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/completion-record.schema.json",
   "title": "Completion Record",
   "description": "Validates the content of a completion-record artifact. The terminal artifact — captures the final state of a work unit for archival.",
   "type": "object",

--- a/schemas/documentation-record.schema.json
+++ b/schemas/documentation-record.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/documentation-record.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/documentation-record.schema.json",
   "title": "Documentation Record",
   "description": "Validates the content of a documentation-record artifact. Records which docs were updated, which were verified accurate, and which were deferred to tracking work-units.",
   "type": "object",

--- a/schemas/implementation-plan.schema.json
+++ b/schemas/implementation-plan.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/implementation-plan.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/implementation-plan.schema.json",
   "title": "Implementation Plan",
   "description": "Validates the content of an implementation-plan artifact. Bridges behavior (from specify) to code (in implement) with design decisions and scenario-to-step mappings.",
   "type": "object",

--- a/schemas/patch.schema.json
+++ b/schemas/patch.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/patch.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/patch.schema.json",
   "title": "Patch",
   "description": "Validates the content of a patch artifact. The artifact representation of a submitted PR — where the change is and what it contains.",
   "type": "object",

--- a/schemas/request.schema.json
+++ b/schemas/request.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/request.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/request.schema.json",
   "title": "Request",
   "description": "Validates the content of a request artifact. The entry point to the system — a lightweight door that triggers survey.",
   "type": "object",

--- a/schemas/requirements.schema.json
+++ b/schemas/requirements.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/requirements.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/requirements.schema.json",
   "title": "Requirements",
   "description": "Validates the content of a requirements artifact. A software requirements specification structured to support decomposition into work units.",
   "type": "object",

--- a/schemas/research-record.schema.json
+++ b/schemas/research-record.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/research-record.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/research-record.schema.json",
   "title": "Research Record",
   "description": "Validates the content of a research-record artifact. Research scoped by topic; optionally scoped by work unit when research is specific to a work unit. Naming convention: research-record-{topic-slug}.yaml where topic-slug matches the topic field.",
   "type": "object",

--- a/schemas/test-evidence.schema.json
+++ b/schemas/test-evidence.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/test-evidence.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/test-evidence.schema.json",
   "title": "Test Evidence",
   "description": "Validates the content of a test-evidence artifact. Records test results against behavior-contract scenarios.",
   "type": "object",

--- a/schemas/work-unit.schema.json
+++ b/schemas/work-unit.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/pentaxis93/groundwork/main/schemas/work-unit.schema.json",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/work-unit.schema.json",
   "title": "Work Unit",
   "description": "Validates the content of a work-unit artifact. A work unit decomposed from requirements, with acceptance criteria that thread through the entire execution phase.",
   "type": "object",

--- a/skills/orient/SKILL.md
+++ b/skills/orient/SKILL.md
@@ -37,7 +37,7 @@ Read the work-unit graph first. Whether starting a session, picking up work, or 
 
 Why the work-unit graph matters: agent sessions are bounded — context windows end, sessions close, agents rotate. The work-unit graph is the persistence layer that survives those boundaries. It holds what remains to be done, what blocks what, and what state each piece of work is in. Working from the graph instead of from memory is what makes multi-session progress reliable.
 
-See [`work-unit-model.md`](https://github.com/pentaxis93/groundwork/blob/main/docs/architecture/work-unit-model.md) for the work-unit state model, dependency graph format, and graph maintenance rules.
+See [`work-unit-model.md`](https://github.com/tesserine/groundwork/blob/main/docs/architecture/work-unit-model.md) for the work-unit state model, dependency graph format, and graph maintenance rules.
 
 ## The Flow
 
@@ -73,7 +73,7 @@ These thread across the topology. They aren't phases — they're disciplines tha
 
 **Introduce third force on friction.** Friction is a two-force collision: task momentum vs obstacle. Routing around is the collapsed triad — both forces lose. When operational friction appears — a missing tool, broken config, stale convention, undocumented requirement — stop and introduce the reconciling move: resolve it structurally before continuing. `resolve` provides the assessment methodology and scope guidance. Friction that exceeds side-quest scope becomes a follow-up work unit via `decompose`. Unresolved friction compounds.
 
-For the connecting structure — artifacts, manifest edges, schemas, and protocol topology — see [`connecting-structure.md`](https://github.com/pentaxis93/groundwork/blob/main/docs/architecture/connecting-structure.md).
+For the connecting structure — artifacts, manifest edges, schemas, and protocol topology — see [`connecting-structure.md`](https://github.com/tesserine/groundwork/blob/main/docs/architecture/connecting-structure.md).
 
 ## Corruption Modes
 

--- a/tests/fixtures/artifacts/invalid-completion-record.json
+++ b/tests/fixtures/artifacts/invalid-completion-record.json
@@ -2,5 +2,5 @@
   "work_unit": "work-unit-178.test-fixtures",
   "criterion_summary": "All acceptance criteria met",
   "gaps": [],
-  "merge_reference": "https://github.com/pentaxis93/groundwork/pull/179"
+  "merge_reference": "https://github.com/tesserine/groundwork/pull/179"
 }

--- a/tests/fixtures/artifacts/invalid-patch.json
+++ b/tests/fixtures/artifacts/invalid-patch.json
@@ -1,5 +1,5 @@
 {
   "work_unit": "work-unit-178.test-fixtures",
-  "pr_reference": "https://github.com/pentaxis93/groundwork/pull/179",
+  "pr_reference": "https://github.com/tesserine/groundwork/pull/179",
   "branch": "work-unit-178/test-fixtures"
 }

--- a/tests/fixtures/artifacts/valid-completion-record.json
+++ b/tests/fixtures/artifacts/valid-completion-record.json
@@ -2,6 +2,6 @@
   "work_unit": "work-unit-178.test-fixtures",
   "criterion_summary": "All three acceptance criteria covered — missing-field rejection, reason-code logging, and valid-record passthrough verified by tests",
   "gaps": [],
-  "merge_reference": "https://github.com/pentaxis93/groundwork/pull/179",
+  "merge_reference": "https://github.com/tesserine/groundwork/pull/179",
   "documentation_status": "API docs updated; architecture docs verified accurate"
 }

--- a/tests/fixtures/artifacts/valid-patch.json
+++ b/tests/fixtures/artifacts/valid-patch.json
@@ -1,6 +1,6 @@
 {
   "work_unit": "work-unit-178.test-fixtures",
-  "pr_reference": "https://github.com/pentaxis93/groundwork/pull/179",
+  "pr_reference": "https://github.com/tesserine/groundwork/pull/179",
   "branch": "work-unit-178/test-fixtures",
   "commit": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
 }


### PR DESCRIPTION
## Summary

- update stale `pentaxis93` repo-owner references to canonical `tesserine` URLs across README, AGENTS, orient skill links, schema `$id` values, and fixture PR references
- preserve scope to URL owner/host segments only; leave `LICENSE` attribution unchanged because it is legal attribution, not a moved-repo reference
- restore correct canonical destinations for readers and tools that follow these links, especially schema consumers using `$id`

## Changes

- documentation links now point at `tesserine/runa`, `tesserine/commons`, and `tesserine/groundwork`
- all 12 schema `$id` values now resolve under `raw.githubusercontent.com/tesserine/groundwork/...`
- fixture `pr_reference` and `merge_reference` examples now point at `tesserine/groundwork/pull/179`

## Issue(s)

Closes #231

## Test plan

- `rg -n "pentaxis93" README.md AGENTS.md schemas skills/orient/SKILL.md tests/fixtures/artifacts`
- `rg -n "pentaxis93" -S .`
- `git diff --check`
- spot-check `https://github.com/tesserine/{groundwork,runa,commons,agentd,base}` and `https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/work-unit.schema.json`
