### PR TITLE
fix(submit): handle existing PR updates as push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - `submit` now treats PR presence as the primary deliverability rule: when an
-  open PR exists, it records the PR URL plus head SHA, fetches the PR head
-  object, and classifies local `HEAD` against that PR head by ancestry
-  regardless of upstream tracking. When no PR exists, upstream tracking and
-  first-push semantics continue to determine deliverability (closes #253).
+  open PR exists, it records the PR URL plus head SHA, head branch, and head
+  repository, fetches the PR head object, classifies local `HEAD` against that
+  PR head by ancestry regardless of upstream tracking, and pushes updates to
+  the discovered PR head repo/ref instead of assuming `origin <branch>` backs
+  the PR. When no PR exists, upstream tracking and first-push semantics
+  continue to determine deliverability (closes #253).
 - Main-sync guidance in `take` and `land` now uses explicit fetch plus
   fast-forward merge instead of `git pull --ff-only`, so protocol execution
   does not inherit a user's global `pull.rebase` setting (closes #251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- `submit` now treats an open PR with new local commits as a push-to-existing-PR
-  delivery path instead of stopping. It still reports an existing PR and
-  recommends `land` when there is no new local work to submit (closes #253).
+- `submit` now treats an open PR with deliverable local commits as a
+  push-to-existing-PR delivery path, including branches checked out without
+  upstream tracking by comparing local `HEAD` with the PR head. It still
+  reports an existing PR and recommends `land` when there is no new local work
+  to submit (closes #253).
 - Main-sync guidance in `take` and `land` now uses explicit fetch plus
   fast-forward merge instead of `git pull --ff-only`, so protocol execution
   does not inherit a user's global `pull.rebase` setting (closes #251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `submit` now treats an open PR with new local commits as a push-to-existing-PR
+  delivery path instead of stopping. It still reports an existing PR and
+  recommends `land` when there is no new local work to submit (closes #253).
 - Main-sync guidance in `take` and `land` now uses explicit fetch plus
   fast-forward merge instead of `git pull --ff-only`, so protocol execution
   does not inherit a user's global `pull.rebase` setting (closes #251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- `submit` now treats an open PR with deliverable local commits as a
-  push-to-existing-PR delivery path, including branches checked out without
-  upstream tracking by recording the PR URL plus head SHA, fetching the PR head
-  object, and classifying local `HEAD` against the PR head by ancestry. It still
-  reports an existing PR and recommends `land` when there is no new local work
-  to submit, and stops rather than pushing when local and PR heads have diverged
-  (closes #253).
+- `submit` now treats PR presence as the primary deliverability rule: when an
+  open PR exists, it records the PR URL plus head SHA, fetches the PR head
+  object, and classifies local `HEAD` against that PR head by ancestry
+  regardless of upstream tracking. When no PR exists, upstream tracking and
+  first-push semantics continue to determine deliverability (closes #253).
 - Main-sync guidance in `take` and `land` now uses explicit fetch plus
   fast-forward merge instead of `git pull --ff-only`, so protocol execution
   does not inherit a user's global `pull.rebase` setting (closes #251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   matching PR base repository remote, classifies local `HEAD` against that PR
   head by ancestry after commit analysis has completed, and pushes updates to
   the discovered PR head repo/ref instead of assuming `origin <branch>` backs
-  the PR. When no PR exists, upstream tracking and first-push semantics
-  determine deliverability; first-push delivery now requires non-empty
-  `git log main..HEAD`, and an empty result reports `clean-branch-no-changes`
-  (closes #253).
+  the PR. When multiple open PRs share the same branch name, they are
+  disambiguated by head repository against a matching local remote before any
+  PR is selected.
+  When no PR exists, upstream tracking is read from the classification-time
+  branch state and first-push semantics determine deliverability; first-push
+  delivery now requires non-empty `git log main..HEAD`, and an empty result
+  reports `clean-branch-no-changes` (closes #253).
 - Main-sync guidance in `take` and `land` now uses explicit fetch plus
   fast-forward merge instead of `git pull --ff-only`, so protocol execution
   does not inherit a user's global `pull.rebase` setting (closes #251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `submit` now treats an open PR with deliverable local commits as a
   push-to-existing-PR delivery path, including branches checked out without
-  upstream tracking by recording the PR URL plus head SHA and classifying local
-  `HEAD` against the PR head by ancestry. It still reports an existing PR and
-  recommends `land` when there is no new local work to submit, and stops rather
-  than pushing when local and PR heads have diverged (closes #253).
+  upstream tracking by recording the PR URL plus head SHA, fetching the PR head
+  object, and classifying local `HEAD` against the PR head by ancestry. It still
+  reports an existing PR and recommends `land` when there is no new local work
+  to submit, and stops rather than pushing when local and PR heads have diverged
+  (closes #253).
 - Main-sync guidance in `take` and `land` now uses explicit fetch plus
   fast-forward merge instead of `git pull --ff-only`, so protocol execution
   does not inherit a user's global `pull.rebase` setting (closes #251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - `submit` now treats PR presence as the primary deliverability rule: when an
-  open PR exists, it records the PR URL plus head SHA, head branch, and head
-  repository, fetches the PR head object, classifies local `HEAD` against that
-  PR head by ancestry after commit analysis has completed, and pushes updates
-  to the discovered PR head repo/ref instead of assuming `origin <branch>`
-  backs the PR. When no PR exists, upstream tracking and first-push semantics
-  continue to determine deliverability (closes #253).
+  open PR exists, it records the PR URL plus head SHA, head branch, head
+  repository, and base repository, fetches the PR head object through the
+  matching PR base repository remote, classifies local `HEAD` against that PR
+  head by ancestry after commit analysis has completed, and pushes updates to
+  the discovered PR head repo/ref instead of assuming `origin <branch>` backs
+  the PR. When no PR exists, upstream tracking and first-push semantics
+  determine deliverability; first-push delivery now requires non-empty
+  `git log main..HEAD`, and an empty result reports `clean-branch-no-changes`
+  (closes #253).
 - Main-sync guidance in `take` and `land` now uses explicit fetch plus
   fast-forward merge instead of `git pull --ff-only`, so protocol execution
   does not inherit a user's global `pull.rebase` setting (closes #251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `submit` now treats an open PR with deliverable local commits as a
   push-to-existing-PR delivery path, including branches checked out without
-  upstream tracking by comparing local `HEAD` with the PR head. It still
-  reports an existing PR and recommends `land` when there is no new local work
-  to submit (closes #253).
+  upstream tracking by recording the PR URL plus head SHA and classifying local
+  `HEAD` against the PR head by ancestry. It still reports an existing PR and
+  recommends `land` when there is no new local work to submit, and stops rather
+  than pushing when local and PR heads have diverged (closes #253).
 - Main-sync guidance in `take` and `land` now uses explicit fetch plus
   fast-forward merge instead of `git pull --ff-only`, so protocol execution
   does not inherit a user's global `pull.rebase` setting (closes #251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   disambiguated by head repository against a matching local remote before any
   PR is selected.
   When no PR exists, upstream tracking is read from the classification-time
-  branch state and first-push semantics determine deliverability; first-push
-  delivery now requires non-empty `git log main..HEAD`, and an empty result
-  reports `clean-branch-no-changes` (closes #253).
+  branch state, `git log main..HEAD` determines whether the branch has
+  deliverable commits for a new PR under first-push or already-pushed
+  semantics, and upstream-ahead commits determine only whether a push is needed
+  before PR creation; an already-pushed branch still needs a PR, while an empty
+  base-branch comparison reports `clean-branch-no-changes` (closes #253).
 - Main-sync guidance in `take` and `land` now uses explicit fetch plus
   fast-forward merge instead of `git pull --ff-only`, so protocol execution
   does not inherit a user's global `pull.rebase` setting (closes #251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `submit` now treats PR presence as the primary deliverability rule: when an
   open PR exists, it records the PR URL plus head SHA, head branch, and head
   repository, fetches the PR head object, classifies local `HEAD` against that
-  PR head by ancestry regardless of upstream tracking, and pushes updates to
-  the discovered PR head repo/ref instead of assuming `origin <branch>` backs
-  the PR. When no PR exists, upstream tracking and first-push semantics
+  PR head by ancestry after commit analysis has completed, and pushes updates
+  to the discovered PR head repo/ref instead of assuming `origin <branch>`
+  backs the PR. When no PR exists, upstream tracking and first-push semantics
   continue to determine deliverability (closes #253).
 - Main-sync guidance in `take` and `land` now uses explicit fetch plus
   fast-forward merge instead of `git pull --ff-only`, so protocol execution

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -68,13 +68,11 @@ Determine:
   the PR-head fetch together. After fetching, verify that `headRefOid` resolves
   as a commit before any operation consumes it.
 - Whether committed local work is deliverable:
-  - **With upstream:** commits ahead of the branch's remote
-    tracking ref (`git log @{upstream}..HEAD`).
-  - **No upstream and no open PR:** local commits on the feature branch are
-    deliverable under first-push semantics.
-  - **No upstream and open PR:** classify local `HEAD` (`git rev-parse HEAD`)
-    against the PR head SHA (`headRefOid`) by ancestry, using
-    `git merge-base --is-ancestor` in both directions:
+  - **Open PR exists:** regardless of whether the branch has upstream tracking,
+    classify local `HEAD` (`git rev-parse HEAD`) against the PR head SHA
+    (`headRefOid`) by ancestry, using `git merge-base --is-ancestor` in both
+    directions. The upstream tracking ref plays no role in deliverability when
+    a PR exists; the fetched PR head is the ground truth.
     - If `HEAD` and `headRefOid` are the same SHA, no committed local work is
       deliverable and the existing PR state should be reported.
     - If `HEAD` is an ancestor of `headRefOid`, the local checkout is behind the
@@ -85,6 +83,10 @@ Determine:
     - If neither commit is an ancestor of the other, the local branch and PR
       head have diverged. Report the divergence and stop; do not force-push or
       rebase automatically.
+  - **No open PR and upstream exists:** commits ahead of the branch's remote
+    tracking ref (`git log @{upstream}..HEAD`) are deliverable.
+  - **No open PR and no upstream:** local commits on the feature branch are
+    deliverable under first-push semantics.
 - GitHub issue number(s), resolved in priority order:
   1. Explicit operator-provided GitHub issue number(s).
   2. Branch name pattern: `issue-<N>/<slug>` (single) or

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -38,8 +38,8 @@ approval to execute the full sequence.
 
 ## Preconditions
 
-- Deliverable local work means uncommitted changes OR commits ahead of the
-  branch's remote tracking ref. If the working tree is clean and no
+- Deliverable local work means uncommitted changes OR committed work identified
+  from the branch's tracking and PR state. If the working tree is clean and no
   deliverable commits exist, there is nothing new to submit. When an open PR
   exists, report its current state and recommend `land` if appropriate; when no
   open PR exists, report and stop.
@@ -58,13 +58,19 @@ Determine:
 - Current branch name.
 - Whether on `main` or a feature branch.
 - Whether uncommitted changes exist (`git status`).
-- Whether committed local work is deliverable:
-  - If the branch has an upstream, commits ahead of the branch's remote
-    tracking ref (`git log @{upstream}..HEAD`).
-  - If the feature branch has no upstream, local commits on that branch are
-    deliverable when the branch is first pushed.
 - Whether an open PR exists for the current branch (`gh pr list --head <branch>
-  --state open`) when `gh` is available.
+  --state open`) when `gh` is available. For an open PR, record the PR head SHA
+  (`headRefOid`).
+- Whether committed local work is deliverable:
+  - **With upstream:** commits ahead of the branch's remote
+    tracking ref (`git log @{upstream}..HEAD`).
+  - **No upstream and no open PR:** local commits on the feature branch are
+    deliverable under first-push semantics.
+  - **No upstream and open PR:** compare local `HEAD` (`git rev-parse HEAD`)
+    with the PR head SHA (`headRefOid`). If they match, no committed local work
+    is deliverable and the existing PR state should be reported. If they differ,
+    the divergent local commits are deliverable through the existing PR update
+    path.
 - GitHub issue number(s), resolved in priority order:
   1. Explicit operator-provided GitHub issue number(s).
   2. Branch name pattern: `issue-<N>/<slug>` (single) or

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -71,26 +71,8 @@ Determine:
   refspec, and remote URL normalization; adapting the protocol to another forge
   requires changing all three together. After fetching, verify that
   `headRefOid` resolves as a commit before any operation consumes it.
-- Whether committed local work is deliverable:
-  - **Open PR exists:** regardless of whether the branch has upstream tracking,
-    classify local `HEAD` (`git rev-parse HEAD`) against the PR head SHA
-    (`headRefOid`) by ancestry, using `git merge-base --is-ancestor` in both
-    directions. The upstream tracking ref plays no role in deliverability when
-    a PR exists; the fetched PR head is the ground truth.
-    - If `HEAD` and `headRefOid` are the same SHA, no committed local work is
-      deliverable and the existing PR state should be reported.
-    - If `HEAD` is an ancestor of `headRefOid`, the local checkout is behind the
-      PR. No committed local work is deliverable; report the existing PR state
-      and stop.
-    - If `headRefOid` is an ancestor of `HEAD`, local commits are deliverable
-      through the existing PR update path.
-    - If neither commit is an ancestor of the other, the local branch and PR
-      head have diverged. Report the divergence and stop; do not force-push or
-      rebase automatically.
-  - **No open PR and upstream exists:** commits ahead of the branch's remote
-    tracking ref (`git log @{upstream}..HEAD`) are deliverable.
-  - **No open PR and no upstream:** local commits on the feature branch are
-    deliverable under first-push semantics.
+- Whether upstream tracking exists for the current branch. This is input for
+  post-commit deliverability classification when no open PR exists.
 - GitHub issue number(s), resolved in priority order:
   1. Explicit operator-provided GitHub issue number(s).
   2. Branch name pattern: `issue-<N>/<slug>` (single) or
@@ -123,7 +105,8 @@ This shared step applies before either PR delivery path. The same commit
 analysis discipline applies whether the deliverable is a new PR or an existing
 PR update.
 
-If all deliverable work is already committed, skip to step 4.
+If the working tree has no uncommitted changes, skip to step 4; committed-work
+deliverability is classified there against the final submission `HEAD`.
 
 **3a. Understand intent.** Examine all uncommitted modifications
 (`git diff`, `git diff --staged`). If GitHub issue context is available,
@@ -153,14 +136,36 @@ than artificial splitting.
 
 ### 4. Resolve PR delivery path
 
-Use the context from step 1 after commit analysis has completed:
+After commit analysis has completed, classify current `HEAD` and select exactly
+one delivery path. This classification is post-commit: if step 3 created a
+commit from uncommitted changes, that new commit is part of the `HEAD` being
+classified. Step 4 consumes the substrate captured in step 1, but the
+deliverability result is produced here.
 
-- **open PR exists and deliverable local work exists:** push to the existing PR
-  branch. This is the normal review-fix path after a PR already exists.
-- **open PR exists and no deliverable local work exists:** report the PR URL
-  and current state, recommend `land` when review status makes that
-  appropriate, and stop. There is nothing new for `submit` to deliver.
-- **no open PR exists:** deliver by opening a new PR after pushing the branch.
+- **Open PR exists:** regardless of whether the branch has upstream tracking,
+  classify current `HEAD` by ancestry. To classify local `HEAD`, run
+  `git rev-parse HEAD` after commit analysis and compare it against the PR head
+  SHA (`headRefOid`) using `git merge-base --is-ancestor` in both directions.
+  The upstream tracking ref plays no role in deliverability when a PR exists;
+  the fetched PR head is the ground truth.
+  - If `HEAD` and `headRefOid` are the same SHA, no committed local work is
+    deliverable and the existing PR state should be reported.
+  - If `HEAD` is an ancestor of `headRefOid`, the local checkout is behind the
+    PR. No committed local work is deliverable; report the existing PR state
+    and stop.
+  - If `headRefOid` is an ancestor of `HEAD`, open PR exists and deliverable
+    local work exists: local commits are deliverable through the existing PR
+    update path, so push to the existing PR branch. This is the normal
+    review-fix path after a PR already exists.
+  - If neither commit is an ancestor of the other, the local branch and PR head
+    have diverged. Report the divergence and stop; do not force-push or rebase
+    automatically.
+- **No open PR and upstream exists:** commits ahead of the branch's remote
+  tracking ref (`git log @{upstream}..HEAD`) are deliverable by opening a new PR
+  after pushing the branch.
+- **No open PR and no upstream:** local commits on the feature branch are
+  deliverable under first-push semantics by opening a new PR after pushing the
+  branch.
 
 ### 5. Push
 

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -59,9 +59,14 @@ Determine:
 - Whether on `main` or a feature branch.
 - Whether uncommitted changes exist (`git status`).
 - Whether an open PR exists for the current branch (`gh pr list --head <branch>
-  --state open --json url,headRefOid`) when `gh` is available. For an open PR,
-  record the PR URL as the downstream PR reference and the PR head SHA
-  (`headRefOid`) for ancestry classification.
+  --state open --json url,number,headRefOid`) when `gh` is available. For an
+  open PR, record the PR URL as the downstream PR reference, the PR number, and
+  the PR head SHA (`headRefOid`) for ancestry classification. Fetch the PR head
+  into the local object database before classification: `git fetch origin
+  pull/<number>/head`. This is the GitHub PR refspec paired with `gh` discovery;
+  adapting the protocol to another forge requires changing both discovery and
+  the PR-head fetch together. After fetching, verify that `headRefOid` resolves
+  as a commit before any operation consumes it.
 - Whether committed local work is deliverable:
   - **With upstream:** commits ahead of the branch's remote
     tracking ref (`git log @{upstream}..HEAD`).
@@ -278,6 +283,9 @@ Output:
   not rebase automatically. Commits are safely local; the operator decides how
   to reconcile.
 - **Push network error:** Retry once. If still failing, report.
+- **PR head fetch or resolvability check fails:** Report the recorded PR URL and
+  stop before ancestry classification. Do not run `git merge-base` against an
+  unresolvable `headRefOid`.
 - **`gh pr create` fails:**
   - Branch already has an open PR: treat as the existing PR update path if
     deliverable local work was pushed; otherwise report the existing PR URL and

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -60,15 +60,24 @@ Determine:
 - Whether uncommitted changes exist (`git status`).
 - Whether an open PR exists for the current branch (`gh pr list --head <branch>
   --state open --json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner`)
-  when `gh` is available. Run `gh repo view --json nameWithOwner,url` in the
-  same repository context as the PR listing, and record that value as the PR
-  base repository identity. For an open PR, record the PR URL as the downstream
+  when `gh` is available. PR discovery handles result counts explicitly:
+  0 results means no open PR; 1 result means that PR is the working PR; 2+
+  results means disambiguate by head repository before recording any working
+  PR. To disambiguate multiple results, filter candidates by PR head repository
+  against local remotes using shared GitHub remote matching and each remote's
+  effective push URL. If exactly one PR survives, use it as the working PR. If
+  zero or 2+ candidates survive, stop with Ambiguous PR discovery before fetch,
+  ancestry classification, push, or patch delivery.
+- For the working PR, run `gh repo view --json nameWithOwner,url` in the same
+  repository context as the PR listing, and record that value as the PR base
+  repository identity. For the working PR, record the PR URL as the downstream
   PR reference, the PR number, the PR head SHA (`headRefOid`) for ancestry
   classification, the PR head branch (`headRefName`), the PR head repository
   (`<headRepositoryOwner.login>/<headRepository.name>`) for existing PR push
   delivery, and the PR base repository for PR-head fetch. Resolve a local remote
   matching the PR base repository, using that remote's fetch URL, and fetch the
-  PR head into the local object database before classification:
+  PR head into the local object database before post-commit deliverability
+  classification:
   `git fetch <base-repo-remote> pull/<number>/head`. This is the GitHub PR
   refspec paired with `gh` discovery. Existing-PR delivery is a single
   GitHub-shaped commitment across `gh` discovery, the `pull/<number>/head`
@@ -79,10 +88,8 @@ Determine:
   accept SSH and HTTPS GitHub URLs, strip `.git`, compare the lowercase
   `<owner>/<repo>`, and treat non-GitHub URL forms as non-matches. Fetch
   resolution inspects `git remote get-url <remote>` against the PR base
-  repository; push resolution inspects
+  repository; push resolution and PR discovery disambiguation inspect
   `git remote get-url --push <remote>` against the PR head repository.
-- Whether upstream tracking exists for the current branch. This is input for
-  post-commit deliverability classification when no open PR exists.
 - GitHub issue number(s), resolved in priority order:
   1. Explicit operator-provided GitHub issue number(s).
   2. Branch name pattern: `issue-<N>/<slug>` (single) or
@@ -149,8 +156,13 @@ than artificial splitting.
 After commit analysis has completed, classify current `HEAD` and select exactly
 one delivery path. This classification is post-commit: if step 3 created a
 commit from uncommitted changes, that new commit is part of the `HEAD` being
-classified. Step 4 consumes the substrate captured in step 1, but the
-deliverability result is produced here.
+classified. Step 4 consumes PR discovery substrate captured in step 1, then
+reads branch substrate that may have changed during step 2 or step 3 from the
+classification-time branch state. Run `git rev-parse HEAD` to capture the
+post-commit `HEAD`. When no open PR exists, determine whether upstream tracking
+exists by running
+`git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` at this point.
+A failing upstream lookup means no upstream exists.
 
 - **Open PR exists:** regardless of whether the branch has upstream tracking,
   classify current `HEAD` by ancestry. To classify local `HEAD`, run
@@ -312,6 +324,12 @@ Output:
   not rebase automatically. Commits are safely local; the operator decides how
   to reconcile.
 - **Push network error:** Retry once. If still failing, report.
+- **Ambiguous PR discovery:** Stop before PR head fetch, ancestry
+  classification, push, or patch delivery. Report the candidate PR URLs, the
+  candidate head repositories, the operator's local remotes with their
+  normalized GitHub repository or sanitized non-match status, and that
+  disambiguation requires exactly one local remote pointing at exactly one
+  candidate PR head repository.
 - **No local remote matches the PR base repository:** Stop before PR head fetch
   and ancestry classification. Report the PR URL, PR base repository, and that
   no matching local remote was found. Do not run `git merge-base` against an

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -182,9 +182,16 @@ A failing upstream lookup means no upstream exists.
   - If neither commit is an ancestor of the other, the local branch and PR head
     have diverged. Report the divergence and stop; do not force-push or rebase
     automatically.
-- **No open PR and upstream exists:** commits ahead of the branch's remote
-  tracking ref (`git log @{upstream}..HEAD`) are deliverable by opening a new PR
-  after pushing the branch.
+- **No open PR and upstream exists:** run `git log main..HEAD` to verify that
+  local commits exist ahead of the base branch. If no commits exist, no
+  committed local work is deliverable; report `clean-branch-no-changes` and
+  stop. If commits exist, the branch is deliverable by opening a new PR. Then
+  inspect commits ahead of the branch's remote tracking ref
+  (`git log @{upstream}..HEAD`). Upstream-ahead commits decide whether a push is
+  needed, not whether PR creation is allowed. If upstream-ahead commits exist,
+  deliver through the new PR path after pushing the branch. If no
+  upstream-ahead commits exist, the already-pushed branch still needs a PR;
+  deliver through the new PR path without pushing again.
 - **No open PR and no upstream:** run `git log main..HEAD` to verify that local
   commits exist ahead of the base branch. If commits exist, local commits on the
   feature branch are deliverable under first-push semantics by opening a new PR
@@ -203,8 +210,11 @@ Use the delivery path from step 4:
   Do not push the local branch name to `origin` and assume that it updates the
   open PR. This push is the delivery action; after it succeeds, report this path
   as `pushed to existing PR`.
-- **New PR path:** push the feature branch to origin. If no upstream is set, run
-  `git push -u origin <branch>`; if upstream exists, run `git push`.
+- **New PR path:** push the feature branch to origin when the delivery
+  classification requires a push. If no upstream is set, run
+  `git push -u origin <branch>`; if upstream exists, run `git push` when
+  upstream-ahead commits exist. If no upstream-ahead commits exist for an
+  upstream-backed branch, open the new PR without a push.
 
 ### 6. Create or identify PR
 

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -59,14 +59,18 @@ Determine:
 - Whether on `main` or a feature branch.
 - Whether uncommitted changes exist (`git status`).
 - Whether an open PR exists for the current branch (`gh pr list --head <branch>
-  --state open --json url,number,headRefOid`) when `gh` is available. For an
-  open PR, record the PR URL as the downstream PR reference, the PR number, and
-  the PR head SHA (`headRefOid`) for ancestry classification. Fetch the PR head
-  into the local object database before classification: `git fetch origin
-  pull/<number>/head`. This is the GitHub PR refspec paired with `gh` discovery;
-  adapting the protocol to another forge requires changing both discovery and
-  the PR-head fetch together. After fetching, verify that `headRefOid` resolves
-  as a commit before any operation consumes it.
+  --state open --json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner`)
+  when `gh` is available. For an open PR, record the PR URL as the downstream PR
+  reference, the PR number, the PR head SHA (`headRefOid`) for ancestry
+  classification, the PR head branch (`headRefName`), and the PR head
+  repository (`<headRepositoryOwner.login>/<headRepository.name>`) for existing
+  PR push delivery. Fetch the PR head into the local object database before
+  classification: `git fetch origin pull/<number>/head`. This is the GitHub PR
+  refspec paired with `gh` discovery. Existing-PR delivery is a single
+  GitHub-shaped commitment across `gh` discovery, the `pull/<number>/head`
+  refspec, and remote URL normalization; adapting the protocol to another forge
+  requires changing all three together. After fetching, verify that
+  `headRefOid` resolves as a commit before any operation consumes it.
 - Whether committed local work is deliverable:
   - **Open PR exists:** regardless of whether the branch has upstream tracking,
     classify local `HEAD` (`git rev-parse HEAD`) against the PR head SHA
@@ -160,12 +164,20 @@ Use the context from step 1 after commit analysis has completed:
 
 ### 5. Push
 
-Push the feature branch to origin:
-- No upstream set: `git push -u origin <branch>`.
-- Upstream exists: `git push`.
+Use the delivery path from step 4:
 
-For an existing PR update, this push is the delivery action: it updates the
-remote branch backing the open PR. Report this path as `pushed to existing PR`.
+- **Existing PR update path:** resolve a local remote whose effective push URL
+  points at the PR head repository recorded in step 1. For each remote, inspect
+  `git remote get-url --push <remote>`. Push the submitted commits to the PR head
+  branch: `git push <head-repo-remote> HEAD:<headRefName>`. Remote matching uses
+  GitHub-form normalization: accept SSH and HTTPS GitHub URLs, strip `.git`,
+  compare the lowercase `<owner>/<repo>`, and treat non-GitHub URL forms as
+  non-matches.
+  Do not push the local branch name to `origin` and assume that it updates the
+  open PR. This push is the delivery action; after it succeeds, report this path
+  as `pushed to existing PR`.
+- **New PR path:** push the feature branch to origin. If no upstream is set, run
+  `git push -u origin <branch>`; if upstream exists, run `git push`.
 
 ### 6. Create or identify PR
 
@@ -285,6 +297,9 @@ Output:
   not rebase automatically. Commits are safely local; the operator decides how
   to reconcile.
 - **Push network error:** Retry once. If still failing, report.
+- **No local remote matches the PR head repository:** Stop before push. Report
+  the PR URL, PR head repository, and `headRefName`. Do not deliver a `patch`
+  artifact because the PR was not updated.
 - **PR head fetch or resolvability check fails:** Report the recorded PR URL and
   stop before ancestry classification. Do not run `git merge-base` against an
   unresolvable `headRefOid`.

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -59,18 +59,27 @@ Determine:
 - Whether on `main` or a feature branch.
 - Whether uncommitted changes exist (`git status`).
 - Whether an open PR exists for the current branch (`gh pr list --head <branch>
-  --state open`) when `gh` is available. For an open PR, record the PR head SHA
-  (`headRefOid`).
+  --state open --json url,headRefOid`) when `gh` is available. For an open PR,
+  record the PR URL as the downstream PR reference and the PR head SHA
+  (`headRefOid`) for ancestry classification.
 - Whether committed local work is deliverable:
   - **With upstream:** commits ahead of the branch's remote
     tracking ref (`git log @{upstream}..HEAD`).
   - **No upstream and no open PR:** local commits on the feature branch are
     deliverable under first-push semantics.
-  - **No upstream and open PR:** compare local `HEAD` (`git rev-parse HEAD`)
-    with the PR head SHA (`headRefOid`). If they match, no committed local work
-    is deliverable and the existing PR state should be reported. If they differ,
-    the divergent local commits are deliverable through the existing PR update
-    path.
+  - **No upstream and open PR:** classify local `HEAD` (`git rev-parse HEAD`)
+    against the PR head SHA (`headRefOid`) by ancestry, using
+    `git merge-base --is-ancestor` in both directions:
+    - If `HEAD` and `headRefOid` are the same SHA, no committed local work is
+      deliverable and the existing PR state should be reported.
+    - If `HEAD` is an ancestor of `headRefOid`, the local checkout is behind the
+      PR. No committed local work is deliverable; report the existing PR state
+      and stop.
+    - If `headRefOid` is an ancestor of `HEAD`, local commits are deliverable
+      through the existing PR update path.
+    - If neither commit is an ancestor of the other, the local branch and PR
+      head have diverged. Report the divergence and stop; do not force-push or
+      rebase automatically.
 - GitHub issue number(s), resolved in priority order:
   1. Explicit operator-provided GitHub issue number(s).
   2. Branch name pattern: `issue-<N>/<slug>` (single) or

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -2,7 +2,7 @@
 name: submit
 description: >-
   Package working changes into a PR: ensure feature branch, analyze and commit
-  changes, push, create PR with derived title/body linked to GitHub issue(s).
+  changes, push, then create or update a PR linked to GitHub issue(s).
   The middle phase of the session lifecycle between take and land.
   Trigger on: 'submit', 'submit pr', 'create pr', 'open pr',
   'send for review', 'package this up'.
@@ -20,32 +20,33 @@ changes need to cross into the review stage.
 1. Resolve the working context (branch, changes, linked issues)
 2. Ensure a feature branch exists (guard rail if on `main`)
 3. Analyze changes and produce well-formed commits
-4. Push to remote
-5. Create a PR with derived title/body and GitHub issue linkage
-6. Deliver the `patch` artifact via the MCP tool
-7. Report the result and suggest next steps
+4. Resolve whether delivery updates an existing PR or opens a new PR
+5. Push to remote
+6. Create a PR when needed
+7. Deliver the `patch` artifact via the MCP tool
+8. Report the result and suggest next steps
 
 The session lifecycle is: `take` (initiate session) → implement → `submit`
 (package for review) → review → `land` (merge and close). `submit` is the
 transition from execution to review.
 
-Do not stop after creating the PR — the delivery and report steps (6 and 7)
-are part of the protocol. Invoking `submit` IS the operator's approval to
-execute the full sequence.
+Do not stop after creating or updating the PR — the delivery and report steps
+(7 and 8) are part of the protocol. Invoking `submit` IS the operator's
+approval to execute the full sequence.
 
 ---
 
 ## Preconditions
 
-- Uncommitted changes OR unpushed commits on a feature branch must exist. If
-  the working tree is clean and no unpushed commits exist, there is nothing to
-  submit — report and stop.
-- If the current feature branch already has an open PR, report the PR URL and
-  stop. The PR already exists; the operator likely wants `land`, not `submit`.
+- Deliverable local work means uncommitted changes OR commits ahead of the
+  branch's remote tracking ref. If the working tree is clean and no
+  deliverable commits exist, there is nothing new to submit. When an open PR
+  exists, report its current state and recommend `land` if appropriate; when no
+  open PR exists, report and stop.
 - Producing the `patch` capstone requires a real PR reference, which in turn
   requires forge tooling (`gh` authenticated against the remote). Where forge
   tooling is absent, the protocol can commit and push locally but cannot
-  deliver the `patch` artifact — see step 5 for the failure path.
+  deliver the `patch` artifact — see step 6 for the failure path.
 
 ---
 
@@ -57,8 +58,13 @@ Determine:
 - Current branch name.
 - Whether on `main` or a feature branch.
 - Whether uncommitted changes exist (`git status`).
-- Whether unpushed commits exist (`git log origin/main..HEAD` or
-  `git log main..HEAD`).
+- Whether committed local work is deliverable:
+  - If the branch has an upstream, commits ahead of the branch's remote
+    tracking ref (`git log @{upstream}..HEAD`).
+  - If the feature branch has no upstream, local commits on that branch are
+    deliverable when the branch is first pushed.
+- Whether an open PR exists for the current branch (`gh pr list --head <branch>
+  --state open`) when `gh` is available.
 - GitHub issue number(s), resolved in priority order:
   1. Explicit operator-provided GitHub issue number(s).
   2. Branch name pattern: `issue-<N>/<slug>` (single) or
@@ -66,11 +72,7 @@ Determine:
   3. None — proceed without GitHub issue linkage.
 
 If GitHub issue number(s) are available and `gh` is installed, fetch issue
-title(s) and body(ies) via `gh issue view` for use in steps 3 and 5.
-
-Where `gh` is available, check for an existing open PR on the current branch
-(`gh pr list --head <branch> --state open`). If one exists, report its URL
-and stop.
+title(s) and body(ies) via `gh issue view` for use in steps 3 and 6.
 
 ### 2. Ensure feature branch
 
@@ -91,8 +93,11 @@ This step is the protocol's core analytical value: understanding changes
 well enough to produce meaningful commit structure, not just staging
 everything at once.
 
-If all changes are already committed (only unpushed commits exist), skip to
-step 4.
+This shared step applies before either PR delivery path. The same commit
+analysis discipline applies whether the deliverable is a new PR or an existing
+PR update.
+
+If all deliverable work is already committed, skip to step 4.
 
 **3a. Understand intent.** Examine all uncommitted modifications
 (`git diff`, `git diff --staged`). If GitHub issue context is available,
@@ -120,19 +125,36 @@ If analysis produces no clear grouping (one tangled change), fall back to a
 single commit with a comprehensive message. A single honest commit is better
 than artificial splitting.
 
-### 4. Push
+### 4. Resolve PR delivery path
+
+Use the context from step 1 after commit analysis has completed:
+
+- **open PR exists and deliverable local work exists:** push to the existing PR
+  branch. This is the normal review-fix path after a PR already exists.
+- **open PR exists and no deliverable local work exists:** report the PR URL
+  and current state, recommend `land` when review status makes that
+  appropriate, and stop. There is nothing new for `submit` to deliver.
+- **no open PR exists:** deliver by opening a new PR after pushing the branch.
+
+### 5. Push
 
 Push the feature branch to origin:
 - No upstream set: `git push -u origin <branch>`.
 - Upstream exists: `git push`.
 
-### 5. Create PR
+For an existing PR update, this push is the delivery action: it updates the
+remote branch backing the open PR. Report this path as `pushed to existing PR`.
+
+### 6. Create or identify PR
 
 The `patch` capstone requires a real PR reference. Where `gh` is available
-and authenticated against the remote, create the PR via `gh pr create`.
-Where forge tooling is absent, the protocol cannot complete — report what
-was committed and pushed locally, note that no `patch` artifact was
-delivered, and stop. Do not synthesize a PR reference.
+and authenticated against the remote:
+- Existing PR update path: reuse the open PR reference found in step 1.
+- New PR path: create the PR via `gh pr create`.
+
+Where forge tooling is absent, the protocol cannot complete — report what was
+committed and pushed locally, note that no `patch` artifact was delivered, and
+stop. Do not synthesize a PR reference.
 
 **Title** (under 70 chars):
 - Single GitHub issue: use the issue title, condensed if needed. Prefix with
@@ -194,14 +216,16 @@ gh pr edit <pr-number-or-url> --body-file /tmp/pr-body.md
   work is ready for review. If the operator explicitly says "draft" or "submit
   as draft," use `--draft`.
 
-### 6. Deliver `patch`
+### 7. Deliver `patch`
 
-The capstone is delivery of the `patch` artifact via the `patch` MCP tool:
+The capstone is delivery of the `patch` artifact via the `patch` MCP tool.
+`patch` is the complete latest PR state snapshot after submission, with the
+same shape for both a newly opened PR and an updated existing PR:
 
 ```
 patch({
   instance_id: "<slug>",
-  pr_reference: "<PR URL from step 5>",
+  pr_reference: "<PR URL from step 6>",
   branch: "<feature branch name>",
   commit: "<head commit SHA at submission>"
 })
@@ -209,9 +233,10 @@ patch({
 
 Runa injects `work_unit` from session context, validates the payload
 against the patch schema, persists the artifact, and records it in the
-artifact store.
+artifact store. Do not emit a partial update artifact that assumes the operator
+already knows the surrounding PR context.
 
-### 7. Report
+### 8. Report
 
 Output:
 - PR URL.
@@ -219,6 +244,7 @@ Output:
 - Commit summary (count and brief subjects).
 - GitHub issue linkage (which GitHub issues are referenced, close vs. ref).
 - `patch` artifact instance_id.
+- Delivery action: "opened new PR" or "pushed to existing PR."
 - Next step: "Get review, then `land` when approved."
 
 ---
@@ -226,11 +252,11 @@ Output:
 ## Failure Policy
 
 - **Forge tooling (`gh`) unavailable or unauthenticated:** The protocol can
-  still commit and push (steps 1–4) but cannot create a PR and therefore
-  cannot deliver the `patch` capstone. Report what was committed and pushed,
-  note the missing forge action, and stop. Do not synthesize a `patch`
-  artifact without a real `pr_reference`. Remote-side failures are covered
-  by the push bullets below.
+  still commit and push (steps 1–5) but cannot create or identify a PR and
+  therefore cannot deliver the `patch` capstone. Report what was committed and
+  pushed, note the missing forge action, and stop. Do not synthesize a `patch`
+  artifact without a real `pr_reference`. Remote-side failures are covered by
+  the push bullets below.
 - **Branch creation fails** (name collision, unresolvable dirty state): Stop
   and report. Do not force-create or silently choose an alternate name.
 - **Push rejected** (remote diverged): Stop and report. Do not force-push. Do
@@ -238,7 +264,9 @@ Output:
   to reconcile.
 - **Push network error:** Retry once. If still failing, report.
 - **`gh pr create` fails:**
-  - Branch already has an open PR: report the existing PR URL (not an error).
+  - Branch already has an open PR: treat as the existing PR update path if
+    deliverable local work was pushed; otherwise report the existing PR URL and
+    stop.
   - Permissions error: stop and report.
   - Other: report and stop. The branch is pushed; the operator resolves
     the cause and directs runa to re-activate `submit`. Manual forge

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -60,17 +60,27 @@ Determine:
 - Whether uncommitted changes exist (`git status`).
 - Whether an open PR exists for the current branch (`gh pr list --head <branch>
   --state open --json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner`)
-  when `gh` is available. For an open PR, record the PR URL as the downstream PR
-  reference, the PR number, the PR head SHA (`headRefOid`) for ancestry
-  classification, the PR head branch (`headRefName`), and the PR head
-  repository (`<headRepositoryOwner.login>/<headRepository.name>`) for existing
-  PR push delivery. Fetch the PR head into the local object database before
-  classification: `git fetch origin pull/<number>/head`. This is the GitHub PR
+  when `gh` is available. Run `gh repo view --json nameWithOwner,url` in the
+  same repository context as the PR listing, and record that value as the PR
+  base repository identity. For an open PR, record the PR URL as the downstream
+  PR reference, the PR number, the PR head SHA (`headRefOid`) for ancestry
+  classification, the PR head branch (`headRefName`), the PR head repository
+  (`<headRepositoryOwner.login>/<headRepository.name>`) for existing PR push
+  delivery, and the PR base repository for PR-head fetch. Resolve a local remote
+  matching the PR base repository, using that remote's fetch URL, and fetch the
+  PR head into the local object database before classification:
+  `git fetch <base-repo-remote> pull/<number>/head`. This is the GitHub PR
   refspec paired with `gh` discovery. Existing-PR delivery is a single
   GitHub-shaped commitment across `gh` discovery, the `pull/<number>/head`
-  refspec, and remote URL normalization; adapting the protocol to another forge
-  requires changing all three together. After fetching, verify that
+  refspec, and shared GitHub remote matching; adapting the protocol to another
+  forge requires changing all three together. After fetching, verify that
   `headRefOid` resolves as a commit before any operation consumes it.
+- Shared GitHub remote matching uses one normalization rule for every consumer:
+  accept SSH and HTTPS GitHub URLs, strip `.git`, compare the lowercase
+  `<owner>/<repo>`, and treat non-GitHub URL forms as non-matches. Fetch
+  resolution inspects `git remote get-url <remote>` against the PR base
+  repository; push resolution inspects
+  `git remote get-url --push <remote>` against the PR head repository.
 - Whether upstream tracking exists for the current branch. This is input for
   post-commit deliverability classification when no open PR exists.
 - GitHub issue number(s), resolved in priority order:
@@ -163,21 +173,21 @@ deliverability result is produced here.
 - **No open PR and upstream exists:** commits ahead of the branch's remote
   tracking ref (`git log @{upstream}..HEAD`) are deliverable by opening a new PR
   after pushing the branch.
-- **No open PR and no upstream:** local commits on the feature branch are
-  deliverable under first-push semantics by opening a new PR after pushing the
-  branch.
+- **No open PR and no upstream:** run `git log main..HEAD` to verify that local
+  commits exist ahead of the base branch. If commits exist, local commits on the
+  feature branch are deliverable under first-push semantics by opening a new PR
+  after pushing the branch. If no commits exist, no committed local work is
+  deliverable; report `clean-branch-no-changes` and stop.
 
 ### 5. Push
 
 Use the delivery path from step 4:
 
 - **Existing PR update path:** resolve a local remote whose effective push URL
-  points at the PR head repository recorded in step 1. For each remote, inspect
-  `git remote get-url --push <remote>`. Push the submitted commits to the PR head
-  branch: `git push <head-repo-remote> HEAD:<headRefName>`. Remote matching uses
-  GitHub-form normalization: accept SSH and HTTPS GitHub URLs, strip `.git`,
-  compare the lowercase `<owner>/<repo>`, and treat non-GitHub URL forms as
-  non-matches.
+  points at the PR head repository recorded in step 1, using shared GitHub
+  remote matching. For each remote, inspect `git remote get-url --push <remote>`.
+  Push the submitted commits to the PR head branch:
+  `git push <head-repo-remote> HEAD:<headRefName>`.
   Do not push the local branch name to `origin` and assume that it updates the
   open PR. This push is the delivery action; after it succeeds, report this path
   as `pushed to existing PR`.
@@ -302,6 +312,10 @@ Output:
   not rebase automatically. Commits are safely local; the operator decides how
   to reconcile.
 - **Push network error:** Retry once. If still failing, report.
+- **No local remote matches the PR base repository:** Stop before PR head fetch
+  and ancestry classification. Report the PR URL, PR base repository, and that
+  no matching local remote was found. Do not run `git merge-base` against an
+  unfetched or unresolvable `headRefOid`.
 - **No local remote matches the PR head repository:** Stop before push. Report
   the PR URL, PR head repository, and `headRefName`. Do not deliver a `patch`
   artifact because the PR was not updated.

--- a/tests/test_submit_protocol.py
+++ b/tests/test_submit_protocol.py
@@ -26,6 +26,15 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertNotIn("git log origin/main..HEAD", protocol)
         self.assertNotIn("git log main..HEAD", protocol)
 
+    def test_deliverability_distinguishes_no_upstream_existing_pr_by_pr_head(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("No upstream and no open PR", protocol)
+        self.assertIn("No upstream and open PR", protocol)
+        self.assertIn("PR head SHA", protocol)
+        self.assertIn("headRefOid", protocol)
+        self.assertIn("git rev-parse HEAD", protocol)
+
     def test_analyze_and_commit_applies_to_both_pr_delivery_paths(self) -> None:
         protocol = normalized_submit_protocol()
 

--- a/tests/test_submit_protocol.py
+++ b/tests/test_submit_protocol.py
@@ -35,6 +35,25 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("headRefOid", protocol)
         self.assertIn("git rev-parse HEAD", protocol)
 
+    def test_existing_pr_context_captures_pr_reference_and_head_sha(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("record the PR URL", protocol)
+        self.assertIn("downstream PR reference", protocol)
+        self.assertIn("PR head SHA", protocol)
+        self.assertIn("headRefOid", protocol)
+
+    def test_no_upstream_existing_pr_classifies_all_ancestry_states(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("If `HEAD` and `headRefOid` are the same SHA", protocol)
+        self.assertIn("If `HEAD` is an ancestor of `headRefOid`", protocol)
+        self.assertIn("local checkout is behind the PR", protocol)
+        self.assertIn("If `headRefOid` is an ancestor of `HEAD`", protocol)
+        self.assertIn("deliverable through the existing PR update path", protocol)
+        self.assertIn("If neither commit is an ancestor of the other", protocol)
+        self.assertIn("Report the divergence and stop", protocol)
+
     def test_analyze_and_commit_applies_to_both_pr_delivery_paths(self) -> None:
         protocol = normalized_submit_protocol()
 

--- a/tests/test_submit_protocol.py
+++ b/tests/test_submit_protocol.py
@@ -43,6 +43,25 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("PR head SHA", protocol)
         self.assertIn("headRefOid", protocol)
 
+    def test_existing_pr_discovery_fetches_resolvable_pr_head_before_classification(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("--json url,number,headRefOid", protocol)
+        self.assertIn("git fetch origin pull/<number>/head", protocol)
+        self.assertIn("GitHub PR refspec", protocol)
+        self.assertIn("verify that `headRefOid` resolves", protocol)
+        self.assertLess(
+            protocol.index("git fetch origin pull/<number>/head"),
+            protocol.index("git merge-base --is-ancestor"),
+        )
+
+    def test_existing_pr_head_fetch_failure_stops_with_pr_url(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("PR head fetch or resolvability check fails", protocol)
+        self.assertIn("recorded PR URL", protocol)
+        self.assertIn("stop before ancestry classification", protocol)
+
     def test_no_upstream_existing_pr_classifies_all_ancestry_states(self) -> None:
         protocol = normalized_submit_protocol()
 

--- a/tests/test_submit_protocol.py
+++ b/tests/test_submit_protocol.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SUBMIT_PROTOCOL_PATH = ROOT / "protocols" / "submit" / "PROTOCOL.md"
+
+
+def normalized_submit_protocol() -> str:
+    return re.sub(r"\s+", " ", SUBMIT_PROTOCOL_PATH.read_text())
+
+
+class SubmitProtocolTests(unittest.TestCase):
+    def test_existing_pr_with_local_work_is_a_push_path_not_a_stop_path(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("open PR exists and deliverable local work exists", protocol)
+        self.assertIn("push to the existing PR branch", protocol)
+        self.assertIn("pushed to existing PR", protocol)
+
+    def test_deliverable_commits_are_measured_against_remote_tracking_ref(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("branch's remote tracking ref", protocol)
+        self.assertNotIn("git log origin/main..HEAD", protocol)
+        self.assertNotIn("git log main..HEAD", protocol)
+
+    def test_analyze_and_commit_applies_to_both_pr_delivery_paths(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("shared step applies before either PR delivery path", protocol)
+        self.assertIn("new PR or an existing PR update", protocol)
+
+    def test_patch_artifact_is_complete_latest_pr_state_on_both_paths(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("complete latest PR state snapshot", protocol)
+        self.assertIn(
+            "same shape for both a newly opened PR and an updated existing PR",
+            protocol,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_submit_protocol.py
+++ b/tests/test_submit_protocol.py
@@ -49,10 +49,20 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("PR head SHA", protocol)
         self.assertIn("headRefOid", protocol)
 
+    def test_existing_pr_context_captures_pr_head_repo_and_ref(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("--json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner", protocol)
+        self.assertIn("PR head branch", protocol)
+        self.assertIn("headRefName", protocol)
+        self.assertIn("PR head repository", protocol)
+        self.assertIn("headRepositoryOwner.login", protocol)
+        self.assertIn("headRepository.name", protocol)
+
     def test_existing_pr_discovery_fetches_resolvable_pr_head_before_classification(self) -> None:
         protocol = normalized_submit_protocol()
 
-        self.assertIn("--json url,number,headRefOid", protocol)
+        self.assertIn("--json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner", protocol)
         self.assertIn("git fetch origin pull/<number>/head", protocol)
         self.assertIn("GitHub PR refspec", protocol)
         self.assertIn("verify that `headRefOid` resolves", protocol)
@@ -78,6 +88,45 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("deliverable through the existing PR update path", protocol)
         self.assertIn("If neither commit is an ancestor of the other", protocol)
         self.assertIn("Report the divergence and stop", protocol)
+
+    def test_existing_pr_push_targets_discovered_pr_head_ref(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("Existing PR update path", protocol)
+        self.assertIn("local remote whose effective push URL points at the PR head repository", protocol)
+        self.assertIn("git push <head-repo-remote> HEAD:<headRefName>", protocol)
+        self.assertIn("Do not push the local branch name to `origin`", protocol)
+
+    def test_existing_pr_remote_matching_is_part_of_github_forge_shape(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("GitHub-shaped commitment", protocol)
+        self.assertIn("`gh` discovery", protocol)
+        self.assertIn("`pull/<number>/head`", protocol)
+        self.assertIn("remote URL normalization", protocol)
+        self.assertIn("git remote get-url --push <remote>", protocol)
+        self.assertIn("SSH and HTTPS GitHub URLs", protocol)
+        self.assertIn("strip `.git`", protocol)
+        self.assertIn("lowercase `<owner>/<repo>`", protocol)
+        self.assertIn("non-GitHub URL forms as non-matches", protocol)
+
+    def test_existing_pr_without_matching_head_remote_stops_before_patch(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("No local remote matches the PR head repository", protocol)
+        self.assertIn("Stop before push", protocol)
+        self.assertIn("PR URL", protocol)
+        self.assertIn("PR head repository", protocol)
+        self.assertIn("headRefName", protocol)
+        self.assertIn("Do not deliver a `patch` artifact", protocol)
+
+    def test_new_pr_path_still_pushes_feature_branch_to_origin(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("New PR path", protocol)
+        self.assertIn("push the feature branch to origin", protocol)
+        self.assertIn("git push -u origin <branch>", protocol)
+        self.assertIn("if upstream exists, run `git push`", protocol)
 
     def test_analyze_and_commit_applies_to_both_pr_delivery_paths(self) -> None:
         protocol = normalized_submit_protocol()

--- a/tests/test_submit_protocol.py
+++ b/tests/test_submit_protocol.py
@@ -11,6 +11,13 @@ def normalized_submit_protocol() -> str:
     return re.sub(r"\s+", " ", SUBMIT_PROTOCOL_PATH.read_text())
 
 
+def normalized_section(start: str, end: str) -> str:
+    protocol = SUBMIT_PROTOCOL_PATH.read_text()
+    section_start = protocol.index(start)
+    section_end = protocol.index(end, section_start)
+    return re.sub(r"\s+", " ", protocol[section_start:section_end])
+
+
 class SubmitProtocolTests(unittest.TestCase):
     def test_existing_pr_with_local_work_is_a_push_path_not_a_stop_path(self) -> None:
         protocol = normalized_submit_protocol()
@@ -59,6 +66,21 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("headRepositoryOwner.login", protocol)
         self.assertIn("headRepository.name", protocol)
 
+    def test_step_1_captures_pr_discovery_substrate(self) -> None:
+        step_1 = normalized_section("### 1. Resolve context", "### 2. Ensure feature branch")
+
+        self.assertIn("--json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner", step_1)
+        self.assertIn("record the PR URL", step_1)
+        self.assertIn("PR number", step_1)
+        self.assertIn("PR head SHA (`headRefOid`)", step_1)
+        self.assertIn("PR head branch (`headRefName`)", step_1)
+        self.assertIn("PR head repository", step_1)
+        self.assertIn("headRepositoryOwner.login", step_1)
+        self.assertIn("headRepository.name", step_1)
+        self.assertIn("git fetch origin pull/<number>/head", step_1)
+        self.assertIn("verify that `headRefOid` resolves", step_1)
+        self.assertIn("post-commit deliverability classification", step_1)
+
     def test_existing_pr_discovery_fetches_resolvable_pr_head_before_classification(self) -> None:
         protocol = normalized_submit_protocol()
 
@@ -88,6 +110,19 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("deliverable through the existing PR update path", protocol)
         self.assertIn("If neither commit is an ancestor of the other", protocol)
         self.assertIn("Report the divergence and stop", protocol)
+
+    def test_step_4_classifies_post_commit_deliverability_for_all_paths(self) -> None:
+        step_4 = normalized_section("### 4. Resolve PR delivery path", "### 5. Push")
+
+        self.assertIn("After commit analysis has completed", step_4)
+        self.assertIn("classify current `HEAD`", step_4)
+        self.assertIn("Open PR exists", step_4)
+        self.assertIn("If `HEAD` and `headRefOid` are the same SHA", step_4)
+        self.assertIn("If `HEAD` is an ancestor of `headRefOid`", step_4)
+        self.assertIn("If `headRefOid` is an ancestor of `HEAD`", step_4)
+        self.assertIn("If neither commit is an ancestor of the other", step_4)
+        self.assertIn("No open PR and upstream exists", step_4)
+        self.assertIn("No open PR and no upstream", step_4)
 
     def test_existing_pr_push_targets_discovered_pr_head_ref(self) -> None:
         protocol = normalized_submit_protocol()

--- a/tests/test_submit_protocol.py
+++ b/tests/test_submit_protocol.py
@@ -5,10 +5,15 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 SUBMIT_PROTOCOL_PATH = ROOT / "protocols" / "submit" / "PROTOCOL.md"
+CHANGELOG_PATH = ROOT / "CHANGELOG.md"
 
 
 def normalized_submit_protocol() -> str:
     return re.sub(r"\s+", " ", SUBMIT_PROTOCOL_PATH.read_text())
+
+
+def normalized_changelog() -> str:
+    return re.sub(r"\s+", " ", CHANGELOG_PATH.read_text())
 
 
 def normalized_section(start: str, end: str) -> str:
@@ -66,10 +71,19 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("headRepositoryOwner.login", protocol)
         self.assertIn("headRepository.name", protocol)
 
+    def test_existing_pr_context_captures_pr_base_repo_from_same_gh_context(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("gh repo view --json nameWithOwner,url", protocol)
+        self.assertIn("same repository context", protocol)
+        self.assertIn("PR base repository", protocol)
+        self.assertIn("base repository identity", protocol)
+
     def test_step_1_captures_pr_discovery_substrate(self) -> None:
         step_1 = normalized_section("### 1. Resolve context", "### 2. Ensure feature branch")
 
         self.assertIn("--json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner", step_1)
+        self.assertIn("gh repo view --json nameWithOwner,url", step_1)
         self.assertIn("record the PR URL", step_1)
         self.assertIn("PR number", step_1)
         self.assertIn("PR head SHA (`headRefOid`)", step_1)
@@ -77,7 +91,8 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("PR head repository", step_1)
         self.assertIn("headRepositoryOwner.login", step_1)
         self.assertIn("headRepository.name", step_1)
-        self.assertIn("git fetch origin pull/<number>/head", step_1)
+        self.assertIn("PR base repository", step_1)
+        self.assertIn("git fetch <base-repo-remote> pull/<number>/head", step_1)
         self.assertIn("verify that `headRefOid` resolves", step_1)
         self.assertIn("post-commit deliverability classification", step_1)
 
@@ -85,13 +100,23 @@ class SubmitProtocolTests(unittest.TestCase):
         protocol = normalized_submit_protocol()
 
         self.assertIn("--json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner", protocol)
-        self.assertIn("git fetch origin pull/<number>/head", protocol)
+        self.assertIn("matching the PR base repository", protocol)
+        self.assertIn("git fetch <base-repo-remote> pull/<number>/head", protocol)
         self.assertIn("GitHub PR refspec", protocol)
         self.assertIn("verify that `headRefOid` resolves", protocol)
         self.assertLess(
-            protocol.index("git fetch origin pull/<number>/head"),
+            protocol.index("git fetch <base-repo-remote> pull/<number>/head"),
             protocol.index("git merge-base --is-ancestor"),
         )
+
+    def test_existing_pr_base_remote_failure_stops_before_classification(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("No local remote matches the PR base repository", protocol)
+        self.assertIn("Stop before PR head fetch and ancestry classification", protocol)
+        self.assertIn("PR URL", protocol)
+        self.assertIn("PR base repository", protocol)
+        self.assertIn("matching local remote", protocol)
 
     def test_existing_pr_head_fetch_failure_stops_with_pr_url(self) -> None:
         protocol = normalized_submit_protocol()
@@ -138,8 +163,9 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("GitHub-shaped commitment", protocol)
         self.assertIn("`gh` discovery", protocol)
         self.assertIn("`pull/<number>/head`", protocol)
-        self.assertIn("remote URL normalization", protocol)
+        self.assertIn("shared GitHub remote matching", protocol)
         self.assertIn("git remote get-url --push <remote>", protocol)
+        self.assertIn("git remote get-url <remote>", protocol)
         self.assertIn("SSH and HTTPS GitHub URLs", protocol)
         self.assertIn("strip `.git`", protocol)
         self.assertIn("lowercase `<owner>/<repo>`", protocol)
@@ -163,6 +189,17 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("git push -u origin <branch>", protocol)
         self.assertIn("if upstream exists, run `git push`", protocol)
 
+    def test_no_open_pr_without_upstream_checks_main_ahead_before_first_push(self) -> None:
+        step_4 = normalized_section("### 4. Resolve PR delivery path", "### 5. Push")
+
+        self.assertIn("No open PR and no upstream", step_4)
+        self.assertIn("git log main..HEAD", step_4)
+        self.assertIn("If commits exist", step_4)
+        self.assertIn("first-push semantics", step_4)
+        self.assertIn("If no commits exist", step_4)
+        self.assertIn("clean-branch-no-changes", step_4)
+        self.assertIn("stop", step_4)
+
     def test_analyze_and_commit_applies_to_both_pr_delivery_paths(self) -> None:
         protocol = normalized_submit_protocol()
 
@@ -177,6 +214,14 @@ class SubmitProtocolTests(unittest.TestCase):
             "same shape for both a newly opened PR and an updated existing PR",
             protocol,
         )
+
+    def test_changelog_describes_base_fetch_and_first_push_emptiness(self) -> None:
+        changelog = normalized_changelog()
+
+        self.assertIn("matching PR base repository remote", changelog)
+        self.assertIn("first-push", changelog)
+        self.assertIn("git log main..HEAD", changelog)
+        self.assertIn("clean-branch-no-changes", changelog)
 
 
 if __name__ == "__main__":

--- a/tests/test_submit_protocol.py
+++ b/tests/test_submit_protocol.py
@@ -19,21 +19,27 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("push to the existing PR branch", protocol)
         self.assertIn("pushed to existing PR", protocol)
 
-    def test_deliverable_commits_are_measured_against_remote_tracking_ref(self) -> None:
+    def test_open_pr_deliverability_uses_pr_head_regardless_of_upstream(self) -> None:
         protocol = normalized_submit_protocol()
 
+        self.assertIn("Open PR exists", protocol)
+        self.assertIn("regardless of whether the branch has upstream tracking", protocol)
+        self.assertIn("classify local `HEAD`", protocol)
+        self.assertIn("PR head SHA (`headRefOid`)", protocol)
+        self.assertIn("git merge-base --is-ancestor", protocol)
+
+    def test_no_open_pr_with_upstream_uses_remote_tracking_ref(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("No open PR and upstream exists", protocol)
         self.assertIn("branch's remote tracking ref", protocol)
-        self.assertNotIn("git log origin/main..HEAD", protocol)
-        self.assertNotIn("git log main..HEAD", protocol)
+        self.assertIn("git log @{upstream}..HEAD", protocol)
 
-    def test_deliverability_distinguishes_no_upstream_existing_pr_by_pr_head(self) -> None:
+    def test_no_open_pr_without_upstream_uses_first_push_semantics(self) -> None:
         protocol = normalized_submit_protocol()
 
-        self.assertIn("No upstream and no open PR", protocol)
-        self.assertIn("No upstream and open PR", protocol)
-        self.assertIn("PR head SHA", protocol)
-        self.assertIn("headRefOid", protocol)
-        self.assertIn("git rev-parse HEAD", protocol)
+        self.assertIn("No open PR and no upstream", protocol)
+        self.assertIn("first-push semantics", protocol)
 
     def test_existing_pr_context_captures_pr_reference_and_head_sha(self) -> None:
         protocol = normalized_submit_protocol()
@@ -62,7 +68,7 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("recorded PR URL", protocol)
         self.assertIn("stop before ancestry classification", protocol)
 
-    def test_no_upstream_existing_pr_classifies_all_ancestry_states(self) -> None:
+    def test_existing_pr_classifies_all_ancestry_states(self) -> None:
         protocol = normalized_submit_protocol()
 
         self.assertIn("If `HEAD` and `headRefOid` are the same SHA", protocol)

--- a/tests/test_submit_protocol.py
+++ b/tests/test_submit_protocol.py
@@ -109,6 +109,36 @@ class SubmitProtocolTests(unittest.TestCase):
             protocol.index("git merge-base --is-ancestor"),
         )
 
+    def test_pr_discovery_handles_zero_one_and_multiple_results(self) -> None:
+        step_1 = normalized_section("### 1. Resolve context", "### 2. Ensure feature branch")
+
+        self.assertIn("PR discovery handles result counts explicitly", step_1)
+        self.assertIn("0 results", step_1)
+        self.assertIn("no open PR", step_1)
+        self.assertIn("1 result", step_1)
+        self.assertIn("working PR", step_1)
+        self.assertIn("2+ results", step_1)
+        self.assertIn("disambiguate by head repository", step_1)
+
+    def test_multiple_pr_discovery_uses_shared_remote_matching_for_head_repo(self) -> None:
+        step_1 = normalized_section("### 1. Resolve context", "### 2. Ensure feature branch")
+
+        self.assertIn("filter candidates by PR head repository", step_1)
+        self.assertIn("local remotes", step_1)
+        self.assertIn("shared GitHub remote matching", step_1)
+        self.assertIn("effective push URL", step_1)
+        self.assertIn("exactly one PR survives", step_1)
+
+    def test_ambiguous_pr_discovery_stops_with_candidate_and_remote_context(self) -> None:
+        protocol = normalized_submit_protocol()
+
+        self.assertIn("Ambiguous PR discovery", protocol)
+        self.assertIn("candidate PR URLs", protocol)
+        self.assertIn("candidate head repositories", protocol)
+        self.assertIn("operator's local remotes", protocol)
+        self.assertIn("exactly one local remote", protocol)
+        self.assertIn("exactly one candidate PR head repository", protocol)
+
     def test_existing_pr_base_remote_failure_stops_before_classification(self) -> None:
         protocol = normalized_submit_protocol()
 
@@ -148,6 +178,16 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("If neither commit is an ancestor of the other", step_4)
         self.assertIn("No open PR and upstream exists", step_4)
         self.assertIn("No open PR and no upstream", step_4)
+
+    def test_upstream_tracking_is_determined_at_step_4_classification_time(self) -> None:
+        step_1 = normalized_section("### 1. Resolve context", "### 2. Ensure feature branch")
+        step_4 = normalized_section("### 4. Resolve PR delivery path", "### 5. Push")
+
+        self.assertNotIn("Whether upstream tracking exists", step_1)
+        self.assertIn("determine whether upstream tracking exists", step_4)
+        self.assertIn("classification-time branch state", step_4)
+        self.assertIn("git rev-parse --abbrev-ref --symbolic-full-name @{upstream}", step_4)
+        self.assertIn("A failing upstream lookup means no upstream exists", step_4)
 
     def test_existing_pr_push_targets_discovered_pr_head_ref(self) -> None:
         protocol = normalized_submit_protocol()
@@ -222,6 +262,15 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("first-push", changelog)
         self.assertIn("git log main..HEAD", changelog)
         self.assertIn("clean-branch-no-changes", changelog)
+
+    def test_changelog_describes_classification_time_upstream_and_pr_disambiguation(self) -> None:
+        changelog = normalized_changelog()
+
+        self.assertIn("classification-time branch state", changelog)
+        self.assertIn("upstream tracking", changelog)
+        self.assertIn("multiple open PRs", changelog)
+        self.assertIn("head repository", changelog)
+        self.assertIn("local remote", changelog)
 
 
 if __name__ == "__main__":

--- a/tests/test_submit_protocol.py
+++ b/tests/test_submit_protocol.py
@@ -47,6 +47,17 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("branch's remote tracking ref", protocol)
         self.assertIn("git log @{upstream}..HEAD", protocol)
 
+    def test_no_open_pr_with_upstream_already_pushed_still_opens_pr(self) -> None:
+        step_4 = normalized_section("### 4. Resolve PR delivery path", "### 5. Push")
+        step_5 = normalized_section("### 5. Push", "### 6. Create or identify PR")
+
+        self.assertIn("No open PR and upstream exists", step_4)
+        self.assertIn("run `git log main..HEAD`", step_4)
+        self.assertIn("already-pushed branch still needs a PR", step_4)
+        self.assertIn("Upstream-ahead commits decide whether a push is needed", step_4)
+        self.assertIn("If no upstream-ahead commits exist", step_4)
+        self.assertIn("open the new PR without a push", step_5)
+
     def test_no_open_pr_without_upstream_uses_first_push_semantics(self) -> None:
         protocol = normalized_submit_protocol()
 
@@ -261,6 +272,7 @@ class SubmitProtocolTests(unittest.TestCase):
         self.assertIn("matching PR base repository remote", changelog)
         self.assertIn("first-push", changelog)
         self.assertIn("git log main..HEAD", changelog)
+        self.assertIn("already-pushed branch still needs a PR", changelog)
         self.assertIn("clean-branch-no-changes", changelog)
 
     def test_changelog_describes_classification_time_upstream_and_pr_disambiguation(self) -> None:


### PR DESCRIPTION
## Summary

- Updates `submit` so repeat invocations on branches with open PRs push new local work to the existing PR instead of stopping.
- Defines deliverable commits relative to the branch's remote tracking ref, avoiding false positives from commits already present on the PR branch.
- Keeps the `patch` artifact shape unchanged and documents it as a complete latest PR state snapshot for both new and updated PRs.

## Changes

- Restructured `protocols/submit/PROTOCOL.md` around shared analyze-and-commit discipline plus explicit PR delivery paths.
- Added regression tests for existing-PR update behavior, remote-tracking-ref detection, shared analysis, and patch snapshot semantics.
- Added an Unreleased changelog entry for the operator-visible protocol behavior change.

## GitHub Issue(s)

Closes #253

## Test plan

- `python -m unittest tests.test_submit_protocol`
- `python -m unittest discover -s tests`
- `git diff --check`
