### PR TITLE
chore(nomenclature): normalize work-unit prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Normalized in-scope prose to the canonical hyphenated `work-unit` /
+  `work-units` spelling across protocols, skills, architecture docs, README,
+  and changelog entries. Machine-facing `work_unit` identifiers remain
+  unchanged (closes #242).
 - Protocol bodies now describe runa-managed execution end-to-end: `survey`
   activates on a `request` artifact rather than being self-invoked by the
   agent; `decompose` is reframed as `work-unit` artifact production rather
@@ -72,10 +76,10 @@ protocols, skills, and artifact schemas that a runa instance orchestrates.
   conditions, and scoping. This is the single file runa reads to understand
   the methodology.
 - Two planning-phase protocols (unscoped): **survey** produces requirements
-  from an external request; **decompose** produces session-sized work units with
+  from an external request; **decompose** produces session-sized work-units with
   acceptance criteria and dependency edges.
 - Eight execution-phase protocols (all `scoped = true`, work-unit threaded):
-  **take** claims a work unit and opens the session → **specify** writes the
+  **take** claims a work-unit and opens the session → **specify** writes the
   behavior contract as Given/When/Then scenarios → **plan** converges on a
   decision-complete design → **implement** executes through RED-GREEN-REFACTOR
   → **verify** gates completion with behavior-level evidence → **document**
@@ -111,7 +115,7 @@ protocols, skills, and artifact schemas that a runa instance orchestrates.
   `LICENSE-UPSTREAM`.
 - **resolve** — friction resolution through the reconciling force. When
   operational friction appears, stop and resolve structurally instead of
-  routing around. Scope guidance distinguishes inline side quests from work units.
+  routing around. Scope guidance distinguishes inline side quests from work-units.
 - **research** — systematic multi-source research with citations. Six-phase
   workflow (clarify, decompose, gather, evaluate, resolve, synthesize).
   Produces a typed artifact (research-record) that other protocols can accept.
@@ -127,7 +131,7 @@ protocols, skills, and artifact schemas that a runa instance orchestrates.
   `manifest.toml`.
 - Planning-phase artifacts carry no `work_unit` field: **request** (external
   input), **requirements** (scope, constraints, priorities),
-  **work-unit** (work unit with acceptance criteria and dependencies).
+  **work-unit** (work-unit with acceptance criteria and dependencies).
 - Execution-phase artifacts carry a `work_unit` envelope for runa's scoped
   validation: **claim** (threading root), **behavior-contract** (Given/When/Then
   scenarios), **implementation-plan** (design decisions, affected files,

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ For what methodology plugins are and how runa executes them, see runa's
 
 Work moves through two phases connected by the work-unit artifact.
 
-**Planning** takes an external request and produces work units.
+**Planning** takes an external request and produces work-units.
 Survey examines what actually needs doing; decompose breaks that into work
 units with acceptance criteria and dependency edges.
 
-**Execution** takes one work unit and carries it through to a merged increment:
-take claims the work unit and opens the session → specify writes the behavior
+**Execution** takes one work-unit and carries it through to a merged increment:
+take claims the work-unit and opens the session → specify writes the behavior
 contract as Given/When/Then scenarios → plan converges on a decision-complete
 design → implement executes through RED-GREEN-REFACTOR → verify gates
 completion with evidence → document ensures accuracy → submit packages the
@@ -41,7 +41,7 @@ Six skills operate across the topology:
 - **research** — external evidence gathering when facts are missing
 - **contract** — behavior traceability through execution
 
-Not every piece of work needs every stage. A bug with an existing work unit enters
+Not every piece of work needs every stage. A bug with an existing work-unit enters
 at execution. A new capability enters at planning. The constraint is sequence,
 not completeness.
 → [`skills/orient/SKILL.md`](skills/orient/SKILL.md)
@@ -63,7 +63,7 @@ memory.
 → [`docs/architecture/work-unit-model.md`](docs/architecture/work-unit-model.md)
 
 **Sovereignty.** Every handoff passes outcomes — what must be true — never
-implementation steps. Work units define acceptance criteria, not procedure. Plans
+implementation steps. Work-units define acceptance criteria, not procedure. Plans
 define interfaces and decisions, not scripts to follow.
 → [`protocols/decompose/PROTOCOL.md`](protocols/decompose/PROTOCOL.md)
 
@@ -108,7 +108,7 @@ symptoms.
 **Friction is structural.** Workarounds compound debt. Operational friction — a
 missing tool, broken configuration, stale convention — gets resolved
 structurally before work continues. Friction that exceeds side-quest scope
-becomes a work unit.
+becomes a work-unit.
 → [`skills/resolve/SKILL.md`](skills/resolve/SKILL.md)
 
 ## What the Repo Contains

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -22,7 +22,7 @@ These survived prior reckoning sessions and are ground for this design.
    itself.
 
 4. **Work-unit identity.** Every artifact instance carries a reference to
-   the work unit it belongs to. Runa uses this to resolve which instances
+   the work-unit it belongs to. Runa uses this to resolve which instances
    are related. Manifest edges stay type-level; instance-level linking
    lives in artifact content.
 
@@ -35,7 +35,7 @@ These survived prior reckoning sessions and are ground for this design.
 
 ## The Forward Flow
 
-The full flow for a single work unit is:
+The full flow for a single work-unit is:
 
 ```
 take → specify → plan → implement → verify → document → submit → land
@@ -43,7 +43,7 @@ take → specify → plan → implement → verify → document → submit → l
 
 Survey and decompose precede take when project-level planning is needed.
 Survey produces requirements; decompose breaks requirements into work-unit
-artifacts. Take picks up a work unit and starts the work-unit lifecycle.
+artifacts. Take picks up a work-unit and starts the work-unit lifecycle.
 
 Document sits between verify and submit. Documentation is submitted
 together with the code it explains. Submit is gated on documentation-record.
@@ -57,7 +57,7 @@ together with the code it explains. Submit is gated on documentation-record.
 | survey    | requirements | Declaration of what needs doing, at any scope |
 | decompose | work-unit | Work units decomposed from requirements |
 | take      | claim | Root node: work-unit identity and orientation |
-| specify   | behavior-contract | Behavioral scenarios for the work unit |
+| specify   | behavior-contract | Behavioral scenarios for the work-unit |
 | plan      | implementation-plan | Design decisions informing execution |
 | implement | test-evidence | Proof of correct implementation — passing tests mapped to scenarios |
 | verify    | completion-evidence | Aggregated behavior coverage status |
@@ -78,7 +78,7 @@ from the artifact graph.
 
 Take currently produces no artifact for runa. It should. Take does the
 most consequential work in the topology — selecting and orienting to a
-work unit — but leaves no trace in the artifact system.
+work-unit — but leaves no trace in the artifact system.
 
 Take's capstone is the **root node** of the work-unit artifact chain.
 It establishes the work-unit identifier that every downstream artifact
@@ -104,7 +104,7 @@ thread would break without it. An input is `accepts` when the capstone
 can be valid but would be better informed by the context.
 
 Requires edges form the **structural backbone** of the topology — the
-chain that must be unbroken for the work unit to flow. Accepts edges
+chain that must be unbroken for the work-unit to flow. Accepts edges
 provide **contextual enrichment** — cross-cutting artifacts that improve
 quality but whose absence doesn't break the chain.
 
@@ -136,24 +136,24 @@ request → requirements → work-unit → claim → behavior-contract
 ```
 
 Cross-cutting: research-record feeds in via accepts edges where needed.
-Research-record may optionally be scoped to a work unit when the research
-is specific to a work unit.
+Research-record may optionally be scoped to a work-unit when the research
+is specific to a work-unit.
 
 ## Work-Unit-Scoped Evaluation
 
 The manifest declares type-level edges. Runa evaluates triggers per work
 unit at runtime, using the `work_unit` field to partition the workspace.
 
-When multiple work units are active simultaneously, plan triggering on
-`on_artifact("behavior-contract")` fires for a specific work unit's
+When multiple work-units are active simultaneously, plan triggering on
+`on_artifact("behavior-contract")` fires for a specific work-unit's
 behavior-contract — not every behavior-contract in the workspace. The
 manifest doesn't express this scoping. Runa computes it from artifact
 content.
 
 Planning-phase artifacts (request, requirements, work-unit) predate work-unit
 identity and are not partitioned this way. Research-record is always
-scoped by topic; optionally scoped by work unit when research is
-specific to a work unit.
+scoped by topic; optionally scoped by work-unit when research is
+specific to a work-unit.
 
 ## Consolidated Manifest
 
@@ -362,8 +362,8 @@ declare it in `may_produce` so that, when an agent's research skill
 emits one mid-session, runa exposes a tool to validate and persist it.
 See "Runtime Layers" and "Skill-Produced Artifacts and the `may_produce`
 Bridge" below for the full mechanism. Research-record may carry
-`work_unit` when the research is specific to a work unit; when it does,
-runa can scope it to the relevant work unit's context. When `work_unit`
+`work_unit` when the research is specific to a work-unit; when it does,
+runa can scope it to the relevant work-unit's context. When `work_unit`
 is absent, the research is cross-cutting. This is the two-population
 principle in action: skills produce artifacts that runa validates
 but doesn't trigger on.
@@ -619,14 +619,14 @@ progressive authoring — are design directions, not current behavior.*
 
 The MCP server is not just an artifact I/O layer. It is the agent's
 entire interface to the methodology. The agent doesn't know about runa,
-manifests, schemas, work units, artifact types, or the topology. It
+manifests, schemas, work-units, artifact types, or the topology. It
 has tools. The tools guide the work. The shape of the tools IS the
 methodology.
 
 ### The agent knows nothing about infrastructure
 
 The MCP server can infer from execution context:
-- **work_unit** — which work unit is being worked
+- **work_unit** — which work-unit is being worked
 - **protocol** — which protocol is executing
 - **artifact type** — what this protocol produces
 - **available context** — what requires/accepts artifacts exist
@@ -667,7 +667,7 @@ amend, flag gaps — not data assembly.
 Every tool call is a structured event. The MCP server sits at the
 chokepoint between agent and system. This enables:
 
-- **Telemetry** — which agent, which protocol, which work unit, what
+- **Telemetry** — which agent, which protocol, which work-unit, what
   was produced, when, whether it validated. Without the agent doing
   anything extra.
 - **Cost tracking** — tool calls correlated with LLM calls. Cost per
@@ -698,15 +698,15 @@ The topology has two specification artifacts at different scales:
 
 - **requirements** (produced by survey) — declares what needs doing at
   any scope: a new tool, a feature, a system change, a migration.
-  Consumed by decompose, which breaks it into work units.
+  Consumed by decompose, which breaks it into work-units.
   This is the project-level specification.
 
 - **behavior-contract** (produced by specify) — declares how a single
-  work unit should behave as Given/When/Then scenarios. This is the
+  work-unit should behave as Given/When/Then scenarios. This is the
   implementation-level specification.
 
 Decompose bridges the two levels. It consumes requirements and produces
-work-unit artifacts — the work units that take picks up.
+work-unit artifacts — the work-units that take picks up.
 
 ## Two Phases
 
@@ -732,14 +732,14 @@ tracks and threads by work-unit identity.
 
 ### decompose
 
-- **requires:** requirements. Cannot break work into work units without
+- **requires:** requirements. Cannot break work into work-units without
   knowing what the work is.
 - **accepts:** research-record. Research may inform decomposition decisions.
 - **trigger:** `on_artifact("requirements")`
 
 ### take
 
-- **requires:** work-unit. A work unit whose dependencies are satisfied.
+- **requires:** work-unit. A work-unit whose dependencies are satisfied.
 - **accepts:** nothing. Planning-phase artifacts feed decompose, not
   take. The work-unit artifact is the bridge.
 - **trigger:** `on_artifact("work-unit")`
@@ -747,7 +747,7 @@ tracks and threads by work-unit identity.
 ### specify
 
 - **requires:** claim, work-unit. The claim provides work-unit identity.
-  The work unit provides acceptance criteria that specify transforms into
+  The work-unit provides acceptance criteria that specify transforms into
   behavioral scenarios — traceability requires seeing the criteria.
 - **accepts:** research-record. Research may inform behavioral scenarios,
   but specify can produce valid GWT scenarios without it.
@@ -773,7 +773,7 @@ tracks and threads by work-unit identity.
 
 - **requires:** behavior-contract, test-evidence, work-unit. Verify checks
   behavior coverage against the contract using test results as evidence.
-  The work unit is required because verify must detect acceptance criteria
+  The work-unit is required because verify must detect acceptance criteria
   that have no scenario coverage — gaps that only the original criteria
   list reveals.
 - **accepts:** nothing currently identified.
@@ -826,7 +826,7 @@ Not from a guess about what the producer might write.
 **Execution-phase artifacts** (claim through completion-record) carry a
 `work_unit` field — the work-unit reference that threads them together. Runa
 uses this to scope context injection: when plan activates, it delivers
-the behavior-contract for this work unit, not every behavior-contract in
+the behavior-contract for this work-unit, not every behavior-contract in
 the workspace.
 
 **Planning-phase artifacts** (request, requirements, work-unit) do not carry
@@ -862,7 +862,7 @@ that survey has something to work from.
 
 **Consumer:** decompose.
 **What decompose needs:** understand the full scope, identify natural seams
-for breaking work into work units, respect constraints and
+for breaking work into work-units, respect constraints and
 dependencies when drawing boundaries.
 
 This is a software requirements specification. Its structure follows
@@ -881,12 +881,12 @@ decomposition.
 ### work-unit
 
 **Consumer:** take.
-**What take needs:** understand the work unit being claimed — what to do,
+**What take needs:** understand the work-unit being claimed — what to do,
 how to know it's done, and whether it's ready to start.
 
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
-| title | string | yes | What this work unit is |
+| title | string | yes | What this work-unit is |
 | description | string | yes | What needs doing |
 | acceptance_criteria | array of strings | yes | Discrete, verifiable conditions for "done" |
 | scope | array of strings | no | In-scope boundaries for the session frame |
@@ -900,7 +900,7 @@ linkage use `<short-slug>`. Dependency references use those exact
 
 ### Traceability Thread
 
-Acceptance criteria on the work unit are the high-level "done" statements.
+Acceptance criteria on the work-unit are the high-level "done" statements.
 Behavior-contract scenarios are the precise behavioral refinement of
 those criteria into Given/When/Then. The traceability thread runs the
 full length of the execution chain:
@@ -923,15 +923,15 @@ Schema implications:
 ### claim
 
 **Consumer:** specify (and all downstream protocols via work_unit threading).
-**What specify needs:** the work-unit identity and a reference to the work unit
+**What specify needs:** the work-unit identity and a reference to the work-unit
 being implemented. The claim is the threading root — thin by design.
 
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
-| work_unit | string (work-unit ref) | yes | The work unit being claimed — threads all downstream artifacts |
-| scope | string | yes | Brief statement of what's being claimed from the work unit |
+| work_unit | string (work-unit ref) | yes | The work-unit being claimed — threads all downstream artifacts |
+| scope | string | yes | Brief statement of what's being claimed from the work-unit |
 
-The claim does not duplicate acceptance criteria from the work unit. Runa's
+The claim does not duplicate acceptance criteria from the work-unit. Runa's
 context injection delivers a protocol's own requires and accepts — not
 transitive dependencies. Protocols that need the acceptance criteria
 must declare the work-unit artifact in their own edges.
@@ -939,7 +939,7 @@ must declare the work-unit artifact in their own edges.
 ### Context Injection Is Not Transitive
 
 Runa injects a protocol's declared requires and accepts instances. It
-does not inject transitive dependencies. If specify needs the work unit
+does not inject transitive dependencies. If specify needs the work-unit
 artifact (to read acceptance criteria), specify must declare it in its
 own edges. The claim alone is not sufficient — it carries the work-unit
 reference but not the work-unit content.
@@ -957,7 +957,7 @@ criteria, structured as executable Given/When/Then.
 The existing schema had the right core — title and GWT scenarios. Two
 changes from this design: each scenario now carries a `criterion`
 reference for traceability, and the common `work_unit` field threads it
-to the work unit.
+to the work-unit.
 
 The existing `metadata` block (produced_by, date) is eliminated.
 Runa knows the producing protocol from the manifest. It tracks
@@ -966,7 +966,7 @@ already knows. By sufficiency, it has no place in the schema.
 
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
-| work_unit | string (work-unit ref) | yes | Common envelope — threads to work unit |
+| work_unit | string (work-unit ref) | yes | Common envelope — threads to work-unit |
 | title | string | yes | Human-readable title for the contract |
 | scenarios | array of scenario | yes (min 1) | Behavioral scenarios |
 
@@ -1067,7 +1067,7 @@ submit handles the PR. Those fields belonged to a different flow.
 
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
-| criterion | string | yes | Acceptance criterion from the work unit |
+| criterion | string | yes | Acceptance criterion from the work-unit |
 | status | enum: covered, partial, uncovered | yes | Coverage status |
 | scenarios | array of strings | no | Scenario names that cover this criterion |
 | failures | array of strings | no | Scenario names that failed for this criterion |
@@ -1104,7 +1104,7 @@ contains. This is the artifact representation of the PR.
 ### completion-record
 
 **Consumer:** none (terminal artifact — archival record).
-**What it captures:** the final state of the work unit. This is a summary
+**What it captures:** the final state of the work-unit. This is a summary
 artifact — the structured enforcement lives upstream in completion-evidence.
 The record distills the conclusion.
 
@@ -1121,11 +1121,11 @@ The record distills the conclusion.
 **Consumers:** specify (accepts), plan (accepts), survey (accepts),
 decompose (accepts).
 **What consumers need:** research findings and their sources, scoped
-by topic. May serve multiple work units when cross-cutting, or be
-scoped to a specific work unit via the optional `work_unit` field.
+by topic. May serve multiple work-units when cross-cutting, or be
+scoped to a specific work-unit via the optional `work_unit` field.
 
 Research-record is always scoped by topic. It optionally carries
-`work_unit` when the research is specific to a work unit — for example,
+`work_unit` when the research is specific to a work-unit — for example,
 researching a particular library for a particular implementation task.
 When `work_unit` is absent, the research is cross-cutting and available
 to any protocol that accepts it. It belongs to neither the planning nor
@@ -1137,7 +1137,7 @@ principle. Runa tracks timestamps from filesystem state.
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
 | topic | string | yes | What was researched (kebab-case slug) |
-| work_unit | string | no | Optional work-unit reference — scopes research to a work unit |
+| work_unit | string | no | Optional work-unit reference — scopes research to a work-unit |
 | findings | array of strings | yes (min 1) | Key findings |
 | sources | array of source | yes (min 1) | Sources consulted |
 

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -55,7 +55,7 @@ together with the code it explains. Submit is gated on documentation-record.
 | Protocol  | Produces | Purpose of capstone |
 |-----------|----------|---------------------|
 | survey    | requirements | Declaration of what needs doing, at any scope |
-| decompose | work-unit | Work units decomposed from requirements |
+| decompose | work-unit | Work-units decomposed from requirements |
 | take      | claim | Root node: work-unit identity and orientation |
 | specify   | behavior-contract | Behavioral scenarios for the work-unit |
 | plan      | implementation-plan | Design decisions informing execution |
@@ -891,7 +891,7 @@ how to know it's done, and whether it's ready to start.
 | acceptance_criteria | array of strings | yes | Discrete, verifiable conditions for "done" |
 | scope | array of strings | no | In-scope boundaries for the session frame |
 | out_of_scope | array of strings | no | Explicit nearby exclusions |
-| dependencies | array of work-unit refs | no | Work units that must be complete before this starts, referenced by `instance_id` |
+| dependencies | array of work-unit refs | no | Work-units that must be complete before this starts, referenced by `instance_id` |
 
 Tracker-backed work-units use `instance_id` convention
 `work-unit-<N>-<short-slug>` on first delivery; work-units without tracker
@@ -1086,7 +1086,7 @@ The existing schema structure survives — it tracks the right things.
 | work_unit | string (work-unit ref) | yes | Common envelope |
 | updated_docs | array of strings | yes | Documentation files updated in this change |
 | verified_accurate_docs | array of strings | yes | Documentation reviewed and confirmed accurate |
-| tracking_work_units | array of strings | yes | Work units filed for documentation follow-up |
+| tracking_work_units | array of strings | yes | Work-units filed for documentation follow-up |
 
 ### patch
 

--- a/docs/architecture/work-unit-model.md
+++ b/docs/architecture/work-unit-model.md
@@ -4,14 +4,14 @@ The work-unit graph is the persistence layer across sessions. Agent sessions end
 
 ## Definitions
 
-- **Work-unit graph**: the set of open work units and their dependency edges. It is the working memory of the project — not a backlog to be groomed, but the live map of what remains and what blocks what.
-- **Unblocked**: a work unit whose hard dependencies are all closed. Transitively unblocked means every ancestor in the dependency chain is closed.
-- **Execution layer**: a set of work units that share no mutual dependencies and can be worked in parallel once their shared ancestors are closed. Layer 0 has no dependencies; layer 1 depends only on layer 0; and so on.
-- **Session-sized**: a work unit that one agent can complete — from reading context through passing verification — in a single focused session.
+- **Work-unit graph**: the set of open work-units and their dependency edges. It is the working memory of the project — not a backlog to be groomed, but the live map of what remains and what blocks what.
+- **Unblocked**: a work-unit whose hard dependencies are all closed. Transitively unblocked means every ancestor in the dependency chain is closed.
+- **Execution layer**: a set of work-units that share no mutual dependencies and can be worked in parallel once their shared ancestors are closed. Layer 0 has no dependencies; layer 1 depends only on layer 0; and so on.
+- **Session-sized**: a work-unit that one agent can complete — from reading context through passing verification — in a single focused session.
 
 ## State Source Rule
 
-State is determined by reading GitHub issue content, not forge metadata (labels, columns). A work unit's state is what its issue body and comments say it is.
+State is determined by reading GitHub issue content, not forge metadata (labels, columns). A work-unit's state is what its issue body and comments say it is.
 
 ## Work-Unit Working States
 
@@ -20,7 +20,7 @@ State is determined by reading GitHub issue content, not forge metadata (labels,
 | draft       | Intent captured, not yet agent-executable     | GitHub issue created without full criteria | Criteria, scope, and size filled in |
 | ready       | Agent-executable and unblocked                | All fields complete, deps closed   | Session claims it                   |
 | in-progress | Active session is working on it               | Session declares goal against it   | Session closes or blocks            |
-| blocked     | Waiting on one or more open dependencies      | Dependency discovered or reopened  | All blocking work units closed      |
+| blocked     | Waiting on one or more open dependencies      | Dependency discovered or reopened  | All blocking work-units closed      |
 | closed      | All acceptance criteria verified              | Verified and merged                | Reopened for regression             |
 | stale       | No progress for 14+ days while still open     | Clock expires                      | Resumed, split, or closed as wont-fix |
 
@@ -46,7 +46,7 @@ Epics with 4+ tasks include a dependency graph in two representations:
 
 ## Graph Maintenance
 
-- **Stale detection**: flag work units with no progress comment for 14+ days. Resolution: resume, split into smaller work, or close as wont-fix with rationale.
-- **Splitting**: when an in-progress work unit exceeds session size, split remaining work into new work units and close the original with a pointer.
-- **Merging**: when two work units converge on the same deliverable, merge into one and close the duplicate with a cross-reference.
-- **Validation after mutation**: after adding, closing, splitting, or merging work units, verify the graph has no orphaned dependencies or cycles.
+- **Stale detection**: flag work-units with no progress comment for 14+ days. Resolution: resume, split into smaller work, or close as wont-fix with rationale.
+- **Splitting**: when an in-progress work-unit exceeds session size, split remaining work into new work-units and close the original with a pointer.
+- **Merging**: when two work-units converge on the same deliverable, merge into one and close the duplicate with a cross-reference.
+- **Validation after mutation**: after adding, closing, splitting, or merging work-units, verify the graph has no orphaned dependencies or cycles.

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -2,29 +2,29 @@
 name: decompose
 description: >-
   Transfer problem understanding across context boundaries through well-formed
-  work units. Produce `work-unit` artifacts: creating, decomposing, refining,
+  work-units. Produce `work-unit` artifacts: creating, decomposing, refining,
   and triaging. Close-state review happens here; the close itself is performed
   by `land`.
 ---
 
 # Work-Unit Craft
 
-A work unit transfers problem understanding across a context boundary — from the
+A work-unit transfers problem understanding across a context boundary — from the
 person who sees the problem to the agent who will solve it. The agent has no
 access to your context, your codebase familiarity, or your unstated assumptions.
-Everything it needs must be in the work unit.
+Everything it needs must be in the work-unit.
 
 For concrete templates, see [references/templates.md](references/templates.md).
 For the work-unit state model and dependency graph format, see
 [`work-unit-model.md`](../../docs/architecture/work-unit-model.md).
-For first-principles constraint verification before framing work units, use
+For first-principles constraint verification before framing work-units, use
 `reckon`.
 
 ## The Central Discipline
 
-**Work units describe what must be true, not how to get there.**
+**Work-units describe what must be true, not how to get there.**
 
-A work unit that says "Replace X with Y" has already made the design decision. If
+A work-unit that says "Replace X with Y" has already made the design decision. If
 that decision is wrong, the implementing agent will faithfully execute the wrong
 solution — and the further the prescription travels through decomposition,
 planning, and implementation, the harder it is to catch. The work-unit author's job
@@ -38,13 +38,13 @@ most common failure mode in work-unit-driven development.
 
 ### Scope and sizing
 
-**One concern per work unit.** A work unit that touches unrelated modules forces the
+**One concern per work-unit.** A work-unit that touches unrelated modules forces the
 implementer to hold multiple problem contexts simultaneously and makes partial
 completion ambiguous. When you notice scope creeping across boundaries, split.
 
-**Session-sized work.** Each task work unit should be completable in one focused
+**Session-sized work.** Each task work-unit should be completable in one focused
 agent session — from reading context through passing verification. Oversized
-work units cause context loss mid-execution; undersized work units create coordination
+work-units cause context loss mid-execution; undersized work-units create coordination
 overhead that exceeds the work itself.
 
 ### Acceptance criteria
@@ -75,23 +75,23 @@ For epics with 4+ tasks, include a dependency graph showing execution layers
 (see [`work-unit-model.md`](../../docs/architecture/work-unit-model.md) § Dependency
 Graph Format) so implementers can parallelize independent work.
 
-### The work unit as contract
+### The work-unit as contract
 
-**Must stand alone without external context.** A work unit is a contract, not a
+**Must stand alone without external context.** A work-unit is a contract, not a
 conversation. The implementer may be a different agent, in a different session,
-with no access to the discussion that produced the work unit. Summary states what
+with no access to the discussion that produced the work-unit. Summary states what
 and why. Scope names concrete files or modules. Criteria are binary pass/fail.
-Task work units reference their parent epic or milestone so the work has context
-in the work-unit graph. If the work unit requires reading a Slack thread or "seeing
+Task work-units reference their parent epic or milestone so the work has context
+in the work-unit graph. If the work-unit requires reading a Slack thread or "seeing
 the earlier discussion" to understand, it is incomplete.
 
 ## Procedures
 
 ### create-work-unit
 
-1. Reckon constraints. Before framing the work unit, establish what is
+1. Reckon constraints. Before framing the work-unit, establish what is
    actually needed — verified constraints, not inherited assumptions.
-   If the work unit originated from an existing solution or implementation
+   If the work-unit originated from an existing solution or implementation
    detail, separate the need from the approach.
 2. Classify work-unit type (`task`, `epic`, `bug`, `spike`).
 3. Write summary: what needs to exist and why. Not how.
@@ -117,7 +117,7 @@ work-unit bodies against template schemas.
 5. Build dependency graph (Mermaid `graph TD` + layered text summary —
    see [`work-unit-model.md`](../../docs/architecture/work-unit-model.md) § Dependency Graph Format).
 6. Size-check each candidate: split if oversized, merge if trivial.
-7. Create task work units in topological order (lowest execution layer first).
+7. Create task work-units in topological order (lowest execution layer first).
 8. Create or update parent epic with task checklist and dependency graph.
 
 ### define-task-boundary
@@ -133,7 +133,7 @@ A well-bounded task has:
 
 ### refine-work-unit
 
-1. Reckon the work unit's framing. Before editing, verify that the problem
+1. Reckon the work-unit's framing. Before editing, verify that the problem
    statement reflects actual need — not an inherited solution dressed as
    a requirement.
 2. Diagnose: vague summary, missing scope, untestable criteria, implicit
@@ -144,17 +144,17 @@ A well-bounded task has:
 
 ### triage-work-units
 
-1. Refine non-ready work units first.
+1. Refine non-ready work-units first.
 2. Build dependency graph for the backlog.
 3. Create topological execution layers.
 4. Apply labels (`size:*`, module/area).
-5. Flag stale work units (no progress for 14+ days) for review. Resolution:
+5. Flag stale work-units (no progress for 14+ days) for review. Resolution:
    resume, split, or close as wont-fix with rationale.
 
 ### review-work-unit-closure
 
 1. Verify all acceptance criteria against implementation.
-2. Check scope deviations — split unintended extra work into new work units.
+2. Check scope deviations — split unintended extra work into new work-units.
 3. Update parent epic checklist.
 
 The close event itself — marking the work-unit closed in the forge tracker —
@@ -229,7 +229,7 @@ the agent supplies the schema fields shown above, and runa does not inject
 
 ## Triggers
 
-- creating or refining work units
+- creating or refining work-units
 - decomposing large goals into executable work
 - triaging or prioritizing a backlog
 - reviewing work-units before closure
@@ -238,7 +238,7 @@ the agent supplies the schema fields shown above, and runa does not inject
 ## Corruption Modes
 
 - `implicit-how`: implementation prescription leaks into scope or criteria.
-  The work unit says "use library X" or "replace A with B" instead of describing
+  The work-unit says "use library X" or "replace A with B" instead of describing
   the required end state.
   *Recognition: read scope and criteria aloud — if they name tools, patterns,
   or implementation steps rather than observable outcomes, prescription has
@@ -260,11 +260,11 @@ the agent supplies the schema fields shown above, and runa does not inject
   *Recognition: if you cannot state the epic's done condition in one sentence,
   it is too broad.*
 
-- `premature-work-units`: filing detailed task work units for work that depends on
-  unresolved design decisions. The work units will need rewriting when the
+- `premature-work-units`: filing detailed task work-units for work that depends on
+  unresolved design decisions. The work-units will need rewriting when the
   decisions land.
-  *Recognition: if the work unit's scope would change based on an open question,
-  the question must be answered first (spike work unit).*
+  *Recognition: if the work-unit's scope would change based on an open question,
+  the question must be answered first (spike work-unit).*
 
 - `graph-omission`: an epic with 4+ tasks has no dependency graph or layered
   execution order, forcing implementers to discover sequencing by reading

--- a/protocols/document/PROTOCOL.md
+++ b/protocols/document/PROTOCOL.md
@@ -20,7 +20,7 @@ Ensure documentation remains accurate and tracked as code evolves.
 - `drift-is-debt`: stale documentation compounds. Each drifted doc trains
   readers to distrust all docs, making accurate docs worthless too.
 - `same-pr`: documentation updates ship in the same PR as the code change that
-  caused them. If deeper work is needed, create a tracking work unit rather than
+  caused them. If deeper work is needed, create a tracking work-unit rather than
   leaving drift untracked.
 
 ## Requirements
@@ -28,7 +28,7 @@ Ensure documentation remains accurate and tracked as code evolves.
 - `changelog-before-land`: user-visible changes include a CHANGELOG entry
   before landing so consumers can understand what changed without reading code.
 - `docs-in-acceptance-criteria`: user-facing changes include documentation
-  updates as explicit acceptance criteria in the work unit.
+  updates as explicit acceptance criteria in the work-unit.
 
 ## Procedures
 
@@ -51,7 +51,7 @@ Fires after verification, before `submit`.
    - `missing` — should exist but does not (creation required)
    - `obsolete` — references removed functionality (rewrite or delete)
 4. **Update or track.** Update drifted or missing docs in the same PR. If
-   deeper work is needed, create a tracking work unit with `decompose`.
+   deeper work is needed, create a tracking work-unit with `decompose`.
 5. **Audit numeric claims.** Replace brittle counts with source-of-truth
    references, or explicitly verify and trace any remaining dynamic numbers.
 6. **Apply audience test.** For each updated or created doc: "Would the
@@ -80,7 +80,7 @@ When encountering existing documentation:
    `missing`, or `obsolete` by comparing claims against actual code behavior.
 2. Prioritize fixes: `missing` critical docs first, then `drifted`, then
    `obsolete`.
-3. Create work units for each fix using `decompose`.
+3. Create work-units for each fix using `decompose`.
 
 ## Triggers
 
@@ -118,7 +118,7 @@ When encountering existing documentation:
 - `specify`: behavior contracts are the authoritative source for what public
   behavior must be reflected in documentation.
 - `decompose`: user-facing changes include documentation expectations in work-unit
-  acceptance criteria; create tracking work units here when review finds deeper
+  acceptance criteria; create tracking work-units here when review finds deeper
   follow-up work.
 - `implement`: inline documentation changes alongside implementation; review checks
   whether those claims still match behavior.

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -3,7 +3,7 @@ name: land
 description: >-
   One-word closeout: land this branch. Closing ceremony verifies completion and
   documentation before mechanical merge. Merge to main, sync, delete feature
-  branch, close satisfied work units, comment progress on partial work units.
+  branch, close satisfied work-units, comment progress on partial work-units.
   Trigger on: 'land', 'land this', 'merge and close', 'ship it'.
 ---
 
@@ -27,7 +27,7 @@ Phase 0 (gather, verify, review, seal) is to `land` what Phase 0 (orient,
 observe, frame, banish) is to `take`. The opening ceremony prepares the agent
 for work; the closing ceremony prepares the work for delivery.
 
-Do not stop after merge — stopping leaves branches dangling and work units unclosed. The full sequence is atomic: ceremony through close.
+Do not stop after merge — stopping leaves branches dangling and work-units unclosed. The full sequence is atomic: ceremony through close.
 
 Do not ask for confirmation before landing. Invoking `land` IS the user's approval to execute the entire workflow.
 
@@ -137,7 +137,7 @@ status, and any action taken.
 
 Gate check before mechanical merge. All three conditions must hold:
 
-1. Verification passed or all linked work units classified (Phase 0b complete)
+1. Verification passed or all linked work-units classified (Phase 0b complete)
 2. Documentation reviewed — drift fixed or tracked (Phase 0c complete)
 3. CHANGELOG entry present if changes are user-visible (Phase 0a flagged)
 
@@ -160,7 +160,7 @@ Examine the branch's commit history to decide whether to squash on merge. Use `g
 **Decision framework** (apply judgment, not mechanical rules):
 
 - **Squash when** the history is iterative refinement — a feature commit followed by fix-ups that revise the same change: majority of commits are fixes of the initial change, commits touch the same files, all share the same scope/component.
-- **Preserve when** commits represent distinct work units — single-commit branches, different components/scopes, multi-step features where each step is meaningful independently.
+- **Preserve when** commits represent distinct work-units — single-commit branches, different components/scopes, multi-step features where each step is meaningful independently.
 
 **When squashing**, draft a consolidated commit message: use the conventional-commit prefix/scope from the initial commit, summarize the consolidated change, don't enumerate squashed commits.
 
@@ -204,7 +204,7 @@ Delete any remaining branch references:
 
 #### 1e. Comment and close GitHub issue(s) (GitHub-issue-linked branches only)
 
-If no linked work units were provided or inferred, skip this step. Where
+If no linked work-units were provided or inferred, skip this step. Where
 `gh` is unavailable, skip this step and record the would-have-been-closed
 work-unit IDs in the `completion-record` for manual follow-up.
 
@@ -229,7 +229,7 @@ Then close: `gh issue close <number> --reason completed`.
 > **Remaining:**
 > - criterion 3
 
-If any comment or close operation fails, continue processing remaining work units, then report which operations failed.
+If any comment or close operation fails, continue processing remaining work-units, then report which operations failed.
 
 #### 1f. Deliver `completion-record`
 
@@ -283,7 +283,7 @@ Report the final state including:
 - If branch deletion fails after successful merge: warn about the deletion failure and continue to GitHub issue close/comment steps. The code is safely on `main`; branch cleanup is not a prerequisite for issue closure.
 - If GitHub issue comment/close API fails for one GitHub issue: continue processing remaining GitHub issues, then report failed GitHub issue number(s) explicitly.
 - If acceptance criteria evaluation fails in Phase 0b (GitHub issue fetch error, criteria unparseable): the inline handling applies — treat the GitHub issue as partial, log a warning. Partial classification does not block the seal; it flows through to Phase 1e where the GitHub issue is left open with a progress comment.
-- **Documentation drift blocks the seal.** Drift discovered in Phase 0c must be fixed directly or tracked via a work unit before the seal can pass. Do not proceed with unresolved drift.
+- **Documentation drift blocks the seal.** Drift discovered in Phase 0c must be fixed directly or tracked via a work-unit before the seal can pass. Do not proceed with unresolved drift.
 - If no GitHub issue numbers are available: do not prompt for GitHub issue IDs during `land`; proceed with merge/sync/cleanup and report a no-GitHub-issue landing.
 - If commit history evaluation is uncertain: default to preserve (`--no-ff`). Squashing is an optimization; when in doubt, keep the original history.
 
@@ -300,4 +300,4 @@ Report the final state including:
   acceptance criteria and verify completion evidence before merge
 - `document`: invoked during Phase 0c for documentation-review — confirms
   documentation reflects the changes being landed
-- `decompose` for work-unit lifecycle patterns and tracking work units from doc review
+- `decompose` for work-unit lifecycle patterns and tracking work-units from doc review

--- a/protocols/plan/PROTOCOL.md
+++ b/protocols/plan/PROTOCOL.md
@@ -59,7 +59,7 @@ Explore the codebase to build a concrete understanding of current state.
 Without this, plans describe imagined systems that collide with the actual
 code.
 
-1. Read the work unit, task, or request to identify what must change.
+1. Read the work-unit, task, or request to identify what must change.
 2. Search for relevant files: entrypoints, configs, schemas, types,
    manifests, docs, and existing implementations of similar behavior.
 3. Trace the code paths that the change will touch or interact with.
@@ -72,7 +72,7 @@ Clarify what the change must achieve and what is out of scope. Without
 intent boundaries, every approach looks equally valid and trade-offs
 cannot be evaluated.
 
-1. State the goal and success criteria derived from the work unit and
+1. State the goal and success criteria derived from the work-unit and
    exploration.
 2. Identify in-scope and out-of-scope boundaries.
 3. Surface constraints from the codebase: dependencies, API contracts,
@@ -163,7 +163,7 @@ it in the artifact store.
   the problem space itself is unclear.
 - `specify`: behavior contract — provides the behavior statements the plan
   must implement.
-- `take`: work initiation — selects which work unit to plan for and prepares the session.
+- `take`: work initiation — selects which work-unit to plan for and prepares the session.
 - `decompose`: executable work-unit decomposition and work-unit quality —
-  turns a decision-complete design into agent-executable work units with
+  turns a decision-complete design into agent-executable work-units with
   binary acceptance criteria.

--- a/protocols/survey/PROTOCOL.md
+++ b/protocols/survey/PROTOCOL.md
@@ -40,7 +40,7 @@ exigence before separating descriptive truth from normative need. You cannot
 recommend work before rejecting the frames that would distort it.
 
 The depth of each step scales with the territory. A tiny repo with three open
-work units and a clear README may need only a light survey. An unfamiliar codebase
+work-units and a clear README may need only a light survey. An unfamiliar codebase
 with no documentation, contested boundaries, or weak evidence needs a deeper
 one. The requirement is honest coverage of the territory at hand, not ritual
 completion of every step at maximum depth.
@@ -70,7 +70,7 @@ actually examined.
 
 ### `descriptive-state`
 
-Observed facts about what exists now: code, docs, work units, workflows,
+Observed facts about what exists now: code, docs, work-units, workflows,
 architecture, operator signals, and evidence gathered from the territory.
 
 This forces observation before prescription. It resists fantasy, premature
@@ -110,7 +110,7 @@ the first plausible frame must be the right one.
 
 ### `recommended-work`
 
-The bounded work package that `decompose` should turn into executable work units.
+The bounded work package that `decompose` should turn into executable work-units.
 
 This forces translation from assessment into action. It resists purely
 descriptive reporting that never crosses into an actionable body of work.
@@ -146,7 +146,7 @@ else is safe to claim.
 
 ### observe-descriptive-state
 
-Gather evidence about what exists. Read the relevant code, docs, work units,
+Gather evidence about what exists. Read the relevant code, docs, work-units,
 artifacts, and system signals. Use `research` when local evidence is
 insufficient.
 
@@ -181,7 +181,7 @@ Ask:
   exists?
 - Am I projecting a familiar repo pattern onto this one?
 - Am I trying to fix everything?
-- Am I retreating to the safest visible surface work unit?
+- Am I retreating to the safest visible surface work-unit?
 
 Record the alternatives that fail this scrutiny and why they were rejected.
 
@@ -228,7 +228,7 @@ protocols.
 
 ## Corruption Modes
 
-**Backlog anchoring.** The assessment merely restates the open work units as "what
+**Backlog anchoring.** The assessment merely restates the open work-units as "what
 needs doing."
 *Recognition:* Remove the work-unit list and the survey says nothing different.
 
@@ -243,7 +243,7 @@ this kind of repo instead of reading this repo.
 assessment would still read the same.
 
 **Scope collapse.** The survey either tries to fix everything or picks only the
-nearest surface work unit.
+nearest surface work-unit.
 *Recognition:* The chosen exigence is either unbounded or trivially local.
 
 **Descriptive-normative confusion.** What exists is reported as if it were what
@@ -261,6 +261,6 @@ rejection, or judgment.
   for deriving normative need.
 - `research`: evidence gathering when local inspection is insufficient.
 - `decompose`: consumes `requirements` and turns the selected work into executable
-  work units.
+  work-units.
 - `take`: starts a session once the work-unit graph reflects the work chosen
   through survey.

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -181,15 +181,15 @@ files, construct filenames, or supply `work_unit`.
 Brief definitions for self-contained use. See
 [`work-unit-model.md`](../../docs/architecture/work-unit-model.md) for the full treatment.
 
-- **Work-unit graph**: the set of open work units and their dependency edges — the live
+- **Work-unit graph**: the set of open work-units and their dependency edges — the live
   map of what remains and what blocks what.
-- **Unblocked**: a work unit whose hard dependencies are all closed.
-- **Execution layer**: a set of work units that share no mutual dependencies and can
+- **Unblocked**: a work-unit whose hard dependencies are all closed.
+- **Execution layer**: a set of work-units that share no mutual dependencies and can
   be worked in parallel once their shared ancestors are closed. Layer 0 has no
   dependencies; layer 1 depends only on layer 0; and so on.
-- **Session-sized**: a work unit that one agent can complete — from reading context
+- **Session-sized**: a work-unit that one agent can complete — from reading context
   through passing verification — in a single focused session.
-- **Work-unit batch**: 2-3 cohesive work units addressed together when they share a
+- **Work-unit batch**: 2-3 cohesive work-units addressed together when they share a
   concern boundary and their combined scope is still session-sized.
 
 ## Operating Principles

--- a/skills/orient/SKILL.md
+++ b/skills/orient/SKILL.md
@@ -41,13 +41,13 @@ Five stages, in dependency order. Each produces what the next consumes.
 
 2. **Define behavior.** `specify` defines the behavior contract in Given/When/Then scenarios. This contract threads through every subsequent stage.
 
-3. **Decompose.** Converge to a decision-complete design (`plan`), break the design into agent-executable work units (`decompose`), and initiate the work session (`take`).
+3. **Decompose.** Converge to a decision-complete design (`plan`), break the design into agent-executable work-units (`decompose`), and initiate the work session (`take`).
 
 4. **Execute and verify.** Implement through RED-GREEN-REFACTOR (`implement`), review documentation accuracy with `document`, verify behavior-level evidence before claiming done (`verify`), and package verified changes into a PR (`submit`). When a plan contains independent tasks, dispatch fresh subagents for each to keep execution context clean — stale context from earlier tasks pollutes later ones. Match subagent model to task complexity: use cheaper/faster models for straightforward work, reserve the most capable model for subtle or cross-cutting changes.
 
 5. **Land.** `land` closes the loop: merge, cleanup, behavior coverage record, documentation coverage status, and work-unit closure.
 
-The stages are in order but not all required for every piece of work. Enter the topology where the work needs you. A bug fix with an existing work unit enters at Execute. A new capability enters at Frame. The constraint is sequence — you can't land before executing — not completeness.
+The stages are in order but not all required for every piece of work. Enter the topology where the work needs you. A bug fix with an existing work-unit enters at Execute. A new capability enters at Frame. The constraint is sequence — you can't land before executing — not completeness.
 
 ## Integration Principles
 
@@ -65,7 +65,7 @@ These thread across the topology. They aren't phases — they're disciplines tha
 
 **Root cause before fixes.** When a test fails or behavior is unexpected, do not guess. Investigate root cause before proposing any fix. `debug` provides the investigation methodology — a cross-cutting discipline that fires at any stage, not only during execution. Once root cause is established, `implement` fix-bug owns the execution cycle. After 3 failed fix attempts, stop fixing and invoke `reckon` via the Skill tool to question the architecture.
 
-**Introduce third force on friction.** Friction is a two-force collision: task momentum vs obstacle. Routing around is the collapsed triad — both forces lose. When operational friction appears — a missing tool, broken config, stale convention, undocumented requirement — stop and introduce the reconciling move: resolve it structurally before continuing. `resolve` provides the assessment methodology and scope guidance. Friction that exceeds side-quest scope becomes a follow-up work unit via `decompose`. Unresolved friction compounds.
+**Introduce third force on friction.** Friction is a two-force collision: task momentum vs obstacle. Routing around is the collapsed triad — both forces lose. When operational friction appears — a missing tool, broken config, stale convention, undocumented requirement — stop and introduce the reconciling move: resolve it structurally before continuing. `resolve` provides the assessment methodology and scope guidance. Friction that exceeds side-quest scope becomes a follow-up work-unit via `decompose`. Unresolved friction compounds.
 
 For the connecting structure — artifacts, manifest edges, schemas, and protocol topology — see [`connecting-structure.md`](https://github.com/tesserine/groundwork/blob/main/docs/architecture/connecting-structure.md).
 
@@ -75,9 +75,9 @@ For the connecting structure — artifacts, manifest edges, schemas, and protoco
 
 **Behavior traceability loss.** Recognition: your tests pass but you can't name which behavior scenario each test verifies, or your completion claim says "all tests pass" without mapping results to named behaviors. Treating `specify` as a one-time preface rather than a contract that threads through execution.
 
-**Work-unit discipline failure.** Recognition: you're deciding what to work on from the conversation or your own reasoning instead of reading the work-unit graph, or you've started implementation without checking whether the work unit is blocked. The work-unit graph is the project's working memory — working from anything else means you're navigating from a snapshot that may already be stale.
+**Work-unit discipline failure.** Recognition: you're deciding what to work on from the conversation or your own reasoning instead of reading the work-unit graph, or you've started implementation without checking whether the work-unit is blocked. The work-unit graph is the project's working memory — working from anything else means you're navigating from a snapshot that may already be stale.
 
-**Sovereignty violation.** Recognition: your work unit's acceptance criteria describe steps to perform rather than outcomes to verify, or your plan reads like a script to follow rather than decisions that constrain a solution space. When this fires, agents execute instructions instead of solving problems — and prescribed steps that encode wrong assumptions propagate unchallenged.
+**Sovereignty violation.** Recognition: your work-unit's acceptance criteria describe steps to perform rather than outcomes to verify, or your plan reads like a script to follow rather than decisions that constrain a solution space. When this fires, agents execute instructions instead of solving problems — and prescribed steps that encode wrong assumptions propagate unchallenged.
 
 **Documentation drift.** Recognition: you're claiming completion but haven't checked whether the change affects any documentation, or you're aware of drifted docs but treating the update as separate future work. Drifted docs compound — each one trains readers to distrust all docs.
 

--- a/skills/orient/SKILL.md
+++ b/skills/orient/SKILL.md
@@ -53,9 +53,9 @@ The stages are in order but not all required for every piece of work. Enter the 
 
 These thread across the topology. They aren't phases — they're disciplines that engage when relevant and stay active from that point forward.
 
-**Sovereignty.** Every handoff passes outcomes (WHAT must be true), never implementation steps (HOW to achieve it). Work units define acceptance criteria, not procedure. Plans define interfaces and decisions, not copy-paste instructions. Example: GitHub issue #5 prescribed "Replace ATTRIBUTION.md with a standard NOTICE file." An implementing agent planned exactly that — but NOTICE is an Apache convention (wrong for MIT), and the file should have been deleted. This skill teaches the map; agent judgment navigates it.
+**Sovereignty.** Every handoff passes outcomes (WHAT must be true), never implementation steps (HOW to achieve it). Work-units define acceptance criteria, not procedure. Plans define interfaces and decisions, not copy-paste instructions. Example: GitHub issue #5 prescribed "Replace ATTRIBUTION.md with a standard NOTICE file." An implementing agent planned exactly that — but NOTICE is an Apache convention (wrong for MIT), and the file should have been deleted. This skill teaches the map; agent judgment navigates it.
 
-**Behavior traceability.** The behavior contract from stage 2 should be traceable at every subsequent stage. Plans link design decisions to behavior statements. Work units map acceptance criteria to behaviors. Tests correspond to named scenarios. Verification cites behavior-level evidence. Landing records what coverage shipped.
+**Behavior traceability.** The behavior contract from stage 2 should be traceable at every subsequent stage. Plans link design decisions to behavior statements. Work-units map acceptance criteria to behaviors. Tests correspond to named scenarios. Verification cites behavior-level evidence. Landing records what coverage shipped.
 
 **Documentation obligation.** User-facing changes carry documentation obligations: acceptance criteria include doc updates, completion claims include doc accuracy evidence, and landing records documentation coverage status. User-visible changes require a CHANGELOG entry.
 


### PR DESCRIPTION
## Summary

- normalize in-scope prose occurrences of `work unit` / `work units` to the canonical hyphenated `work-unit` / `work-units` form
- preserve machine-facing `work_unit` identifiers and `work-unit` artifact/type references so the change remains nomenclature-only
- add a single `[Unreleased]` changelog note for the normalization

## Changes

- update README, changelog, protocol docs, the orient skill, and architecture docs to use the canonical hyphenated prose form
- keep the change bounded to wording normalization without semantic or structural edits

## GitHub Issue(s)

Closes #242

## Test plan

- `rg -n --glob 'README.md' --glob 'CHANGELOG.md' --glob 'protocols/**' --glob 'skills/**' --glob 'docs/**' '\\bwork units?\\b'`
- `git diff --check`
