### PR TITLE
docs(protocols): make main sync independent of pull.rebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Main-sync guidance in `take` and `land` now uses explicit fetch plus
+  fast-forward merge instead of `git pull --ff-only`, so protocol execution
+  does not inherit a user's global `pull.rebase` setting (closes #251).
 - `schemas/request.schema.json` now vendors the commons canonical request
   schema with inline provenance metadata, and `schemas/README.md` documents
   the vendoring discipline for methodology runtime schemas (closes #247).

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -179,7 +179,7 @@ Merge through GitHub's PR API so the PR is recorded as "merged," not just "close
 
 1. Run `gh pr merge <number>` with the appropriate strategy flag: `--squash` if squashing (with `--subject` and `--body` for the drafted commit message), `--merge` if preserving history.
 2. Include `--delete-branch` to let GitHub clean up the remote branch.
-3. After the API merge completes, sync local state: `git checkout main`, `git pull --ff-only origin main`.
+3. After the API merge completes, sync local state: `git checkout main`, `git fetch origin --prune`, `git merge --ff-only origin/main`.
 4. Record the merge commit SHA from the local main HEAD for use in GitHub issue comments.
 
 **Why not local merge:** A local `git merge` + `git push` lands the code on main but bypasses GitHub's PR merge tracking. GitHub sees the PR's commits already on main and auto-closes the PR as "closed" rather than "merged" when the branch is deleted. This loses PR merge metadata and breaks PR history.
@@ -190,7 +190,7 @@ This path is only for branches that never had a PR — not a fallback for when `
 
 If no PR was found in step 1b, merge locally:
 
-1. Fetch and fast-forward `main` to match origin (`git fetch origin --prune`, `git checkout main`, `git pull --ff-only origin main`).
+1. Fetch and fast-forward `main` to match origin (`git fetch origin --prune`, `git checkout main`, `git merge --ff-only origin/main`).
 2. Merge the feature branch. If squashing: `git merge --squash`, then `git commit` with the drafted message. If preserving: `git merge --no-ff`.
 3. Push `main` to origin.
 4. Record the merge commit SHA.

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -126,7 +126,7 @@ batch and package them as one PR at `submit`.
 
 Set up the repository-local workspace for the selected work.
 
-1. Ensure on `main` and up-to-date: `git checkout main && git pull --ff-only`.
+1. Ensure on `main` and up-to-date: `git checkout main`, `git fetch origin --prune`, `git merge --ff-only origin/main`.
 2. Create a feature branch. The work-unit artifact is always present; what
    varies is tracker linkage and, when linked, whether scope is single or
    batched:


### PR DESCRIPTION
## Summary

- Replaces documented `git pull --ff-only` main-sync steps with explicit fetch plus fast-forward merge.
- Covers both `land` sync paths and the related `take` preparation guidance so the commands do not inherit global `pull.rebase` configuration.
- Records the protocol bug fix in the changelog.

## Changes

- `take` preparation now syncs `main` with `git fetch origin --prune` and `git merge --ff-only origin/main`.
- `land` API-merge and local fallback sync paths use the same explicit fast-forward operation.
- `CHANGELOG.md` notes the user-visible protocol guidance correction.

## GitHub Issue(s)

Closes #251

## Test plan

- `if rg -n "git pull --ff-only|pull --ff-only" protocols/take/PROTOCOL.md protocols/land/PROTOCOL.md; then exit 1; else echo "no stale pull guidance in take/land"; fi`
- `rg -n "git fetch origin --prune|git merge --ff-only origin/main" protocols/take/PROTOCOL.md protocols/land/PROTOCOL.md`
- `git diff --check`
