### PR TITLE
fix(protocols): Phase B — align with runa-managed execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Protocol bodies now describe runa-managed execution end-to-end: `survey`
+  activates on a `request` artifact rather than being self-invoked by the
+  agent; `decompose` is reframed as `work-unit` artifact production rather
+  than GitHub-issue management (the close event moves to `land`); `take`
+  consumes the injected `work-unit` and produces its `claim` capstone
+  rather than listing the forge tracker to select work; `survey`, `plan`,
+  and `document` deliver their capstones (`requirements`,
+  `implementation-plan`, `documentation-record`) via the runa MCP tool
+  surface rather than prose, files, or PR text; `submit` and `land`
+  deliver `patch` and `completion-record` via MCP and no longer hard-
+  require the `gh` CLI — forge tooling becomes conditional with graceful
+  degradation (closes #214, #215, #216, #217, #218).
+- Protocol self-description language aligned across five runa-managed
+  protocols: `take`, `implement`, `verify`, `submit`, and `land` now
+  describe themselves as protocols rather than skills, matching the
+  protocol/skill distinction runa makes operational. Legitimate skill
+  delegations (to `orient`, `reckon`, `research`, `debug`) remain framed
+  as skill invocations (closes #219).
 - Canonical repository references now point at the `tesserine` organization
   across schema `$id` values, documentation links, and artifact fixtures,
   replacing stale pre-migration repository URLs left behind by the org move.

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -2,8 +2,9 @@
 name: decompose
 description: >-
   Transfer problem understanding across context boundaries through well-formed
-  work units. Use for creating, decomposing, refining, triaging, and closing work units
-  in GitHub projects.
+  work units. Produce `work-unit` artifacts: creating, decomposing, refining,
+  and triaging. Close-state review happens here; the close itself is performed
+  by `land`.
 requires: ["requirements"]
 accepts: ["research-record"]
 produces: ["work-unit"]
@@ -67,10 +68,10 @@ implementer from treating them as optional.
 
 ### Dependencies
 
-**Explicit and hard only.** Dependencies are GitHub issue references (`#N`) that
-represent true blockers — work that literally cannot proceed without the
-dependency being complete. Preferred ordering is not a dependency. Soft
-dependencies create false bottlenecks that serialize work unnecessarily.
+**Explicit and hard only.** Dependencies name other work-units that represent
+true blockers — work that literally cannot proceed without the dependency being
+complete. Preferred ordering is not a dependency. Soft dependencies create
+false bottlenecks that serialize work unnecessarily.
 
 ### Epics and decomposition
 
@@ -103,12 +104,13 @@ the earlier discussion" to understand, it is incomplete.
 4. Define scope with concrete files or modules.
 5. Write acceptance criteria as observable outcomes — functional behavior,
    testing expectations, documentation updates where applicable.
-6. Identify dependencies by searching existing GitHub issues. Link with `#N`.
+6. Identify dependencies by searching existing work-units in the tracker.
+   Record each as a work-unit reference.
 7. Assemble using template from `references/templates.md`. Title format:
    `<type>(<scope>): <what>`.
 
 A structural linter is available at `scripts/issue_lint.py` for validating
-GitHub issue bodies against template schemas.
+work-unit bodies against template schemas.
 
 ### decompose-epic
 
@@ -160,7 +162,10 @@ A well-bounded task has:
 1. Verify all acceptance criteria against implementation.
 2. Check scope deviations — split unintended extra work into new work units.
 3. Update parent epic checklist.
-4. Close with commit/PR reference (`Closes #N`).
+
+The close event itself — marking the work-unit closed in the forge tracker —
+is performed by `land` when it produces the `completion-record`. `decompose`
+owns the pre-close review; `land` owns the seal.
 
 ## Triggers
 

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -157,7 +157,7 @@ A well-bounded task has:
 5. Flag stale work units (no progress for 14+ days) for review. Resolution:
    resume, split, or close as wont-fix with rationale.
 
-### close-work-unit
+### review-work-unit-closure
 
 1. Verify all acceptance criteria against implementation.
 2. Check scope deviations — split unintended extra work into new work units.
@@ -172,7 +172,7 @@ owns the pre-close review; `land` owns the seal.
 - creating or refining work units
 - decomposing large goals into executable work
 - triaging or prioritizing a backlog
-- closing completed work
+- reviewing work-units before closure
 - planning milestones or releases
 
 ## Corruption Modes

--- a/protocols/document/PROTOCOL.md
+++ b/protocols/document/PROTOCOL.md
@@ -62,8 +62,21 @@ Fires after verification, before `submit`.
    references, or explicitly verify and trace any remaining dynamic numbers.
 6. **Apply audience test.** For each updated or created doc: "Would the
    intended reader know what to do after reading this?"
-7. **Record coverage.** In the PR or commit, state which docs were updated,
-   which were verified accurate, and which were flagged with tracking work units.
+7. **Deliver `documentation-record`.** Invoke the `documentation-record` MCP
+   tool:
+
+   ```
+   documentation-record({
+     instance_id: "<slug>",
+     updated_docs: ["..."],
+     verified_accurate_docs: ["..."],
+     tracking_work_units: ["..."]
+   })
+   ```
+
+   Runa injects `work_unit` from session context, validates the payload
+   against the documentation-record schema, persists the artifact, and
+   records the coverage summary.
 
 ### evaluate-existing-docs
 

--- a/protocols/implement/PROTOCOL.md
+++ b/protocols/implement/PROTOCOL.md
@@ -1,12 +1,11 @@
 ---
 name: implement
 description: >-
-  Use when implementing any feature or bugfix, before writing implementation
-  code. Enforces test-driven development through RED-GREEN-REFACTOR with
-  delete-and-start-over discipline. Fires when implementing behavior-contract-defined
-  behaviors, fixing bugs, refactoring, or any time production code is about
-  to be written. If you are about to write implementation code, this skill
-  applies.
+  Protocol for executing any feature or bugfix against a behavior contract
+  and implementation plan. Enforces test-driven development through
+  RED-GREEN-REFACTOR with delete-and-start-over discipline. Fires when
+  production code is about to be written — implementing
+  behavior-contract-defined behaviors, fixing bugs, or refactoring.
 metadata:
   version: "1.0.0"
   updated: "2026-03-08"
@@ -43,7 +42,7 @@ Implement fresh from tests. No exceptions.
 
 ## Lifecycle Role
 
-This skill is the execution discipline in groundwork's topology. It sits
+This protocol is the execution discipline in groundwork's topology. It sits
 between behavior identification and completion verification:
 
 1. `specify` identifies what behaviors the system needs — sentence-named scenarios
@@ -53,9 +52,9 @@ between behavior identification and completion verification:
 3. `verify` gates the completion claim with
    behavior-level evidence.
 
-This skill owns per-test cycle evidence: each test was watched failing, then
-passing. It does not own aggregate completion evidence — that belongs to
-`verify`.
+This protocol owns per-test cycle evidence: each test was watched failing,
+then passing. It does not own aggregate completion evidence — that belongs
+to `verify`.
 
 ## Discipline
 
@@ -339,13 +338,13 @@ skip the `implement` discipline are slower, not faster.
 
 ## Cross-References
 
-- `specify`: identifies behaviors before this skill executes the cycle. Each
-  RED test corresponds to a named behavior scenario from `specify`.
-- `verify`: owns behavior-level completion evidence.
-  This skill owns per-test cycle evidence (watched it fail, watched it pass).
-- `debug`: owns root-cause analysis. This skill provides the
-  entry point ("write a failing test reproducing the bug") but defers
-  methodology to `debug` when root cause is unclear.
+- `specify`: identifies behaviors before this protocol executes the cycle.
+  Each RED test corresponds to a named behavior scenario from `specify`.
+- `verify`: owns behavior-level completion evidence. This protocol owns
+  per-test cycle evidence (watched it fail, watched it pass).
+- `debug`: the skill that owns root-cause analysis. This protocol provides
+  the entry point ("write a failing test reproducing the bug") but defers
+  methodology to the `debug` skill when root cause is unclear.
 - `document`: doc comments and type annotations are written alongside
   code during GREEN and REFACTOR phases — they are implementation work,
   not afterthought.

--- a/protocols/implement/PROTOCOL.md
+++ b/protocols/implement/PROTOCOL.md
@@ -338,13 +338,14 @@ skip the `implement` discipline are slower, not faster.
 
 ## Cross-References
 
-- `specify`: identifies behaviors before this protocol executes the cycle.
-  Each RED test corresponds to a named behavior scenario from `specify`.
-- `verify`: owns behavior-level completion evidence. This protocol owns
-  per-test cycle evidence (watched it fail, watched it pass).
-- `debug`: the skill that owns root-cause analysis. This protocol provides
-  the entry point ("write a failing test reproducing the bug") but defers
+- `specify` (protocol): identifies behaviors before this protocol executes
+  the cycle. Each RED test corresponds to a named behavior scenario from
+  `specify`.
+- `verify` (protocol): owns behavior-level completion evidence. This
+  protocol owns per-test cycle evidence (watched it fail, watched it pass).
+- `debug` (skill): owns root-cause analysis. This protocol provides the
+  entry point ("write a failing test reproducing the bug") but defers
   methodology to the `debug` skill when root cause is unclear.
-- `document`: doc comments and type annotations are written alongside
-  code during GREEN and REFACTOR phases — they are implementation work,
-  not afterthought.
+- `document` (protocol): doc comments and type annotations are written
+  alongside code during GREEN and REFACTOR phases — they are implementation
+  work, not afterthought.

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -46,6 +46,12 @@ Do not ask for confirmation before landing. Invoking `land` IS the user's approv
     - `issue-<number>/<slug>` (single GitHub issue)
     - `issues-<number>-<number>-.../<slug>` (multi-GitHub-issue, unbounded)
   - If no GitHub issue numbers are available, continue with the no-GitHub-issue closeout path.
+- Forge tooling (`gh`) is the primary path for PR lookup, PR merge,
+  acceptance-criteria evaluation against tracker state, and work-unit
+  closure. Where `gh` is unavailable, the protocol falls back to local
+  merge (step 1c fallback) and records unclosed work-units in the
+  `completion-record` for manual follow-up. The protocol does not
+  hard-fail on `gh` absence.
 
 ---
 
@@ -156,7 +162,10 @@ Record the squash decision. If squashing, also record the drafted commit message
 
 #### 1b. Discover PR number
 
-Look up the open PR for the feature branch (`gh pr list --head <branch> --state open`). This must happen before merge because `gh pr merge` requires the PR number. If no PR is found, fall back to local merge (step 1c fallback).
+Where `gh` is available, look up the open PR for the feature branch
+(`gh pr list --head <branch> --state open`). This must happen before merge
+because `gh pr merge` requires the PR number. If no PR is found — or if
+`gh` is unavailable — fall back to local merge (step 1c fallback).
 
 #### 1c. Merge via PR API
 
@@ -189,7 +198,9 @@ Delete any remaining branch references:
 
 #### 1e. Comment and close GitHub issue(s) (GitHub-issue-linked branches only)
 
-If no linked work units were provided or inferred, skip this step.
+If no linked work units were provided or inferred, skip this step. Where
+`gh` is unavailable, skip this step and record the would-have-been-closed
+work-unit IDs in the `completion-record` for manual follow-up.
 
 Apply the classifications from Phase 0b.
 
@@ -214,21 +225,46 @@ Then close: `gh issue close <number> --reason completed`.
 
 If any comment or close operation fails, continue processing remaining work units, then report which operations failed.
 
-#### 1f. Verify and report
+#### 1f. Deliver `completion-record`
+
+The capstone is delivery of the `completion-record` artifact — the terminal
+archival record for the work-unit. Invoke the `completion-record` MCP tool:
+
+```
+completion-record({
+  instance_id: "<slug>",
+  criterion_summary: "<how acceptance criteria were met>",
+  gaps: ["<known gaps or deferred work — empty array if none>"],
+  merge_reference: "<merge commit SHA or PR URL from step 1c>",
+  documentation_status: "<summary of coverage from Phase 0c>"
+})
+```
+
+Runa injects `work_unit` from session context, validates the payload
+against the completion-record schema, persists the artifact, and records
+it in the artifact store.
+
+If work-units could not be closed in the tracker (e.g., `gh` unavailable
+in step 1e), include those IDs and the reason in `gaps` so the manual
+follow-up is discoverable from the archival record.
+
+#### 1g. Verify and report
 
 Confirm success conditions:
 - Current branch is `main`
 - Working tree is clean
 - Feature branch absent on origin
 - PR state is `MERGED` (not just `CLOSED`)
-- For GitHub-issue-linked landings: every satisfied GitHub issue state is `CLOSED`
+- For GitHub-issue-linked landings: every satisfied GitHub issue state is `CLOSED` (or recorded in `gaps` if `gh` was unavailable)
 - For GitHub-issue-linked landings: every partial GitHub issue has a progress comment listing remaining criteria
+- `completion-record` artifact delivered
 - Documentation coverage summary reported
 
 Report the final state including:
 - GitHub issue disposition:
   - GitHub-issue-linked: satisfied (closed) and partial (open with remaining criteria)
   - No-GitHub-issue: explicitly report "no GitHub issue linked"
+- `completion-record` instance_id
 - Documentation coverage summary from Phase 0c
 - Any warnings or failed operations from earlier steps
 

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -17,7 +17,10 @@ trigger:
 
 ## Overview
 
-Use this skill when the user wants full delivery closure in one command.
+Protocol for closing the session lifecycle: verify the work satisfies its
+contract, review documentation coverage, merge the branch, close the
+satisfied work-units, and deliver the `completion-record` that seals the
+archival trail.
 
 `land` operates in two phases:
 
@@ -101,15 +104,19 @@ available.
 Criteria: [all met | partial — list remaining]
 ```
 
-Implementation: invoke the `verify` skill. For
-GitHub-issue-linked branches, fetch each target GitHub issue (`gh issue view`) and evaluate
-acceptance criteria against the branch diff. Classify each GitHub issue as satisfied
-(all criteria met) or partial (some remain). If no acceptance criteria can be
-extracted from the GitHub issue body, classify as partial — a GitHub issue without explicit
-criteria may have unstated requirements. If a GitHub issue fetch fails, treat that
-GitHub issue as partial and log a warning. For no-GitHub-issue landings, skip acceptance
-criteria evaluation — `verify` still runs to confirm
-the work itself is complete. Store classifications for Phase 1e.
+Implementation: the `verify` protocol has already run upstream — its
+`completion-evidence` artifact is available through runa's session context.
+Re-check acceptance-criteria coverage against the current branch diff as a
+final seal, using the upstream `completion-evidence` as the baseline. Where
+`gh` is available and the branch is GitHub-issue-linked, fetch each target
+issue (`gh issue view`) and evaluate acceptance criteria against the diff.
+Classify each work-unit as satisfied (all criteria met) or partial (some
+remain). If no acceptance criteria can be extracted from the work-unit body,
+classify as partial — a work-unit without explicit criteria may have
+unstated requirements. If an issue fetch fails, treat that work-unit as
+partial and log a warning. For no-GitHub-issue landings, skip the
+tracker-evaluation branch and rely on the upstream `completion-evidence`.
+Store classifications for Phase 1e.
 
 #### 0c. Review
 
@@ -121,11 +128,13 @@ documentation drift blocks the seal.
 Docs: [clean | fixed: list | tracked: work-unit refs]
 ```
 
-Implementation: invoke the `document` protocol's documentation-review
-procedure via the Skill tool. Check whether changed files affect areas with documentation artifacts
-(README, ARCHITECTURE, API docs). Fix drift directly and commit;
-file tracking work units for anything deeper. Record a coverage summary: each
-artifact checked, its status, and any action taken.
+Implementation: perform the documentation-review discipline that the
+`document` protocol encodes against the current branch diff, confirming
+coverage has not drifted since `document` ran. Check whether changed files
+affect areas with documentation artifacts (README, ARCHITECTURE, API
+docs). Fix drift directly and commit; file tracking work-units for
+anything deeper. Record a coverage summary: each artifact checked, its
+status, and any action taken.
 
 #### 0d. Seal
 

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -106,10 +106,13 @@ Criteria: [all met | partial — list remaining]
 
 Implementation: the `verify` protocol has already run upstream — its
 `completion-evidence` artifact is available through runa's session context.
-Re-check acceptance-criteria coverage against the current branch diff as a
-final seal, using the upstream `completion-evidence` as the baseline. Where
-`gh` is available and the branch is GitHub-issue-linked, fetch each target
-issue (`gh issue view`) and evaluate acceptance criteria against the diff.
+Phase 0b is a seal spot-check, not re-invocation of `verify`: confirm that
+acceptance-criteria coverage against the current branch diff still matches
+the upstream `completion-evidence` baseline, and stop there. If drift is
+detected, the seal fails and `land` halts (per the Failure Policy); running
+`verify` again is an upstream repair, not part of this phase. Where `gh` is
+available and the branch is GitHub-issue-linked, fetch each target issue
+(`gh issue view`) to cross-reference acceptance criteria against the diff.
 Classify each work-unit as satisfied (all criteria met) or partial (some
 remain). If no acceptance criteria can be extracted from the work-unit body,
 classify as partial — a work-unit without explicit criteria may have
@@ -281,7 +284,7 @@ Report the final state including:
 
 ## Failure Policy
 
-- **Seal failure blocks Phase 1.** If the seal (Phase 0d) fails, fix the blocking GitHub issue(s) and re-enter the ceremony from the failed step. Do not proceed to mechanical merge until the seal passes.
+- **Seal failure blocks Phase 1.** If the seal (Phase 0d) fails, the operator resolves the blocking condition (GitHub issue, documentation drift, upstream verify drift, etc.) and directs runa to re-activate `land`; runa resumes the ceremony at the failed step. Do not proceed to mechanical merge until the seal passes.
 - If `gh pr merge` fails: stop immediately, do not close the GitHub issue. If the failure is transient (network), retry once. If structural (merge conflict, check failure), report and stop. Do not fall back to local merge — the whole point of using the API is to preserve PR merge metadata.
 - If branch deletion fails after successful merge: warn about the deletion failure and continue to GitHub issue close/comment steps. The code is safely on `main`; branch cleanup is not a prerequisite for issue closure.
 - If GitHub issue comment/close API fails for one GitHub issue: continue processing remaining GitHub issues, then report failed GitHub issue number(s) explicitly.

--- a/protocols/plan/PROTOCOL.md
+++ b/protocols/plan/PROTOCOL.md
@@ -127,9 +127,24 @@ dangerous.
 Omit repeated repo facts and edge cases that cannot cause implementation
 mistakes.
 
-In interactive sessions, present the plan in the conversation for review.
-When producing a plan for handoff to another agent, write it to a file.
-(The topology contract will formalize artifact routing when implemented.)
+### deliver-plan
+
+Deliver the `implementation-plan` artifact by invoking the
+`implementation-plan` MCP tool:
+
+```
+implementation-plan({
+  instance_id: "<slug>",
+  summary: "<what the plan accomplishes>",
+  design_decisions: [{decision: "...", rationale: "..."}, ...],
+  affected_files: ["..."],
+  behavior_mapping: [{scenario: "...", steps: ["..."]}, ...]
+})
+```
+
+Runa injects `work_unit` from session context, validates the payload
+against the implementation-plan schema, persists the artifact, and records
+it in the artifact store.
 
 ## Corruption Modes
 

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -18,7 +18,9 @@ trigger:
 
 ## Overview
 
-Use this skill when implementation is complete and changes need to become a PR.
+Protocol for packaging verified, documented changes into a PR and delivering
+the `patch` artifact. Fires when implementation is complete and reviewed
+changes need to cross into the review stage.
 
 `submit` means:
 1. Resolve the working context (branch, changes, linked issues)
@@ -91,9 +93,9 @@ If on `main` (or detached HEAD):
 
 ### 3. Analyze changes and commit
 
-This step is the skill's core analytical value: understanding changes well
-enough to produce meaningful commit structure, not just staging everything at
-once.
+This step is the protocol's core analytical value: understanding changes
+well enough to produce meaningful commit structure, not just staging
+everything at once.
 
 If all changes are already committed (only unpushed commits exist), skip to
 step 4.
@@ -279,9 +281,13 @@ Output:
 
 ---
 
-## Related Skills
+## Cross-References
 
-- `take` for work initiation — select work unit(s), prepare workspace, declare direction (the preceding phase)
-- `land` for merge, cleanup, and GitHub issue closure (the following phase)
-- `verify` — should fire before `submit`
-- `document` for documentation review before submission
+- `take`: the opening bookend of the session lifecycle — consumes the
+  selected work-unit, prepares the workspace, and produces the `claim`.
+- `land`: the closing bookend — closing ceremony, merge, and work-unit
+  closure after review.
+- `verify`: runs before `submit`; its `completion-evidence` output is
+  a required input (per `manifest.toml`).
+- `document`: runs between `verify` and `submit`; its
+  `documentation-record` output is a required input.

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -26,15 +26,16 @@ Use this skill when implementation is complete and changes need to become a PR.
 3. Analyze changes and produce well-formed commits
 4. Push to remote
 5. Create a PR with derived title/body and GitHub issue linkage
-6. Report the result and suggest next steps
+6. Deliver the `patch` artifact via the MCP tool
+7. Report the result and suggest next steps
 
 The session lifecycle is: `take` (initiate session) → implement → `submit`
 (package for review) → review → `land` (merge and close). `submit` is the
 transition from execution to review.
 
-Do not stop after creating the PR — the report step (step 6) is part of the
-skill. Invoking `submit` IS the operator's approval to execute the full
-sequence.
+Do not stop after creating the PR — the delivery and report steps (6 and 7)
+are part of the protocol. Invoking `submit` IS the operator's approval to
+execute the full sequence.
 
 ---
 
@@ -45,7 +46,10 @@ sequence.
   submit — report and stop.
 - If the current feature branch already has an open PR, report the PR URL and
   stop. The PR already exists; the operator likely wants `land`, not `submit`.
-- `gh` CLI must be authenticated and the remote accessible.
+- Producing the `patch` capstone requires a real PR reference, which in turn
+  requires forge tooling (`gh` authenticated against the remote). Where forge
+  tooling is absent, the protocol can commit and push locally but cannot
+  deliver the `patch` artifact — see step 5 for the failure path.
 
 ---
 
@@ -65,12 +69,12 @@ Determine:
      `issues-<N>-<M>-.../<slug>` (multi).
   3. None — proceed without GitHub issue linkage.
 
-If GitHub issue number(s) are available, fetch GitHub issue title(s) and body(ies) via
-`gh issue view` for use in steps 3 and 5.
+If GitHub issue number(s) are available and `gh` is installed, fetch issue
+title(s) and body(ies) via `gh issue view` for use in steps 3 and 5.
 
-Check for an existing open PR on the current branch
-(`gh pr list --head <branch> --state open`). If one exists, report its URL and
-stop.
+Where `gh` is available, check for an existing open PR on the current branch
+(`gh pr list --head <branch> --state open`). If one exists, report its URL
+and stop.
 
 ### 2. Ensure feature branch
 
@@ -128,7 +132,11 @@ Push the feature branch to origin:
 
 ### 5. Create PR
 
-Create a pull request via `gh pr create`.
+The `patch` capstone requires a real PR reference. Where `gh` is available
+and authenticated against the remote, create the PR via `gh pr create`.
+Where forge tooling is absent, the protocol cannot complete — report what
+was committed and pushed locally, note that no `patch` artifact was
+delivered, and stop. Do not synthesize a PR reference.
 
 **Title** (under 70 chars):
 - Single GitHub issue: use the issue title, condensed if needed. Prefix with
@@ -190,21 +198,42 @@ gh pr edit <pr-number-or-url> --body-file /tmp/pr-body.md
   work is ready for review. If the operator explicitly says "draft" or "submit
   as draft," use `--draft`.
 
-### 6. Report
+### 6. Deliver `patch`
+
+The capstone is delivery of the `patch` artifact via the `patch` MCP tool:
+
+```
+patch({
+  instance_id: "<slug>",
+  pr_reference: "<PR URL from step 5>",
+  branch: "<feature branch name>",
+  commit: "<head commit SHA at submission>"
+})
+```
+
+Runa injects `work_unit` from session context, validates the payload
+against the patch schema, persists the artifact, and records it in the
+artifact store.
+
+### 7. Report
 
 Output:
 - PR URL.
 - Branch name.
 - Commit summary (count and brief subjects).
 - GitHub issue linkage (which GitHub issues are referenced, close vs. ref).
+- `patch` artifact instance_id.
 - Next step: "Get review, then `land` when approved."
 
 ---
 
 ## Failure Policy
 
-- **`gh` not authenticated or remote unreachable:** Stop immediately. This is
-  infrastructure the operator must fix.
+- **Forge tooling (`gh`) unavailable or remote unreachable:** The protocol
+  cannot produce a PR reference and therefore cannot deliver the `patch`
+  capstone. Report what was committed and pushed locally, note the missing
+  forge action, and stop. Do not synthesize a `patch` artifact without a
+  real `pr_reference`.
 - **Branch creation fails** (name collision, unresolvable dirty state): Stop
   and report. Do not force-create or silently choose an alternate name.
 - **Push rejected** (remote diverged): Stop and report. Do not force-push. Do

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -231,11 +231,12 @@ Output:
 
 ## Failure Policy
 
-- **Forge tooling (`gh`) unavailable or remote unreachable:** The protocol
-  cannot produce a PR reference and therefore cannot deliver the `patch`
-  capstone. Report what was committed and pushed locally, note the missing
-  forge action, and stop. Do not synthesize a `patch` artifact without a
-  real `pr_reference`.
+- **Forge tooling (`gh`) unavailable or unauthenticated:** The protocol can
+  still commit and push (steps 1–4) but cannot create a PR and therefore
+  cannot deliver the `patch` capstone. Report what was committed and pushed,
+  note the missing forge action, and stop. Do not synthesize a `patch`
+  artifact without a real `pr_reference`. Remote-side failures are covered
+  by the push bullets below.
 - **Branch creation fails** (name collision, unresolvable dirty state): Stop
   and report. Do not force-create or silently choose an alternate name.
 - **Push rejected** (remote diverged): Stop and report. Do not force-push. Do

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -245,8 +245,9 @@ Output:
 - **`gh pr create` fails:**
   - Branch already has an open PR: report the existing PR URL (not an error).
   - Permissions error: stop and report.
-  - Other: report. The branch is pushed; the operator can retry or create
-    manually.
+  - Other: report and stop. The branch is pushed; the operator resolves
+    the cause and directs runa to re-activate `submit`. Manual forge
+    intervention is outside the protocol surface.
 - **PR body corruption from shell interpolation:** If generated content appears
   corrupted or command output is injected, rebuild the body in a file and
   repair using `gh pr edit --body-file <path>`. Do not retry with inline

--- a/protocols/survey/PROTOCOL.md
+++ b/protocols/survey/PROTOCOL.md
@@ -20,9 +20,11 @@ trigger:
 
 # Survey
 
-Survey is the entry point for the autonomous groundwork pipeline. It is the one
-protocol the agent chooses to invoke for itself. The agent pulls the starter
-cord; once `requirements` exists, runa manages the downstream cascade.
+Survey is the entry point to the groundwork pipeline. Runa activates the
+protocol when a `request` artifact enters the system — an external change
+request, question, bug report, or feature idea. Request intake is external;
+once survey produces `requirements`, runa manages the downstream cascade
+through decompose and the execution-phase protocols.
 
 Survey exists because "what needs doing here?" is the most dangerous judgment
 an unsupervised agent makes. This is where anchoring, pattern-matching, and

--- a/protocols/survey/PROTOCOL.md
+++ b/protocols/survey/PROTOCOL.md
@@ -199,11 +199,30 @@ priority. State why it wins now and what remains outside the boundary.
 The output here is not "a list of interesting problems." It is a bounded
 judgment about what should move forward first.
 
-### write-requirements
+### deliver-requirements
 
-Write the `requirements` artifact using the required fields. The artifact is
-valid only if it preserves the inquiry that produced it. If the writing hides
-the reasoning, the survey has not been transmitted.
+Deliver the `requirements` artifact by invoking the `requirements` MCP tool:
+
+```
+requirements({
+  instance_id: "<slug>",
+  scope: "<purpose and boundaries — from § Requirements Structure>",
+  functional_requirements: ["..."],
+  non_functional_requirements: ["..."],
+  constraints: ["..."],
+  assumptions: ["..."],
+  dependencies: ["..."]
+})
+```
+
+Runa validates the payload against the requirements schema, persists the
+artifact under the given `instance_id`, and records it in the artifact store.
+
+Delivery is successful when the tool returns without error; the survey is
+transmitted when the payload preserves the inquiry that produced it. Schema
+validity is not substance validity — if the content hides the reasoning
+behind the choices, the survey has not been transmitted even when the call
+succeeds.
 
 ## Invocation Pattern
 

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -138,8 +138,8 @@ Set up the repository-local workspace for the selected work.
      `chore/<slug>`
 
    The work-unit artifact itself is always present — runa injects it
-   regardless. What varies across these three patterns is whether the
-   work-unit carries a forge tracker identifier. Where slug is the
+   regardless. What varies is tracker linkage and — when linked — whether
+   a single work-unit or a cohesive batch is in scope. Where slug is the
    work-unit title — lowercase, hyphenated, truncated to 40 chars. The
    `issue-` prefix on linked branch names is a repository-local naming
    convention; the `<N>` encodes the work-unit's tracker identifier.

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -16,8 +16,9 @@ trigger:
 
 ## Overview
 
-Use this skill to start a work session: choose what to work on, prepare the
-workspace, and declare the session's direction.
+Protocol for opening a work session: consume the selected work-unit,
+prepare the repository-local workspace, and produce a `claim` that threads
+all downstream artifacts.
 
 `take` is the opening bookend of the session lifecycle:
 `take` (select + prepare) → implement → `submit` (package for review) →
@@ -36,22 +37,22 @@ For first-principles design decisions, use `reckon`.
 
 #### Phase 0: Opening
 
-The opening ceremony equips the session with everything subsequent phases need:
-the methodology context that connects skills into a coherent system, awareness
-of the current workspace state, a directional frame that guides selection, and
-a clean starting surface. Each step builds on the previous — orient loads the
-methodology, observe reads the workspace, frame sets direction, banish clears
-the path.
+The opening ceremony equips the session with everything subsequent phases
+need: the methodology context that connects the protocol-and-skill system
+into a coherent whole, awareness of the current workspace state, a
+directional frame that guides the session, and a clean starting surface.
+Each step builds on the previous — orient loads the methodology, observe
+reads the workspace, frame sets direction, banish clears the path.
 
 Follows the LBRP sequence: orient → observe → frame → banish.
 
 ##### 0a. Orient
 
-The agent receives its operating methodology — the connected system that makes
-later skills work together rather than in isolation. `take` opens individual
-work sessions; `orient` establishes the methodology those sessions operate
-within. If `orient` has not been loaded this session, load it now before
-proceeding.
+The agent receives its operating methodology — the connected system that
+makes later protocols and skills work together rather than in isolation.
+`take` opens individual work sessions; `orient` establishes the methodology
+those sessions operate within. If `orient` has not been loaded this
+session, load it now before proceeding.
 
 ```
 ◈ ORIENT
@@ -237,7 +238,8 @@ Brief definitions for self-contained use. See
 - `decompose`: decomposition, work-unit boundaries, acceptance criteria contracts.
 - `reckon`: validate assumptions before committing to an approach.
 - `specify`: behavior-first contract definition for implementation increments.
-- `orient`: the methodology map — activates the connected skill
-  system that `take` operates within. Loaded during orient (Phase 0a).
+- `orient`: the methodology map — activates the connected system of
+  protocols and skills that `take` operates within. Loaded during
+  orient (Phase 0a).
 - Opening ceremony pattern adapted from LBRP (`aiandi-dev-environment`) —
   internalized, no runtime dependency.

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -114,9 +114,11 @@ Evaluate workspace state (observed in 0b) against the frame (established in
 
 #### Phase 1: Consume work-unit
 
-Selection happened upstream — by operator direction when the session is
-human-initiated, or by `decompose` producing the `work-unit` artifact that
-runa then activates `take` on. The protocol does not select work.
+Selection happened upstream — either by operator direction (the operator
+names the work-unit and directs runa to activate `take` on it) or by
+`decompose` producing the `work-unit` artifact that runa activates `take`
+on. Runa is always the activator; the protocol does not select work and is
+never invoked CLI-direct.
 
 Read the injected work-unit artifact to load the context that Phase 2
 preparation and Phase 3 capstone will build on. When the upstream scope
@@ -132,15 +134,19 @@ Set up the repository-local workspace for the selected work.
 2. Create a feature branch:
    - Single work-unit: `issue-<N>/<slug>`
    - Work-unit batch: `issues-<N>-<M>-.../<slug>` (unbounded)
-   - No linked work-unit (bare invocation): `feat/<slug>`, `fix/<slug>`, or
+   - Work-unit without tracker linkage: `feat/<slug>`, `fix/<slug>`, or
      `chore/<slug>`
 
-   Where slug is the work-unit title — lowercase, hyphenated, truncated to
-   40 chars. The `issue-` prefix on linked branch names is a repository-local
-   naming convention; the `<N>` encodes the work-unit's tracker identifier.
-3. Resolve referenced work-units. Runa injects the active work-unit; when it
-   references other work-units as dependencies or context, read those via
-   the tracker surface (or runa's context, where available).
+   The work-unit artifact itself is always present — runa injects it
+   regardless. What varies across these three patterns is whether the
+   work-unit carries a forge tracker identifier. Where slug is the
+   work-unit title — lowercase, hyphenated, truncated to 40 chars. The
+   `issue-` prefix on linked branch names is a repository-local naming
+   convention; the `<N>` encodes the work-unit's tracker identifier.
+3. Resolve referenced work-units. Runa injects the active work-unit; when
+   it references other work-units as dependencies or context, prefer runa's
+   injected context. Where runa does not carry a referenced work-unit, fall
+   back to the tracker surface (`gh issue view`) if available.
 
 #### Phase 3: Claim — produce the session capstone
 

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -131,18 +131,16 @@ batch and package them as one PR at `submit`.
 Set up the repository-local workspace for the selected work.
 
 1. Ensure on `main` and up-to-date: `git checkout main && git pull --ff-only`.
-2. Create a feature branch:
-   - Single work-unit: `issue-<N>/<slug>`
-   - Work-unit batch: `issues-<N>-<M>-.../<slug>` (unbounded)
-   - Work-unit without tracker linkage: `feat/<slug>`, `fix/<slug>`, or
-     `chore/<slug>`
+2. Create a feature branch. The work-unit artifact is always present; what
+   varies is tracker linkage and, when linked, whether scope is single or
+   batched:
+   - Linked, single work-unit: `issue-<N>/<slug>`
+   - Linked, cohesive batch: `issues-<N>-<M>-.../<slug>` (unbounded)
+   - No tracker linkage: `feat/<slug>`, `fix/<slug>`, or `chore/<slug>`
 
-   The work-unit artifact itself is always present — runa injects it
-   regardless. What varies is tracker linkage and — when linked — whether
-   a single work-unit or a cohesive batch is in scope. The slug is the
-   work-unit title — lowercase, hyphenated, truncated to 40 chars. The
-   `issue-` prefix on linked branch names is a repository-local naming
-   convention; the `<N>` encodes the work-unit's tracker identifier.
+   Slug is the work-unit title — lowercase, hyphenated, truncated to 40
+   chars. The `issue-` prefix on linked branch names is a repository-local
+   naming convention; `<N>` encodes the work-unit's tracker identifier.
 3. Resolve referenced work-units. Runa injects the active work-unit; when
    it references other work-units as dependencies or context, prefer runa's
    injected context. Where runa does not carry a referenced work-unit, fall

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -139,7 +139,7 @@ Set up the repository-local workspace for the selected work.
 
    The work-unit artifact itself is always present — runa injects it
    regardless. What varies is tracker linkage and — when linked — whether
-   a single work-unit or a cohesive batch is in scope. Where slug is the
+   a single work-unit or a cohesive batch is in scope. The slug is the
    work-unit title — lowercase, hyphenated, truncated to 40 chars. The
    `issue-` prefix on linked branch names is a repository-local naming
    convention; the `<N>` encodes the work-unit's tracker identifier.

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -84,13 +84,10 @@ Establish the session's purpose using the Four Touches:
 | **In scope** | What boundaries contain this work? |
 | **Out of scope** | What nearby work is explicitly excluded? |
 
-Frame depth varies by what is known at invocation. When GitHub issue number(s) are
-provided, derive all four touches from the GitHub issue body — purpose from the
-summary, success from acceptance criteria, scope from the work-unit boundary. This
-yields a full frame. When invoked with a topic or no arguments, frame
-directionally — purpose is "advance the project," success is "one session-sized
-increment," scope sharpens after selection. A partial frame is expected; do not
-block here.
+The work-unit artifact is always present — runa activates the protocol on the
+selected work-unit. Derive all four touches from the work-unit body: purpose
+from the summary, success from acceptance criteria, scope from the work-unit
+boundary, out-of-scope from the work-unit's explicit exclusions.
 
 ```
 ◈ FRAME
@@ -114,62 +111,61 @@ Evaluate workspace state (observed in 0b) against the frame (established in
 [CLEAN | kept: reason | stashed: reason]
 ```
 
-#### Phase 1: Selection
+#### Phase 1: Consume work-unit
 
-Determine what to work on. Use observations from Phase 0b — do not re-run
-status checks.
+Selection happened upstream — by operator direction when the session is
+human-initiated, or by `decompose` producing the `work-unit` artifact that
+runa then activates `take` on. The protocol does not select work.
 
-**If GitHub issue number(s) provided:** selection is already resolved. Fetch GitHub issue
-thread(s) via `gh issue view`, confirm they are open and unblocked, then
-proceed to Phase 2. When multiple GitHub issue numbers are given, they may be batched:
-2-3 cohesive work units can be addressed in a single session and packaged as one PR
-when they share a concern boundary.
-
-**If topic string provided:**
-
-1. List open GitHub issues: `gh issue list --state open`.
-2. Identify open GitHub issues related to the topic (title, labels, body content).
-3. Shortlist 3-5 matches, rank by relevance and impact.
-4. Select one work unit (or a cohesive batch of 2-3).
-5. Proceed to Phase 2.
-
-**If no arguments:**
-
-1. List open GitHub issues: `gh issue list --state open`.
-2. Identify all ready (unblocked) candidate work units — a work unit is ready when its
-   GitHub issue body is agent-executable and every hard dependency is closed.
-3. Apply force filters first: a direct operator request or hard deadline wins
-   immediately.
-4. Shortlist 3-5 candidates from the lowest available execution layer. Rank by
-   value, time criticality, and unblock leverage relative to effort. Be
-   decisive — selection should not consume significant session time.
-5. If candidates tie: choose the one that unblocks the most downstream work.
-6. Select one work unit (or a cohesive batch of 2-3).
+Read the injected work-unit artifact to load the context that Phase 2
+preparation and Phase 3 capstone will build on. When the upstream scope
+legitimately spans 2–3 cohesive work-units that share a concern boundary,
+runa activates `take` on each in turn; the session may address them as a
+batch and package them as one PR at `submit`.
 
 #### Phase 2: Preparation
 
-Set up the workspace for the selected work.
+Set up the repository-local workspace for the selected work.
 
 1. Ensure on `main` and up-to-date: `git checkout main && git pull --ff-only`.
 2. Create a feature branch:
-   - Single GitHub issue: `issue-<N>/<slug>`
-   - GitHub issue batch: `issues-<N>-<M>-.../<slug>` (unbounded)
-   - Topic without a linked GitHub issue: `feat/<slug>`, `fix/<slug>`, or `chore/<slug>`
+   - Single work-unit: `issue-<N>/<slug>`
+   - Work-unit batch: `issues-<N>-<M>-.../<slug>` (unbounded)
+   - No linked work-unit (bare invocation): `feat/<slug>`, `fix/<slug>`, or
+     `chore/<slug>`
 
-   Where slug is the GitHub issue title (or topic string, when no linked GitHub issue) — lowercase,
-   hyphenated, truncated to 40 chars.
-3. Load work-unit context: read the GitHub issue body, comments, and linked GitHub issues to build
-   working understanding.
+   Where slug is the work-unit title — lowercase, hyphenated, truncated to
+   40 chars. The `issue-` prefix on linked branch names is a repository-local
+   naming convention; the `<N>` encodes the work-unit's tracker identifier.
+3. Resolve referenced work-units. Runa injects the active work-unit; when it
+   references other work-units as dependencies or context, read those via
+   the tracker surface (or runa's context, where available).
 
-#### Phase 3: Declaration
+#### Phase 3: Claim — produce the session capstone
 
-Declare the session's direction. The frame from Phase 0c feeds directly into
-this — refine it with what you learned during selection and preparation.
+The capstone is delivery of the `claim` artifact. `claim` threads every
+downstream artifact (behavior-contract, implementation-plan, test-evidence,
+completion-evidence, documentation-record, patch, completion-record) to
+the active work-unit.
 
-- **Starting direction**: what you intend to accomplish (a direction, not a
-  rigid prediction — this will sharpen as you work).
-- **Scope gate**: specific nearby work intentionally excluded this session.
-- **Work unit(s) in scope**: which work unit(s) this session addresses.
+Invoke the `claim` MCP tool. Runa injects `work_unit` from session context;
+the agent supplies `instance_id` and `scope`:
+
+```
+claim({
+  instance_id: "<slug-naming-this-claim>",
+  scope: "<what is being claimed from the work-unit in this session>"
+})
+```
+
+The `scope` field captures the session's starting direction — what the
+agent intends to accomplish from this work-unit. It is a direction, not a
+rigid prediction; implementation will sharpen it. Name nearby work
+intentionally excluded inline in the scope statement.
+
+Runa validates the payload against the `claim` schema, persists the
+artifact, and records it in the artifact store. The agent does not write
+files, construct filenames, or supply `work_unit`.
 
 ### session-close
 

--- a/protocols/verify/PROTOCOL.md
+++ b/protocols/verify/PROTOCOL.md
@@ -1,11 +1,10 @@
 ---
 name: verify
 description: >-
-  Use when about to claim work is complete, fixed, or passing. Use before
-  committing, creating PRs, or moving to the next task. Requires running
-  verification commands and confirming output before making any success
-  claims. Evidence before assertions, always. If you are about to say
-  something is done, working, fixed, or passing, this skill applies.
+  Protocol for gating completion claims with fresh verification evidence.
+  Fires after execution, before claiming work is complete, fixed, or
+  passing. Requires running verification commands and confirming output
+  before making any success claims. Evidence before assertions, always.
 metadata:
   version: "1.0.0"
   updated: "2026-03-09"
@@ -49,11 +48,11 @@ Skip any step = the claim has no basis
 
 ## Lifecycle Role
 
-This skill owns **aggregate completion claims** — the moment before you say
-"done." It fires after execution, before packaging work for review.
+This protocol owns **aggregate completion claims** — the moment before you
+say "done." It fires after execution, before packaging work for review.
 
 It does not own per-test cycle evidence (that belongs to the `implement`
-discipline — each test watched failing, then passing). It owns the final
+protocol — each test watched failing, then passing). It owns the final
 gate: all tests pass, all requirements met, the build succeeds, the work is
 actually complete.
 
@@ -165,10 +164,10 @@ the claim — the claim does not select the evidence.
 ## Cross-References
 
 - `implement` owns per-test cycle evidence (each test watched failing, then
-  passing). This skill owns aggregate completion claims.
-- `document` review fires after code changes, before this skill's gate.
+  passing). This protocol owns aggregate completion claims.
+- `document` review fires after code changes, before this protocol's gate.
   Documentation accuracy is completion evidence.
-- `submit` consumes this skill's output — work must be verified before
+- `submit` consumes this protocol's output — work must be verified before
   packaging for review.
 
 ## The Bottom Line


### PR DESCRIPTION
## Summary

- Six issues addressing groundwork's protocol-layer self-description against runa's runtime model: survey's entrypoint, decompose's framing, take's selection, capstone delivery via MCP, conditional `gh` CLI, and protocols-vs-skills language.
- Second attempt at Phase B. First attempt (PR #229, closed 2026-04-18) extracted hygiene into a nonexistent forge skill. Issues were rewritten 2026-04-18 with explicit hygiene-vs-syntax scope guards; this PR keeps all repository and review hygiene inside the protocol bodies.
- Depends on Phase A (PR #225) and Phase A.5 (PR #232), both shipped.

## Changes

- **`fix(survey)`** — align entrypoint with runa activation from `request` artifacts. Drop the "agent chooses to invoke for itself" framing; opening now matches the existing Invocation Pattern section. Closes #214.
- **`fix(decompose)`** — reframe as `work-unit` artifact production. Drop "in GitHub projects" from the description; remove "Close with commit/PR reference (`Closes #N`)" from the close-work-unit procedure (the close event belongs to `land`, which produces the `completion-record`). Closes #215.
- **`fix(take)`** — consume the runa-injected `work-unit` rather than listing the forge tracker. Phase 1's three selection paths (`gh issue view` / `gh issue list`) collapse into "read the injected work-unit". Phase 3 is reframed as `claim` production — the session capstone. Repository hygiene (`git checkout main`, feature-branch creation, branch-name patterns) preserved. Closes #216.
- **`fix(protocol-output)`** — route survey/plan/document capstones (`requirements`, `implementation-plan`, `documentation-record`) through MCP tool calls, reusing Phase A's per-artifact-type tool pattern. Schema-validity vs. substance-validity distinction preserved where relevant. Closes #217.
- **`fix(submit-land)`** — remove hard `gh` requirement; deliver `patch` and `completion-record` via MCP with graceful degradation. In submit, forge absence means the `patch` capstone cannot complete (report and stop; do not synthesize a PR reference). In land, forge absence triggers the existing local-merge fallback and records unclosed work-units in `gaps`. All cognitive discipline stays: commit-series, PR body, `Closes #N` vs `Refs #N` judgment, branch cleanup, satisfied-vs-partial work-unit disposition. Closes #218.
- **`fix(protocol-language)`** — describe runa-managed protocols as protocols, not skills. Affects self-descriptions in take, implement, verify, submit, land. Legitimate skill delegations (`orient`, `reckon`, `research`, `debug`) remain explicit skill invocations. Closes #219.
- **`docs(changelog)`** — two-bullet entry per the substance-vs-alignment split convention.

## Semantic shift beyond language alignment

Phase 0b and 0c in `land` change semantics, not just language. Previously these steps called other protocols back (invoke the `verify` skill; invoke the `document` protocol); post-PR they perform the upstream protocols' discipline against the current branch diff without re-invocation. Under the runa-only activation invariant, protocols do not re-invoke other protocols mid-execution. Commit `3666166` (`fix(protocol-activation)`) is the self-review pass that carried this through.

## Scope discipline

- Change-set: nine `protocols/*/PROTOCOL.md` files + `CHANGELOG.md`. No manifest, schema, or architecture changes.
- No new skills; no forge skill. All hygiene stays inside protocol bodies per #218's explicit scope guard.
- No opportunistic normalization of adjacent fields or unrelated prose.
- `gh` / `git` command syntax appears inline where the agent executes the command, under conditional framing where required.

## Test plan

Mechanical grep sweeps (from repo root) all return zero hits:

- [x] `rg "Use this skill" protocols/` → 0
- [x] `rg "this skill applies" protocols/` → 0
- [x] `rg "in GitHub projects" protocols/` → 0
- [x] `rg "Close with commit/PR reference" protocols/` → 0
- [x] `rg "one protocol the agent chooses to invoke" protocols/` → 0
- [x] `rg "gh CLI must be authenticated" protocols/` → 0
- [x] `rg "gh issue (list|view)" protocols/take/` → 0

Change-set boundary:

- [x] `git diff --name-only main` lists only the 10 files above
- [x] `git diff main -- manifest.toml schemas/ docs/` → empty
- [x] `CLAUDE.md` → `AGENTS.md` symlink intact
- [x] No added or deleted files

Per-issue acceptance walk-through (against the diffs):

- [x] #214 — survey opening states runa activation from `request` and the external/downstream boundary
- [x] #215 — decompose frontmatter drops "in GitHub projects"; `Closes #N` step removed from close-work-unit
- [x] #216 — take Phase 1 consumes runa-injected work-unit; Phase 3 produces `claim` via MCP; `git checkout -b` retained
- [x] #217 — survey/plan/document each show the MCP tool call in their output sections
- [x] #218 — submit has no gh-precondition bullet; submit/land each deliver their capstones via MCP; cognitive discipline intact
- [x] #219 — no self-referential "skill" framing in take/implement/verify/submit/land; orient/reckon/research/debug remain skill delegations

Phase E (live integration test on babbie) is out of scope — that is the epic gate after Phase D ships.

Refs #220 (Phase B).
