### PR TITLE
fix(protocols): make runa MCP tool surface visible in protocol prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   agent; `decompose` is reframed as `work-unit` artifact production rather
   than GitHub-issue management (the close event moves to `land`); `take`
   consumes the injected `work-unit` and produces its `claim` capstone
-  rather than listing the forge tracker to select work; `survey`, `plan`,
-  and `document` deliver their capstones (`requirements`,
-  `implementation-plan`, `documentation-record`) via the runa MCP tool
-  surface rather than prose, files, or PR text; `submit` and `land`
-  deliver `patch` and `completion-record` via MCP and no longer hard-
-  require the `gh` CLI — forge tooling becomes conditional with graceful
-  degradation (closes #214, #215, #216, #217, #218).
+  rather than listing the forge tracker to select work; all ten producing
+  protocols now name their capstone delivery path through runa's MCP tool
+  surface instead of leaving agents to infer a non-MCP path. Planning-phase
+  artifacts (`requirements`, `work-unit`) describe agent-supplied payloads
+  directly; scoped execution artifacts (`claim`, `behavior-contract`,
+  `implementation-plan`, `test-evidence`, `completion-evidence`,
+  `documentation-record`, `patch`, `completion-record`) distinguish
+  agent-supplied fields from runa-injected `work_unit`; `submit` and `land`
+  no longer hard-require the `gh` CLI — forge tooling becomes conditional
+  with graceful degradation (closes #214, #215, #216, #217, #218, #222).
 - Protocol self-description language aligned across five runa-managed
   protocols: `take`, `implement`, `verify`, `submit`, and `land` now
   describe themselves as protocols rather than skills, matching the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `documentation-record`, `patch`, `completion-record`) distinguish
   agent-supplied fields from runa-injected `work_unit`; `submit` and `land`
   no longer hard-require the `gh` CLI — forge tooling becomes conditional
-  with graceful degradation (closes #214, #215, #216, #217, #218, #222).
+  with graceful degradation. `work-unit` now also carries optional `scope`
+  and `out_of_scope` boundary arrays, and tracker-backed first delivery uses
+  reversible `instance_id` convention `work-unit-<N>-<short-slug>` so
+  `take` framing and dependency references remain structurally recoverable
+  across protocol boundaries (closes #214, #215, #216, #217, #218, #222).
 - Protocol self-description language aligned across five runa-managed
   protocols: `take`, `implement`, `verify`, `submit`, and `land` now
   describe themselves as protocols rather than skills, matching the

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -862,7 +862,14 @@ how to know it's done, and whether it's ready to start.
 | title | string | yes | What this work unit is |
 | description | string | yes | What needs doing |
 | acceptance_criteria | array of strings | yes | Discrete, verifiable conditions for "done" |
-| dependencies | array of work-unit refs | no | Work units that must be complete before this starts |
+| scope | array of strings | no | In-scope boundaries for the session frame |
+| out_of_scope | array of strings | no | Explicit nearby exclusions |
+| dependencies | array of work-unit refs | no | Work units that must be complete before this starts, referenced by `instance_id` |
+
+Tracker-backed work-units use `instance_id` convention
+`work-unit-<N>-<short-slug>` on first delivery; work-units without tracker
+linkage use `<short-slug>`. Dependency references use those exact
+`instance_id` values.
 
 ### Traceability Thread
 

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -182,20 +182,24 @@ work-unit. Reuse the existing `instance_id` when refining an already-delivered
 work-unit artifact so artifact identity and inbound dependency references
 remain stable. For a work-unit that exists in the tracker but has not
 previously been delivered through this MCP flow, the first MCP delivery
-follows the create pattern and mints a fresh slug; subsequent updates to that
-work-unit reuse the slug minted there. In this section, "refining an existing
-work-unit" means refining an existing artifact, not merely refining a
-tracker item.
+uses the reversible tracker-backed convention
+`work-unit-<N>-<short-slug>`, where `<N>` is the tracker identifier. For a
+work-unit with no tracker linkage, first delivery uses `<short-slug>` directly.
+Subsequent updates reuse the `instance_id` established at first delivery. In
+this section, "refining an existing work-unit" means refining an existing
+artifact, not merely refining a tracker item.
 
 For new work-units produced by `create-work-unit` or `decompose-epic`:
 
 ```
 work-unit({
-  instance_id: "<new-slug>",
+  instance_id: "work-unit-123-pipeline-refactor",
   title: "<type(scope): what>",
   description: "<what needs doing and why>",
   acceptance_criteria: ["..."],
-  dependencies: ["work-unit-123.pipeline-refactor"]
+  scope: ["decompose delivery", "take framing"],
+  out_of_scope: ["submit protocol", "land protocol"],
+  dependencies: ["work-unit-122-artifact-store-cleanup"]
 })
 ```
 
@@ -207,7 +211,9 @@ work-unit({
   title: "<type(scope): what>",
   description: "<what needs doing and why>",
   acceptance_criteria: ["..."],
-  dependencies: ["work-unit-123.pipeline-refactor"]
+  scope: ["decompose delivery", "take framing"],
+  out_of_scope: ["submit protocol", "land protocol"],
+  dependencies: ["work-unit-122-artifact-store-cleanup"]
 })
 ```
 
@@ -217,15 +223,15 @@ one.
 
 Runa validates the payload against the `work-unit` schema, persists the
 artifact under the given `instance_id`, and records it in the artifact store.
-The `dependencies` field takes the slug-form `instance_id` values of the
-target work-units, not tracker references such as `#123`. Where earlier
-procedures identify a dependency by tracker reference, delivery must translate
-that tracker item to the target work-unit's artifact `instance_id` before
-invoking the MCP tool. If a dependency exists only as a legacy tracker-backed
-item and has not yet been delivered through this MCP flow, first deliver that
-dependency by minting its artifact slug as described above, then reference that
-slug in `dependencies`. `work-unit` is a planning-phase artifact: the agent
-supplies the schema fields shown above, and runa does not inject `work_unit`.
+The `dependencies` field takes the target work-units' exact `instance_id`
+values, not tracker references such as `#123`. For tracker-backed
+dependencies, first delivery uses the same reversible
+`work-unit-<N>-<short-slug>` convention, so later sessions can recover the
+tracker identifier directly from the artifact identifier without maintaining a
+separate mapping. For non-tracker-backed dependencies, use the dependency's
+bare `<short-slug>` `instance_id`. `work-unit` is a planning-phase artifact:
+the agent supplies the schema fields shown above, and runa does not inject
+`work_unit`.
 
 ## Triggers
 

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -167,6 +167,26 @@ The close event itself — marking the work-unit closed in the forge tracker —
 is performed by `land` when it produces the `completion-record`. `decompose`
 owns the pre-close review; `land` owns the seal.
 
+### deliver-work-unit
+
+Deliver each `work-unit` artifact by invoking the `work-unit` MCP tool once
+per work unit:
+
+```
+work-unit({
+  instance_id: "<slug>",
+  title: "<type(scope): what>",
+  description: "<what needs doing and why>",
+  acceptance_criteria: ["..."],
+  dependencies: ["..."]
+})
+```
+
+Runa validates the payload against the `work-unit` schema, persists the
+artifact under the given `instance_id`, and records it in the artifact store.
+`work-unit` is a planning-phase artifact: the agent supplies the schema fields
+shown above, and runa does not inject `work_unit`.
+
 ## Triggers
 
 - creating or refining work units

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -178,9 +178,14 @@ artifacts with tracker as an optional sync target — is separate future work.
 
 Deliver each `work-unit` artifact by invoking the `work-unit` MCP tool once
 per delivered artifact. Use a fresh `instance_id` when creating a new
-work-unit; reuse the existing `instance_id` when refining an existing
-work-unit so artifact identity and inbound dependency references remain
-stable.
+work-unit. Reuse the existing `instance_id` when refining an already-delivered
+work-unit artifact so artifact identity and inbound dependency references
+remain stable. For a work-unit that exists in the tracker but has not
+previously been delivered through this MCP flow, the first MCP delivery
+follows the create pattern and mints a fresh slug; subsequent updates to that
+work-unit reuse the slug minted there. In this section, "refining an existing
+work-unit" means refining an existing artifact, not merely refining a
+tracker item.
 
 For new work-units produced by `create-work-unit` or `decompose-epic`:
 
@@ -190,7 +195,7 @@ work-unit({
   title: "<type(scope): what>",
   description: "<what needs doing and why>",
   acceptance_criteria: ["..."],
-  dependencies: ["..."]
+  dependencies: ["work-unit-123.pipeline-refactor"]
 })
 ```
 
@@ -202,7 +207,7 @@ work-unit({
   title: "<type(scope): what>",
   description: "<what needs doing and why>",
   acceptance_criteria: ["..."],
-  dependencies: ["..."]
+  dependencies: ["work-unit-123.pipeline-refactor"]
 })
 ```
 
@@ -212,8 +217,15 @@ one.
 
 Runa validates the payload against the `work-unit` schema, persists the
 artifact under the given `instance_id`, and records it in the artifact store.
-`work-unit` is a planning-phase artifact: the agent supplies the schema fields
-shown above, and runa does not inject `work_unit`.
+The `dependencies` field takes the slug-form `instance_id` values of the
+target work-units, not tracker references such as `#123`. Where earlier
+procedures identify a dependency by tracker reference, delivery must translate
+that tracker item to the target work-unit's artifact `instance_id` before
+invoking the MCP tool. If a dependency exists only as a legacy tracker-backed
+item and has not yet been delivered through this MCP flow, first deliver that
+dependency by minting its artifact slug as described above, then reference that
+slug in `dependencies`. `work-unit` is a planning-phase artifact: the agent
+supplies the schema fields shown above, and runa does not inject `work_unit`.
 
 ## Triggers
 

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -169,18 +169,46 @@ owns the pre-close review; `land` owns the seal.
 
 ### deliver-work-unit
 
+Tracker operations in the procedures above — searching existing work-units,
+labels, stale-age review, and parent-epic checklist updates — remain required
+for `decompose`'s current forge-tracker-coupled workflow. Delivering the
+`work-unit` artifact through runa's MCP tool does not replace those tracker
+surfaces. Full runa-native `decompose` — where work-units live as runa
+artifacts with tracker as an optional sync target — is separate future work.
+
 Deliver each `work-unit` artifact by invoking the `work-unit` MCP tool once
-per work unit:
+per delivered artifact. Use a fresh `instance_id` when creating a new
+work-unit; reuse the existing `instance_id` when refining an existing
+work-unit so artifact identity and inbound dependency references remain
+stable.
+
+For new work-units produced by `create-work-unit` or `decompose-epic`:
 
 ```
 work-unit({
-  instance_id: "<slug>",
+  instance_id: "<new-slug>",
   title: "<type(scope): what>",
   description: "<what needs doing and why>",
   acceptance_criteria: ["..."],
   dependencies: ["..."]
 })
 ```
+
+For refinements produced by `refine-work-unit`:
+
+```
+work-unit({
+  instance_id: "<existing-instance-id>",
+  title: "<type(scope): what>",
+  description: "<what needs doing and why>",
+  acceptance_criteria: ["..."],
+  dependencies: ["..."]
+})
+```
+
+Choosing a new slug during refinement creates a duplicate artifact and leaves
+inbound `dependencies` pointing at the stale work-unit instead of the refined
+one.
 
 Runa validates the payload against the `work-unit` schema, persists the
 artifact under the given `instance_id`, and records it in the artifact store.

--- a/protocols/document/PROTOCOL.md
+++ b/protocols/document/PROTOCOL.md
@@ -62,8 +62,8 @@ Fires after verification, before `submit`.
    references, or explicitly verify and trace any remaining dynamic numbers.
 6. **Apply audience test.** For each updated or created doc: "Would the
    intended reader know what to do after reading this?"
-7. **Deliver `documentation-record`.** Invoke the `documentation-record` MCP
-   tool:
+7. **Deliver `documentation-record`.** Invoke the
+   `documentation-record` MCP tool:
 
    ```
    documentation-record({
@@ -76,7 +76,7 @@ Fires after verification, before `submit`.
 
    Runa injects `work_unit` from session context, validates the payload
    against the documentation-record schema, persists the artifact, and
-   records the coverage summary.
+   records it in the artifact store.
 
 ### evaluate-existing-docs
 

--- a/protocols/implement/PROTOCOL.md
+++ b/protocols/implement/PROTOCOL.md
@@ -243,6 +243,27 @@ gone. The choice now is between trusted code (test-driven) and untrusted code
 (implementation-first with tests bolted on). Trusted code is faster in the
 long run.
 
+### deliver-test-evidence
+
+The capstone is delivery of the `test-evidence` artifact. Invoke the
+`test-evidence` MCP tool:
+
+```
+test-evidence({
+  instance_id: "<slug>",
+  evidence: [{
+    scenario: "<scenario name from behavior-contract>",
+    result: "pass",
+    command: "<verification command>",
+    output_summary: "<proof the test ran>"
+  }]
+})
+```
+
+Runa injects `work_unit` from session context, validates the payload against
+the test-evidence schema, persists the artifact, and records it in the
+artifact store.
+
 ## Anti-Rationalization
 
 Every excuse in this table has been offered sincerely. Every one leads to

--- a/protocols/specify/PROTOCOL.md
+++ b/protocols/specify/PROTOCOL.md
@@ -129,6 +129,29 @@ refactor that preserves the behavior.
 4. **Green:** implement minimal code to pass. Resist the urge to generalize.
 5. **Refactor** while keeping the full suite green.
 
+### deliver-behavior-contract
+
+The capstone is delivery of the `behavior-contract` artifact. Invoke the
+`behavior-contract` MCP tool:
+
+```
+behavior-contract({
+  instance_id: "<slug>",
+  title: "<human-readable contract title>",
+  scenarios: [{
+    name: "<scenario name>",
+    criterion: "<acceptance criterion this refines>",
+    given: "<initial context>",
+    when: "<action or event>",
+    then: "<expected outcome>"
+  }]
+})
+```
+
+Runa injects `work_unit` from session context, validates the payload against
+the behavior-contract schema, persists the artifact, and records it in the
+artifact store.
+
 ## Corruption Modes
 
 **Vague names.** Test names that do not describe the behavior.

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -87,8 +87,10 @@ Establish the session's purpose using the Four Touches:
 
 The work-unit artifact is always present — runa activates the protocol on the
 selected work-unit. Derive all four touches from the work-unit body: purpose
-from the summary, success from acceptance criteria, scope from the work-unit
-boundary, out-of-scope from the work-unit's explicit exclusions.
+from `description`, success from `acceptance_criteria`, scope from the
+work-unit's `scope` array, and out-of-scope from the work-unit's
+`out_of_scope` array. When either boundary array is absent, fall back to
+description-inferred framing.
 
 ```
 ◈ FRAME

--- a/protocols/verify/PROTOCOL.md
+++ b/protocols/verify/PROTOCOL.md
@@ -141,6 +141,27 @@ Unverified: Trust agent report at face value
 - Implications of success ("Ready for review")
 - Any communication suggesting completion or correctness
 
+### deliver-completion-evidence
+
+The capstone is delivery of the `completion-evidence` artifact. Invoke the
+`completion-evidence` MCP tool:
+
+```
+completion-evidence({
+  instance_id: "<slug>",
+  criterion_coverage: [{
+    criterion: "<acceptance criterion>",
+    status: "covered",
+    scenarios: ["<covering scenario names>"],
+    failures: []
+  }]
+})
+```
+
+Runa injects `work_unit` from session context, validates the payload against
+the completion-evidence schema, persists the artifact, and records it in the
+artifact store.
+
 ## Corruption Modes
 
 **Performative verification.** Going through the motions without actually

--- a/schemas/work-unit.schema.json
+++ b/schemas/work-unit.schema.json
@@ -25,6 +25,20 @@
         "type": "string"
       }
     },
+    "scope": {
+      "type": "array",
+      "description": "In-scope boundaries for this work unit.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "out_of_scope": {
+      "type": "array",
+      "description": "Explicit exclusions adjacent to this work unit.",
+      "items": {
+        "type": "string"
+      }
+    },
     "dependencies": {
       "type": "array",
       "description": "Work units that must be complete before this starts.",

--- a/schemas/work-unit.schema.json
+++ b/schemas/work-unit.schema.json
@@ -28,15 +28,19 @@
     "scope": {
       "type": "array",
       "description": "In-scope boundaries for this work unit.",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "out_of_scope": {
       "type": "array",
       "description": "Explicit exclusions adjacent to this work unit.",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "dependencies": {
@@ -44,7 +48,7 @@
       "description": "Work units that must be complete before this starts.",
       "items": {
         "type": "string",
-        "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
+        "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
       }
     }
   }

--- a/tests/fixtures/artifacts/invalid-behavior-contract.json
+++ b/tests/fixtures/artifacts/invalid-behavior-contract.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "title": "Schema validation at ingestion entry point",
   "scenarios": [
     {

--- a/tests/fixtures/artifacts/invalid-completion-evidence.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "criterion_coverage": [
     {
       "criterion": "Records missing required fields are rejected with a 400 status",

--- a/tests/fixtures/artifacts/invalid-completion-record.json
+++ b/tests/fixtures/artifacts/invalid-completion-record.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "criterion_summary": "All acceptance criteria met",
   "gaps": [],
   "merge_reference": "https://github.com/tesserine/groundwork/pull/179"

--- a/tests/fixtures/artifacts/invalid-documentation-record.json
+++ b/tests/fixtures/artifacts/invalid-documentation-record.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "updated_docs": [
     "docs/ingestion-api.md"
   ],

--- a/tests/fixtures/artifacts/invalid-implementation-plan.json
+++ b/tests/fixtures/artifacts/invalid-implementation-plan.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "summary": "Add a JSON Schema validation middleware to the ingestion endpoint",
   "affected_files": [
     "src/ingestion/handler.py"

--- a/tests/fixtures/artifacts/invalid-patch.json
+++ b/tests/fixtures/artifacts/invalid-patch.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "pr_reference": "https://github.com/tesserine/groundwork/pull/179",
   "branch": "work-unit-178/test-fixtures"
 }

--- a/tests/fixtures/artifacts/invalid-test-evidence.json
+++ b/tests/fixtures/artifacts/invalid-test-evidence.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "evidence": [
     {
       "scenario": "reject-missing-required-field",

--- a/tests/fixtures/artifacts/invalid-work-unit.json
+++ b/tests/fixtures/artifacts/invalid-work-unit.json
@@ -1,5 +1,16 @@
 {
   "title": "Validate record schema before ingestion",
-  "description": "Add a schema validation step at the ingestion entry point",
-  "acceptance_criteria": "Records missing required fields are rejected"
+  "description": "Add a schema validation step at the ingestion entry point that rejects records missing required fields or containing invalid types",
+  "acceptance_criteria": [
+    "Records missing required fields are rejected with a 400 status",
+    "Rejected records are logged with a reason code",
+    "Valid records pass through unchanged"
+  ],
+  "scope": [],
+  "out_of_scope": [
+    ""
+  ],
+  "dependencies": [
+    "work-unit-175.pipeline-refactor"
+  ]
 }

--- a/tests/fixtures/artifacts/valid-behavior-contract.json
+++ b/tests/fixtures/artifacts/valid-behavior-contract.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "title": "Schema validation at ingestion entry point",
   "scenarios": [
     {

--- a/tests/fixtures/artifacts/valid-claim.json
+++ b/tests/fixtures/artifacts/valid-claim.json
@@ -1,4 +1,4 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "scope": "Create valid and invalid fixture pairs for all 12 artifact type schemas"
 }

--- a/tests/fixtures/artifacts/valid-completion-evidence.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "criterion_coverage": [
     {
       "criterion": "Records missing required fields are rejected with a 400 status",

--- a/tests/fixtures/artifacts/valid-completion-record.json
+++ b/tests/fixtures/artifacts/valid-completion-record.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "criterion_summary": "All three acceptance criteria covered — missing-field rejection, reason-code logging, and valid-record passthrough verified by tests",
   "gaps": [],
   "merge_reference": "https://github.com/tesserine/groundwork/pull/179",

--- a/tests/fixtures/artifacts/valid-documentation-record.json
+++ b/tests/fixtures/artifacts/valid-documentation-record.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "updated_docs": [
     "docs/ingestion-api.md"
   ],

--- a/tests/fixtures/artifacts/valid-implementation-plan.json
+++ b/tests/fixtures/artifacts/valid-implementation-plan.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "summary": "Add a JSON Schema validation middleware to the ingestion endpoint that checks records against the expected schema before forwarding to the pipeline",
   "design_decisions": [
     {

--- a/tests/fixtures/artifacts/valid-patch.json
+++ b/tests/fixtures/artifacts/valid-patch.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "pr_reference": "https://github.com/tesserine/groundwork/pull/179",
   "branch": "work-unit-178/test-fixtures",
   "commit": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"

--- a/tests/fixtures/artifacts/valid-research-record-scoped.json
+++ b/tests/fixtures/artifacts/valid-research-record-scoped.json
@@ -1,6 +1,6 @@
 {
   "topic": "json-schema-validation",
-  "work_unit": "work-unit-184.research-record-work-unit",
+  "work_unit": "work-unit-184-research-record-work-unit",
   "findings": [
     "Draft 2020-12 supports dynamic references and prefixItems for tuple validation",
     "The jsonschema Python library supports Draft 2020-12 as of version 4.18"

--- a/tests/fixtures/artifacts/valid-test-evidence.json
+++ b/tests/fixtures/artifacts/valid-test-evidence.json
@@ -1,5 +1,5 @@
 {
-  "work_unit": "work-unit-178.test-fixtures",
+  "work_unit": "work-unit-178-test-fixtures",
   "evidence": [
     {
       "scenario": "reject-missing-required-field",

--- a/tests/fixtures/artifacts/valid-work-unit.json
+++ b/tests/fixtures/artifacts/valid-work-unit.json
@@ -6,7 +6,15 @@
     "Rejected records are logged with a reason code",
     "Valid records pass through unchanged"
   ],
+  "scope": [
+    "ingestion entry-point validation",
+    "request rejection behavior for invalid records"
+  ],
+  "out_of_scope": [
+    "pipeline refactor",
+    "downstream record transformation"
+  ],
   "dependencies": [
-    "work-unit-175.pipeline-refactor"
+    "work-unit-175-pipeline-refactor"
   ]
 }


### PR DESCRIPTION
## Summary

- make the remaining producing protocols name their MCP delivery tool instead of leaving the delivery path implicit
- document the planning-phase `work-unit` exception in `decompose` and the runa-injected `work_unit` contract in `specify`, `implement`, and `verify`
- align `document` wording and the changelog with the now-complete 10/10 protocol delivery-surface coverage

## Changes

- add delivery sections to `decompose`, `specify`, `implement`, and `verify` with schema-accurate example payloads
- clarify that `decompose`'s `work-unit` artifacts are agent-supplied planning artifacts with no injected `work_unit`
- reflow `document`'s delivery wording and standardize it on artifact-store language
- update `CHANGELOG.md` to reflect full MCP-delivery guidance coverage across producing protocols

## GitHub Issue(s)

Closes #222
Refs #220

## Test plan

- `git diff --check`
- `for f in protocols/*/PROTOCOL.md; do p=$(basename $(dirname "$f")); produces=$(sed -n '1,20p' "$f" | awk -F'[][]' '/^produces:/ {print $2}'); if [ -n "$produces" ]; then if rg -q "MCP tool|artifact store|Runa injects|instance_id" "$f"; then echo "$p OK"; else echo "$p MISSING"; fi; fi; done`
- inspect the new delivery sections in `decompose`, `specify`, `implement`, and `verify` for schema-accurate payload shapes and correct `work_unit` injection semantics
