### PR TITLE
chore(schemas): vendor request schema from commons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `schemas/request.schema.json` now vendors the commons canonical request
+  schema with inline provenance metadata, and `schemas/README.md` documents
+  the vendoring discipline for methodology runtime schemas (closes #247).
 - Normalized in-scope prose to the canonical hyphenated `work-unit` /
   `work-units` spelling across protocols, skills, architecture docs, README,
   and changelog entries. Machine-facing `work_unit` identifiers remain

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,16 @@
+# Schemas
+
+This directory contains the JSON Schemas that groundwork exposes at runtime.
+Most of these schemas are methodology-private and are defined only in this
+repository.
+
+`request.schema.json` is different: it is a vendored copy of the canonical
+request contract maintained by `tesserine/commons`. Groundwork keeps the runtime
+copy here so runtime consumers still read schemas from groundwork, not from
+commons.
+
+The vendored request schema carries provenance metadata identifying the
+canonical authority, an immutable release-tag or commit-SHA URL for the
+canonical schema and prose, and the request spec's full semver. When updating
+the vendored copy, update both the schema content and the provenance metadata
+together so conformance stays explicit.

--- a/schemas/request.schema.json
+++ b/schemas/request.schema.json
@@ -1,8 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/request.schema.json",
   "title": "Request",
-  "description": "Validates the content of a request artifact. The entry point to the system — a lightweight door that triggers survey.",
+  "description": "Canonical schema for the request artifact — the entry point that triggers a session. Version 1.0.0. commons is the spec authority; REQUEST.md carries the governing prose and ADR-0005 describes the system-conventions pattern under which this lives. When this schema and REQUEST.md disagree, REQUEST.md is authoritative.",
+  "$comment": "Groundwork vendors this runtime copy of the commons canonical request schema.",
+  "x-tesserine-canonical": {
+    "version": "1.0.0",
+    "schema_url": "https://raw.githubusercontent.com/tesserine/commons/v0.1.1/schemas/request/v1/request.schema.json",
+    "prose_url": "https://raw.githubusercontent.com/tesserine/commons/v0.1.1/REQUEST.md"
+  },
   "type": "object",
   "required": ["description", "source"],
   "additionalProperties": false,

--- a/tests/test_request_schema_vendoring.py
+++ b/tests/test_request_schema_vendoring.py
@@ -1,0 +1,84 @@
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUEST_SCHEMA_PATH = ROOT / "schemas" / "request.schema.json"
+SCHEMAS_README_PATH = ROOT / "schemas" / "README.md"
+VALID_REQUEST_FIXTURE_PATH = ROOT / "tests" / "fixtures" / "artifacts" / "valid-request.json"
+INVALID_REQUEST_FIXTURE_PATH = ROOT / "tests" / "fixtures" / "artifacts" / "invalid-request.json"
+
+
+def validate_request_instance(schema: dict, instance: dict) -> None:
+    if schema["type"] != "object":
+        raise AssertionError("request schema must validate an object")
+    if not isinstance(instance, dict):
+        raise ValueError("instance must be an object")
+
+    properties = schema["properties"]
+
+    for field in schema["required"]:
+        if field not in instance:
+            raise ValueError(f"missing required field: {field}")
+
+    if schema["additionalProperties"] is False:
+        unknown_fields = set(instance) - set(properties)
+        if unknown_fields:
+            raise ValueError(f"unexpected fields: {sorted(unknown_fields)!r}")
+
+    for field, value in instance.items():
+        field_schema = properties[field]
+        if field_schema["type"] == "string":
+            if not isinstance(value, str):
+                raise ValueError(f"{field} must be a string")
+            if "minLength" in field_schema and len(value) < field_schema["minLength"]:
+                raise ValueError(f"{field} must be at least {field_schema['minLength']} characters")
+
+
+class RequestSchemaVendoringTests(unittest.TestCase):
+    def test_request_schema_declares_canonical_release_provenance(self) -> None:
+        schema = json.loads(REQUEST_SCHEMA_PATH.read_text())
+
+        self.assertNotIn("$id", schema)
+        self.assertEqual(
+            schema["x-tesserine-canonical"],
+            {
+                "version": "1.0.0",
+                "schema_url": (
+                    "https://raw.githubusercontent.com/tesserine/commons/"
+                    "v0.1.1/schemas/request/v1/request.schema.json"
+                ),
+                "prose_url": (
+                    "https://raw.githubusercontent.com/tesserine/commons/"
+                    "v0.1.1/REQUEST.md"
+                ),
+            },
+        )
+
+    def test_schemas_readme_documents_request_vendoring_discipline(self) -> None:
+        readme = SCHEMAS_README_PATH.read_text()
+
+        self.assertIn("methodology-private", readme)
+        self.assertIn("request.schema.json", readme)
+        self.assertIn("tesserine/commons", readme)
+        self.assertIn("runtime consumers still read schemas from groundwork", readme)
+        self.assertIn("immutable release-tag or commit-SHA URL", readme)
+        self.assertIn("full semver", readme)
+
+    def test_valid_request_fixture_still_matches_vendored_schema_contract(self) -> None:
+        schema = json.loads(REQUEST_SCHEMA_PATH.read_text())
+        fixture = json.loads(VALID_REQUEST_FIXTURE_PATH.read_text())
+
+        validate_request_instance(schema, fixture)
+
+    def test_invalid_request_fixture_still_fails_vendored_schema_contract(self) -> None:
+        schema = json.loads(REQUEST_SCHEMA_PATH.read_text())
+        fixture = json.loads(INVALID_REQUEST_FIXTURE_PATH.read_text())
+
+        with self.assertRaisesRegex(ValueError, "missing required field: source"):
+            validate_request_instance(schema, fixture)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- vendor groundwork's runtime request schema as an explicit copy of the commons canonical request spec
- add inline provenance metadata using immutable `v0.1.1` release-tag URLs and spec version `1.0.0`
- document the vendoring discipline in `schemas/README.md` and add regression coverage for provenance and fixture behavior

## Changes

- remove the local `$id` from `schemas/request.schema.json` and replace it with canonical description text plus `x-tesserine-canonical` provenance
- add `schemas/README.md` so a reader can recover canonical authority, conformance version, and vendoring rules from groundwork alone
- record the change in `CHANGELOG.md` and add `tests/test_request_schema_vendoring.py`

## GitHub Issue(s)

Closes #247

## Test plan

- `python3 -m unittest discover -s tests -p 'test*.py'`
- run a parity check against `https://raw.githubusercontent.com/tesserine/commons/v0.1.1/schemas/request/v1/request.schema.json` to confirm material contract parity and expected valid/invalid fixture behavior
