### PR TITLE
chore(schemas): strip pre-runa-native naming prose

### DIFF
--- a/schemas/research-record.schema.json
+++ b/schemas/research-record.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/research-record.schema.json",
   "title": "Research Record",
-  "description": "Validates the content of a research-record artifact. Research scoped by topic; optionally scoped by work unit when research is specific to a work unit. Naming convention: research-record-{topic-slug}.yaml where topic-slug matches the topic field.",
+  "description": "Validates the content of a research-record artifact. Research scoped by topic; optionally scoped by work unit when research is specific to a work unit.",
   "type": "object",
   "required": ["topic", "findings", "sources"],
   "additionalProperties": false,


### PR DESCRIPTION
## Summary

- Removes stale pre-runa-native filename guidance from the `research-record` schema description.
- Preserves the schema contract; only descriptive prose changes.
- Confirms the remaining schema descriptions do not carry filename/naming-convention prose.

## Changes

- Updated `schemas/research-record.schema.json` to drop the obsolete `research-record-{topic-slug}.yaml` naming sentence.
- Left canonical artifact placement documentation unchanged; `docs/architecture/connecting-structure.md` already documents runa-owned `{type_name}/{instance_id}.json` placement.

## GitHub Issue(s)

Closes #226

## Test plan

- `jq empty schemas/*.schema.json`
- `! rg -n "Naming convention|naming convention|filename|file name|file-name|\\.ya?ml|\\{type_name\\}|instance_id" schemas`
- `git diff --check HEAD~1 HEAD`
