### PR TITLE
chore(frontmatter): audit skill and protocol frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `manifest.toml`. With this wiring, an agent inside any of these
   protocol sessions can persist a fresh research-record through runa
   rather than producing it as a loose skill artifact.
+- Skill and protocol frontmatter now keeps only minimal
+  harness/reader-facing identification data. Runa contract
+  declarations live only in `manifest.toml`, and removing the mirrored
+  protocol `may_produce` fields eliminates the already-existing
+  `research-record` drift case those duplicates had accumulated.
 - Canonical reference (`docs/architecture/connecting-structure.md`)
   gains Runtime Layers and Skill-Produced Artifacts sections that
   document the four-layer agentd/harness/runa/groundwork model and

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -416,6 +416,31 @@ no direct channel to runa. Anything a skill produces that needs to
 enter runa's validated artifact store must cross through an active
 protocol session. The next section describes the specific mechanism.
 
+### Authoring surfaces and authority
+
+The four layers imply a single authoritative place for each kind of
+declaration:
+
+- `manifest.toml` is the sole contract surface for runa-managed
+  protocol declarations: `requires`, `accepts`, `produces`,
+  `may_produce`, and `trigger`.
+- Skill frontmatter is a harness-and-reader surface, not a runa
+  surface. The harness uses identifying fields such as `name` and
+  `description`; optional `metadata` remains for human-oriented
+  context such as version or attribution.
+- Protocol frontmatter is reader-facing only. Runa reads the
+  `PROTOCOL.md` file as instructions text; it does not parse mirrored
+  contract declarations from the markdown header.
+
+Duplicating manifest-shaped fields into skill or protocol frontmatter
+creates a second unsynchronized surface. The repository already saw
+this drift: after `manifest.toml` added
+`may_produce = ["research-record"]` to four protocols, those
+protocols' markdown frontmatter still said `may_produce: []`.
+Removing the duplicate fields eliminates that inconsistency class
+rather than asking future authors to maintain two declarations by
+hand.
+
 ## Skill-Produced Artifacts and the `may_produce` Bridge
 
 A skill can be loaded by the harness only during an agent session,
@@ -492,8 +517,10 @@ persisted through runa:
    plausibly need to produce a fresh instance of the artifact during
    that protocol's session. Add the artifact to that protocol's
    `may_produce` if yes. This decision is independent of step 2.
-4. The skill itself does not need to declare anything for runa's
-   sake — runa does not read skill frontmatter.
+4. Keep any skill frontmatter limited to harness/reader identification
+   fields. The runa-facing declaration lives only in `manifest.toml`;
+   do not mirror `accepts`, `produces`, `may_produce`, or `trigger`
+   into the skill file.
 
 ## Agent Interface
 

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -5,12 +5,6 @@ description: >-
   work units. Produce `work-unit` artifacts: creating, decomposing, refining,
   and triaging. Close-state review happens here; the close itself is performed
   by `land`.
-requires: ["requirements"]
-accepts: ["research-record"]
-produces: ["work-unit"]
-may_produce: []
-trigger:
-  on_artifact: "requirements"
 ---
 
 # Work-Unit Craft

--- a/protocols/document/PROTOCOL.md
+++ b/protocols/document/PROTOCOL.md
@@ -5,12 +5,6 @@ description: >-
   submission, or when existing docs need classification for drift, missing
   coverage, or obsolescence. This is the focused documentation review protocol
   that records documentation coverage and tracking outcomes.
-requires: ["completion-evidence"]
-accepts: ["behavior-contract", "implementation-plan"]
-produces: ["documentation-record"]
-may_produce: []
-trigger:
-  on_artifact: "completion-evidence"
 ---
 
 # Document

--- a/protocols/implement/PROTOCOL.md
+++ b/protocols/implement/PROTOCOL.md
@@ -10,12 +10,6 @@ metadata:
   version: "1.0.0"
   updated: "2026-03-08"
   origin: "Adapted from obra/superpowers (MIT). See LICENSE-UPSTREAM."
-requires: ["behavior-contract", "implementation-plan"]
-accepts: []
-produces: ["test-evidence"]
-may_produce: []
-trigger:
-  on_artifact: "implementation-plan"
 ---
 
 # Implement

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -5,12 +5,6 @@ description: >-
   documentation before mechanical merge. Merge to main, sync, delete feature
   branch, close satisfied work units, comment progress on partial work units.
   Trigger on: 'land', 'land this', 'merge and close', 'ship it'.
-requires: ["patch"]
-accepts: ["completion-evidence", "behavior-contract", "documentation-record", "work-unit"]
-produces: ["completion-record"]
-may_produce: []
-trigger:
-  on_artifact: "patch"
 ---
 
 # Land — Close, Verify, Merge

--- a/protocols/plan/PROTOCOL.md
+++ b/protocols/plan/PROTOCOL.md
@@ -11,12 +11,6 @@ metadata:
   version: "1.1.0"
   updated: "2026-03-08"
   origin: "Adapted from OpenAI Codex CLI (Apache-2.0). See LICENSE-UPSTREAM."
-requires: ["behavior-contract"]
-accepts: ["research-record"]
-produces: ["implementation-plan"]
-may_produce: []
-trigger:
-  on_artifact: "behavior-contract"
 ---
 
 # Plan

--- a/protocols/specify/PROTOCOL.md
+++ b/protocols/specify/PROTOCOL.md
@@ -4,12 +4,6 @@ description: Protocol for writing and maintaining executable behavior specificat
 metadata:
   version: "2.1.0"
   updated: "2026-03-17"
-requires: ["claim", "work-unit"]
-accepts: ["research-record"]
-produces: ["behavior-contract"]
-may_produce: []
-trigger:
-  on_artifact: "claim"
 ---
 
 # Specify

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -6,12 +6,6 @@ description: >-
   The middle phase of the session lifecycle between take and land.
   Trigger on: 'submit', 'submit pr', 'create pr', 'open pr',
   'send for review', 'package this up'.
-requires: ["completion-evidence", "documentation-record"]
-accepts: []
-produces: ["patch"]
-may_produce: []
-trigger:
-  on_artifact: "documentation-record"
 ---
 
 # Submit — Commit, Push, PR

--- a/protocols/survey/PROTOCOL.md
+++ b/protocols/survey/PROTOCOL.md
@@ -10,12 +10,6 @@ description: >-
 metadata:
   version: "1.0.0"
   updated: "2026-03-17"
-requires: ["request"]
-accepts: ["research-record"]
-produces: ["requirements"]
-may_produce: []
-trigger:
-  on_artifact: "request"
 ---
 
 # Survey

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -4,12 +4,6 @@ description: >-
   Session work initiation: select work-unit(s), prepare workspace, declare
   direction. Opening bookend of the session lifecycle — `land` is the closing
   bookend. Trigger on: 'take', 'take work', 'start session', 'start work-unit'.
-requires: ["work-unit"]
-accepts: []
-produces: ["claim"]
-may_produce: []
-trigger:
-  on_artifact: "work-unit"
 ---
 
 # Take — Work Selection & Initiation

--- a/protocols/verify/PROTOCOL.md
+++ b/protocols/verify/PROTOCOL.md
@@ -9,12 +9,6 @@ metadata:
   version: "1.0.0"
   updated: "2026-03-09"
   origin: "Adapted from obra/superpowers (MIT). See LICENSE-UPSTREAM."
-requires: ["behavior-contract", "test-evidence", "work-unit"]
-accepts: []
-produces: ["completion-evidence"]
-may_produce: []
-trigger:
-  on_artifact: "test-evidence"
 ---
 
 # Verify

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -10,12 +10,6 @@ metadata:
   version: "1.0.0"
   updated: "2026-03-09"
   origin: "Adapted from obra/superpowers (MIT). See LICENSE-UPSTREAM."
-requires: []
-accepts: ["test-evidence"]
-produces: []
-may_produce: []
-trigger:
-  on_signal: "investigation-needed"
 ---
 
 # Debug

--- a/skills/orient/SKILL.md
+++ b/skills/orient/SKILL.md
@@ -8,12 +8,6 @@ description: >-
 metadata:
   version: "3.1.0"
   updated: "2026-03-17"
-requires: []
-accepts: []
-produces: []
-may_produce: []
-trigger:
-  on_signal: "methodology-orientation"
 ---
 
 # Orient

--- a/skills/reckon/SKILL.md
+++ b/skills/reckon/SKILL.md
@@ -13,12 +13,6 @@ description: >-
 metadata:
   version: "4.1.0"
   updated: "2026-04-03"
-requires: []
-accepts: ["research-record"]
-produces: []
-may_produce: []
-trigger:
-  on_signal: "frame-constraints"
 ---
 
 # Reckon

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,18 +1,11 @@
 ---
 name: research
 description: Systematic multi-source research with citations and synthesis using 6-phase workflow and Tavily
-license: MIT
 metadata:
   version: "1.3.0"
   source: internal
   updated: "2026-03-07"
   workflow: 6-phase (Clarify → Decompose → Gather → Evaluate → Resolve → Synthesize)
-requires: []
-accepts: []
-produces: ["research-record"]
-may_produce: []
-trigger:
-  on_signal: "evidence-needed"
 ---
 
 # Research Skill

--- a/skills/resolve/SKILL.md
+++ b/skills/resolve/SKILL.md
@@ -14,12 +14,6 @@ description: >-
 metadata:
   version: "2.1.0"
   updated: "2026-03-08"
-requires: []
-accepts: []
-produces: []
-may_produce: []
-trigger:
-  on_signal: "friction-detected"
 ---
 
 # Resolve


### PR DESCRIPTION
## Summary

- remove dead manifest-shaped fields from skill and protocol frontmatter where no consumer reads them
- document the actual consumer chain in the architecture reference so `manifest.toml` is the single authoritative runa-facing declaration surface
- make the existing `research-record` `may_produce` drift case disappear by deleting the duplicated markdown declarations instead of maintaining them

## Changes

- reduce `skills/*/SKILL.md` and `protocols/*/PROTOCOL.md` frontmatter to minimal harness/reader-facing identification metadata
- remove mirrored `requires`, `accepts`, `produces`, `may_produce`, and `trigger` declarations from markdown files
- add an architecture-doc section explaining authority by consumer and record the convention in the changelog

## GitHub Issue(s)

Closes #223

## Test plan

- `git diff --check`
- `rg -n "^(requires|accepts|produces|may_produce):|^trigger:$|on_signal:" skills protocols -S`
- Python scan over every `SKILL.md` and `PROTOCOL.md` confirming no removed frontmatter keys remain
