### PR TITLE
feat(release-ceremony): adopt ecosystem release tooling

### DIFF
--- a/.github/workflows/release-metadata.yml
+++ b/.github/workflows/release-metadata.yml
@@ -1,0 +1,46 @@
+name: Release Metadata
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "CHANGELOG.md"
+      - "RELEASING.md"
+      - "manifest.toml"
+      - "schemas/**"
+      - "protocols/**"
+      - "skills/**"
+      - "scripts/release-check"
+      - "scripts/release-cut"
+      - "scripts/release_lib.py"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-metadata.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "CHANGELOG.md"
+      - "RELEASING.md"
+      - "manifest.toml"
+      - "schemas/**"
+      - "protocols/**"
+      - "skills/**"
+      - "scripts/release-check"
+      - "scripts/release-cut"
+      - "scripts/release_lib.py"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-metadata.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  metadata:
+    name: Release metadata
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check release metadata
+        run: ./scripts/release-check metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require annotated tag
+        run: |
+          test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+      - name: Require tag target on main
+        run: |
+          set -euo pipefail
+          git fetch --force origin refs/heads/main:refs/remotes/origin/main
+          tag_commit="$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")"
+          git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+      - name: Verify release identity
+        run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+      - name: Extract release notes
+        run: ./scripts/release-check notes "$GITHUB_REF_NAME" > release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          release_flags=()
+          if [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+[.][0-9]+[.][0-9]+-rc[.][1-9][0-9]*$ ]]; then
+            release_flags+=(--prerelease)
+          fi
+          gh release create "$GITHUB_REF_NAME" \
+            --title "groundwork $GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            --verify-tag \
+            "${release_flags[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `manifest.toml` is now the version-of-record, `scripts/release-check`
   verifies release metadata and tag identity, `scripts/release-cut` performs
   the atomic release operation, and GitHub Actions publish tag-backed releases
-  from changelog notes (closes #301).
+  from changelog notes. The verifier rejects tag-time releases with pending
+  Unreleased entries, validates manifest-declared schemas as JSON, and
+  preserves pre-existing local tags during release-cut failures (closes #301).
 
 ## [0.1.2-rc.1] — 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Release ceremony tooling for the Groundwork methodology release surface:
+  `manifest.toml` is now the version-of-record, `scripts/release-check`
+  verifies release metadata and tag identity, `scripts/release-cut` performs
+  the atomic release operation, and GitHub Actions publish tag-backed releases
+  from changelog notes (closes #301).
+
+## [0.1.2-rc.1] — 2026-05-05
+
+### Added
+
 - New authoring guide `docs/authoring/skills.md` for the `SKILL.md`
   frontmatter convention. Compiles the post-audit convention
   (settled in #245) into follow-direct form so a methodology author

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,103 @@
+# Releasing Groundwork
+
+Audience: the release operator cutting a Groundwork release or release
+candidate. This document assumes access to the repository, GitHub, and Python
+3.11 or newer.
+
+## Release Identity
+
+Groundwork uses one repository tag for one methodology version. Tags are
+`vX.Y.Z` for stable releases and `vX.Y.Z-rc.N` for release candidates. The
+top-level `version = "X.Y.Z"` or `version = "X.Y.Z-rc.N"` field in
+`manifest.toml` is the version-of-record established by commons ADR-0011.
+
+Tag grammar follows commons ADR-0012 exactly: numeric identifiers do not allow
+leading zeroes, release candidates start at `rc.1`, and alpha, beta, and build
+metadata forms are outside this repo's release surface.
+
+## Pre-Release Gate
+
+A releasable commit is on `main`, up to date with `origin/main`, and has a
+clean working tree. Before cutting a tag:
+
+```sh
+git checkout main
+git fetch origin main
+git merge --ff-only origin/main
+git status --short
+./scripts/release-check metadata
+```
+
+For a final tag-time identity check against source already rolled to a version:
+
+```sh
+./scripts/release-check release "vX.Y.Z"
+```
+
+Use `vX.Y.Z-rc.N` for release candidates.
+
+## Atomic Release Operation
+
+Command shape: `scripts/release-cut vX.Y.Z[-rc.N]`.
+
+Stable releases use the repo-owned helper:
+
+```sh
+scripts/release-cut vX.Y.Z
+```
+
+Release candidates use the same helper:
+
+```sh
+scripts/release-cut vX.Y.Z-rc.N
+```
+
+The documented command updates `manifest.toml`, rolls `CHANGELOG.md`, commits
+the release, creates an annotated tag, verifies the tag identity, and pushes
+`main` plus the tag with one atomic git push.
+
+## Post-Release Gate
+
+The tag push runs `.github/workflows/release.yml`. That workflow verifies the
+annotated tag, requires the tag target to be reachable from `main`, runs
+`release-check release`, extracts release notes from `CHANGELOG.md`, and
+publishes the GitHub Release.
+
+Only `vX.Y.Z-rc.N` tags are published as GitHub prereleases.
+
+Manual stable GitHub Release recovery, when needed after a workflow failure:
+
+```sh
+./scripts/release-check notes "vX.Y.Z" > /tmp/groundwork-release-notes.md
+gh release create "vX.Y.Z" \
+  --title "groundwork vX.Y.Z" \
+  --notes-file /tmp/groundwork-release-notes.md \
+  --verify-tag
+```
+
+Manual release-candidate recovery includes the prerelease flag:
+
+```sh
+./scripts/release-check notes "vX.Y.Z-rc.N" > /tmp/groundwork-release-notes.md
+gh release create "vX.Y.Z-rc.N" \
+  --title "groundwork vX.Y.Z-rc.N" \
+  --notes-file /tmp/groundwork-release-notes.md \
+  --verify-tag \
+  --prerelease
+```
+
+## Failure Modes
+
+If `release-cut` fails before the atomic push, fix the source issue and rerun
+the command. If the atomic push fails, the helper removes the local tag and
+resets the release commit so the remote branch and tag remain unchanged.
+
+If a published tag points at source that violates the release identity checks
+and no external consumers have used it, delete the tag locally and remotely and
+rerun the release operation. If external consumers may have used it, leave the
+bad tag in the public record and cut the next version.
+
+If the GitHub Release workflow fails after the tag is valid, repair the
+workflow or environment and create the GitHub Release from
+`scripts/release-check notes`. Do not edit release notes by hand unless the
+changelog section is also corrected in source.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -88,9 +88,11 @@ gh release create "vX.Y.Z-rc.N" \
 
 ## Failure Modes
 
-If `release-cut` fails before the atomic push, fix the source issue and rerun
-the command. If the atomic push fails, the helper removes the local tag and
-resets the release commit so the remote branch and tag remain unchanged.
+If `release-cut` reports that the local tag already exists, it has not changed
+source state; inspect or remove the local tag before rerunning. If
+`release-cut` fails before the atomic push, fix the source issue and rerun the
+command. If the atomic push fails, the helper removes the local tag it created
+and resets the release commit so the remote branch and tag remain unchanged.
 
 If a published tag points at source that violates the release identity checks
 and no external consumers have used it, delete the tag locally and remotely and

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,6 +4,7 @@
 # Topology emerges from the graph of requires/produces relationships.
 
 name = "groundwork"
+version = "0.1.2-rc.1"
 
 # --- Artifact Types ---
 

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+
+from release_lib import ReleaseError, release_check_main, repo_root_from_script
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(release_check_main(repo_root_from_script(__file__), sys.argv[1:]))
+    except ReleaseError as error:
+        print(f"release-check: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/release-cut
+++ b/scripts/release-cut
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+
+from release_lib import ReleaseError, release_cut_main, repo_root_from_script
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(release_cut_main(repo_root_from_script(__file__), sys.argv[1:]))
+    except ReleaseError as error:
+        print(f"release-cut: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -87,6 +87,7 @@ def check_changelog_structure(root: Path) -> None:
         die("CHANGELOG.md must contain exactly one ## [Unreleased] heading")
 
     seen_release = False
+    seen_versions: set[str] = set()
     for line in lines:
         if not line.startswith("## "):
             continue
@@ -96,6 +97,10 @@ def check_changelog_structure(root: Path) -> None:
             continue
         if not RELEASE_HEADING_RE.fullmatch(line):
             die(f"CHANGELOG.md release heading is malformed: {line}")
+        version = line[len("## [") : line.index("]")]
+        if version in seen_versions:
+            die(f"CHANGELOG.md has duplicate release heading for [{version}]")
+        seen_versions.add(version)
         seen_release = True
 
 
@@ -297,6 +302,29 @@ def require_clean_main(root: Path) -> None:
     status = git(root, "status", "--short").stdout.strip()
     if status:
         die("release-cut requires a clean working tree")
+    git(root, "fetch", "origin", "main")
+    head = git(root, "rev-parse", "HEAD").stdout.strip()
+    origin_main = git(root, "rev-parse", "FETCH_HEAD").stdout.strip()
+    if head == origin_main:
+        return
+
+    behind, ahead = (
+        int(count)
+        for count in git(root, "rev-list", "--left-right", "--count", "FETCH_HEAD...HEAD").stdout.split()
+    )
+
+    def commits(count: int) -> str:
+        return f"{count} commit" if count == 1 else f"{count} commits"
+
+    if ahead and behind:
+        divergence = f"main has diverged from origin/main ({commits(ahead)} ahead, {commits(behind)} behind)"
+    elif ahead:
+        divergence = f"main is {commits(ahead)} ahead of origin/main"
+    elif behind:
+        divergence = f"main is {commits(behind)} behind origin/main"
+    else:
+        divergence = "main does not match origin/main"
+    die(f"release-cut requires main to equal origin/main; {divergence}")
 
 
 def local_tag_exists(root: Path, tag: str) -> bool:

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import re
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.[1-9][0-9]*)?$")
+TAG_RE = re.compile(r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.[1-9][0-9]*)?$")
+RELEASE_HEADING_RE = re.compile(
+    r"^## \[(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.[1-9][0-9]*)?\] — [0-9]{4}-[0-9]{2}-[0-9]{2}$"
+)
+
+
+class ReleaseError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    stdout: str
+    stderr: str
+
+
+def die(message: str) -> None:
+    raise ReleaseError(message)
+
+
+def repo_root_from_script(script_file: str) -> Path:
+    return Path(script_file).resolve().parents[1]
+
+
+def version_from_tag(tag: str) -> str:
+    match = TAG_RE.fullmatch(tag)
+    if not match:
+        die(f"release tag must look like vX.Y.Z or vX.Y.Z-rc.N per ADR-0012: {tag}")
+    return tag[1:]
+
+
+def check_version_shape(version: str) -> None:
+    if not VERSION_RE.fullmatch(version):
+        die(f"version must look like X.Y.Z or X.Y.Z-rc.N per ADR-0012: {version}")
+
+
+def read_manifest(root: Path) -> dict:
+    manifest = root / "manifest.toml"
+    if not manifest.is_file():
+        die("manifest.toml not found")
+    try:
+        return tomllib.loads(manifest.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as error:
+        die(f"manifest.toml is invalid TOML: {error}")
+
+
+def manifest_version(root: Path) -> str:
+    manifest = read_manifest(root)
+    version = manifest.get("version")
+    if not isinstance(version, str) or not version:
+        die("manifest.toml top-level version not found")
+    check_version_shape(version)
+    return version
+
+
+def changelog_path(root: Path) -> Path:
+    path = root / "CHANGELOG.md"
+    if not path.is_file():
+        die("CHANGELOG.md not found")
+    return path
+
+
+def release_heading_for(version: str) -> str | None:
+    prefix = f"## [{version}] — "
+    return prefix
+
+
+def check_changelog_structure(root: Path) -> None:
+    changelog = changelog_path(root)
+    lines = changelog.read_text(encoding="utf-8").splitlines()
+    unreleased_count = sum(1 for line in lines if line == "## [Unreleased]")
+    if unreleased_count != 1:
+        die("CHANGELOG.md must contain exactly one ## [Unreleased] heading")
+
+    seen_release = False
+    for line in lines:
+        if not line.startswith("## "):
+            continue
+        if line == "## [Unreleased]":
+            if seen_release:
+                die("CHANGELOG.md places ## [Unreleased] after a release heading")
+            continue
+        if not RELEASE_HEADING_RE.fullmatch(line):
+            die(f"CHANGELOG.md release heading is malformed: {line}")
+        seen_release = True
+
+
+def require_release_heading(root: Path, version: str) -> None:
+    prefix = release_heading_for(version)
+    for line in changelog_path(root).read_text(encoding="utf-8").splitlines():
+        if prefix and line.startswith(prefix):
+            date = line[len(prefix) :]
+            if re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}", date):
+                return
+    die(f"CHANGELOG.md has no release heading for [{version}]")
+
+
+def emit_notes(root: Path, version: str) -> str:
+    prefix = release_heading_for(version)
+    lines = changelog_path(root).read_text(encoding="utf-8").splitlines()
+    start: int | None = None
+    for index, line in enumerate(lines):
+        if prefix and line.startswith(prefix):
+            start = index + 1
+            break
+    if start is None:
+        die(f"CHANGELOG.md has no release heading for [{version}]")
+
+    end = len(lines)
+    for index in range(start, len(lines)):
+        if lines[index].startswith("## "):
+            end = index
+            break
+
+    section = lines[start:end]
+    while section and section[0] == "":
+        section.pop(0)
+    while section and section[-1] == "":
+        section.pop()
+    return "\n".join(section) + ("\n" if section else "")
+
+
+def check_methodology_integrity(root: Path) -> None:
+    manifest = read_manifest(root)
+    artifact_types = manifest.get("artifact_types")
+    protocols = manifest.get("protocols")
+    if not isinstance(artifact_types, list):
+        die("manifest.toml artifact_types must be an array")
+    if not isinstance(protocols, list):
+        die("manifest.toml protocols must be an array")
+
+    artifacts: set[str] = set()
+    for entry in artifact_types:
+        name = entry.get("name") if isinstance(entry, dict) else None
+        if not isinstance(name, str) or not name:
+            die("manifest.toml artifact_types entries must declare name")
+        artifacts.add(name)
+        schema = root / "schemas" / f"{name}.schema.json"
+        if not schema.is_file():
+            die(f"artifact type {name} has no schema at schemas/{name}.schema.json")
+
+    for entry in protocols:
+        if not isinstance(entry, dict):
+            die("manifest.toml protocols entries must be tables")
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            die("manifest.toml protocols entries must declare name")
+        protocol_file = root / "protocols" / name / "PROTOCOL.md"
+        if not protocol_file.is_file():
+            die(f"protocol {name} has no file at protocols/{name}/PROTOCOL.md")
+        for field in ["requires", "accepts", "produces", "may_produce"]:
+            values = entry.get(field, [])
+            if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+                die(f"protocol {name} field {field} must be an array of artifact names")
+            for artifact in values:
+                if artifact not in artifacts:
+                    die(f"protocol {name} references undeclared artifact {artifact} in {field}")
+        trigger = entry.get("trigger")
+        if isinstance(trigger, dict) and trigger.get("type") == "on_artifact":
+            artifact = trigger.get("name")
+            if artifact not in artifacts:
+                die(f"protocol {name} trigger references undeclared artifact {artifact}")
+
+    skills_dir = root / "skills"
+    if skills_dir.is_dir():
+        for skill in sorted(path for path in skills_dir.iterdir() if path.is_dir()):
+            if not (skill / "SKILL.md").is_file():
+                die(f"skill {skill.name} has no SKILL.md")
+
+
+def check_release_surface_files(root: Path) -> None:
+    for relative in [
+        "RELEASING.md",
+        "scripts/release-check",
+        "scripts/release-cut",
+        ".github/workflows/release.yml",
+        ".github/workflows/release-metadata.yml",
+    ]:
+        if not (root / relative).is_file():
+            die(f"{relative} not found")
+
+
+def run_metadata(root: Path) -> None:
+    manifest_version(root)
+    check_changelog_structure(root)
+    check_methodology_integrity(root)
+    check_release_surface_files(root)
+
+
+def run_release(root: Path, tag: str) -> None:
+    version = version_from_tag(tag)
+    run_metadata(root)
+    current = manifest_version(root)
+    if current != version:
+        die(f"manifest version {current} does not match tag version {version}")
+    require_release_heading(root, version)
+
+
+def replace_manifest_version(root: Path, version: str) -> None:
+    manifest = root / "manifest.toml"
+    text = manifest.read_text(encoding="utf-8")
+    pattern = re.compile(r'(?m)^version\s*=\s*"[^"]+"\s*$')
+    replacement = f'version = "{version}"'
+    if pattern.search(text):
+        text = pattern.sub(replacement, text, count=1)
+    else:
+        name_match = re.search(r'(?m)^name\s*=\s*"[^"]+"\s*$', text)
+        if not name_match:
+            die("manifest.toml must declare name before release-cut can insert version")
+        insert_at = name_match.end()
+        text = text[:insert_at] + "\n" + replacement + text[insert_at:]
+    manifest.write_text(text, encoding="utf-8")
+
+
+def roll_changelog(root: Path, version: str) -> None:
+    changelog = changelog_path(root)
+    lines = changelog.read_text(encoding="utf-8").splitlines()
+    try:
+        unreleased = lines.index("## [Unreleased]")
+    except ValueError:
+        die("CHANGELOG.md must contain ## [Unreleased]")
+
+    next_heading = len(lines)
+    for index in range(unreleased + 1, len(lines)):
+        if lines[index].startswith("## "):
+            next_heading = index
+            break
+
+    unreleased_body = lines[unreleased + 1 : next_heading]
+    while unreleased_body and unreleased_body[0] == "":
+        unreleased_body.pop(0)
+    while unreleased_body and unreleased_body[-1] == "":
+        unreleased_body.pop()
+
+    today = _dt.date.today().isoformat()
+    release_section = [f"## [{version}] — {today}"]
+    if unreleased_body:
+        release_section.extend(["", *unreleased_body])
+
+    new_lines = lines[: unreleased + 1] + [""] + release_section
+    if next_heading < len(lines):
+        new_lines.extend(["", *lines[next_heading:]])
+    changelog.write_text("\n".join(new_lines).rstrip() + "\n", encoding="utf-8")
+
+
+def git(root: Path, *args: str, check: bool = True) -> CommandResult:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and result.returncode != 0:
+        die(f"git {' '.join(args)} failed: {result.stderr.strip() or result.stdout.strip()}")
+    return CommandResult(result.stdout, result.stderr)
+
+
+def require_clean_main(root: Path) -> None:
+    branch = git(root, "branch", "--show-current").stdout.strip()
+    if branch != "main":
+        die(f"release-cut must run on main, not {branch or 'detached HEAD'}")
+    status = git(root, "status", "--short").stdout.strip()
+    if status:
+        die("release-cut requires a clean working tree")
+
+
+def release_cut(root: Path, tag: str) -> None:
+    version = version_from_tag(tag)
+    require_clean_main(root)
+    run_metadata(root)
+
+    before = git(root, "rev-parse", "HEAD").stdout.strip()
+    try:
+        replace_manifest_version(root, version)
+        roll_changelog(root, version)
+        run_release(root, tag)
+        git(root, "add", "manifest.toml", "CHANGELOG.md")
+        git(root, "commit", "-m", f"chore(release): {version}", "-m", f"Release {tag}.")
+        git(root, "tag", "-a", tag, "-m", f"groundwork {tag}")
+        push = subprocess.run(
+            ["git", "push", "--atomic", "origin", "main", tag],
+            cwd=root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if push.returncode != 0:
+            raise ReleaseError(f"atomic push failed: {push.stderr.strip() or push.stdout.strip()}")
+    except Exception:
+        subprocess.run(["git", "tag", "-d", tag], cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(["git", "reset", "--hard", before], cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        raise
+
+
+def release_check_main(root: Path, argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="release-check")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    subcommands.add_parser("metadata")
+    notes = subcommands.add_parser("notes")
+    notes.add_argument("tag")
+    release = subcommands.add_parser("release")
+    release.add_argument("tag")
+    args = parser.parse_args(argv)
+
+    if args.command == "metadata":
+        run_metadata(root)
+    elif args.command == "notes":
+        sys.stdout.write(emit_notes(root, version_from_tag(args.tag)))
+    elif args.command == "release":
+        run_release(root, args.tag)
+    return 0
+
+
+def release_cut_main(root: Path, argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="release-cut")
+    parser.add_argument("tag")
+    args = parser.parse_args(argv)
+    release_cut(root, args.tag)
+    return 0

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
+import json
 import re
 import subprocess
 import sys
@@ -108,6 +109,21 @@ def require_release_heading(root: Path, version: str) -> None:
     die(f"CHANGELOG.md has no release heading for [{version}]")
 
 
+def require_unreleased_empty(root: Path) -> None:
+    lines = changelog_path(root).read_text(encoding="utf-8").splitlines()
+    start = lines.index("## [Unreleased]") + 1
+    end = len(lines)
+    for index in range(start, len(lines)):
+        if lines[index].startswith("## "):
+            end = index
+            break
+
+    for line in lines[start:end]:
+        if line == "" or line.startswith("### "):
+            continue
+        die("Unreleased contains entries; roll them into the release section before tagging")
+
+
 def emit_notes(root: Path, version: str) -> str:
     prefix = release_heading_for(version)
     lines = changelog_path(root).read_text(encoding="utf-8").splitlines()
@@ -151,6 +167,10 @@ def check_methodology_integrity(root: Path) -> None:
         schema = root / "schemas" / f"{name}.schema.json"
         if not schema.is_file():
             die(f"artifact type {name} has no schema at schemas/{name}.schema.json")
+        try:
+            json.loads(schema.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            die(f"schema schemas/{name}.schema.json is not valid JSON: {error}")
 
     for entry in protocols:
         if not isinstance(entry, dict):
@@ -207,6 +227,7 @@ def run_release(root: Path, tag: str) -> None:
     if current != version:
         die(f"manifest version {current} does not match tag version {version}")
     require_release_heading(root, version)
+    require_unreleased_empty(root)
 
 
 def replace_manifest_version(root: Path, version: str) -> None:
@@ -278,12 +299,23 @@ def require_clean_main(root: Path) -> None:
         die("release-cut requires a clean working tree")
 
 
+def local_tag_exists(root: Path, tag: str) -> bool:
+    result = subprocess.run(
+        ["git", "show-ref", "--verify", "--quiet", f"refs/tags/{tag}"],
+        cwd=root,
+    )
+    return result.returncode == 0
+
+
 def release_cut(root: Path, tag: str) -> None:
     version = version_from_tag(tag)
     require_clean_main(root)
+    if local_tag_exists(root, tag):
+        die(f"local tag {tag} already exists")
     run_metadata(root)
 
     before = git(root, "rev-parse", "HEAD").stdout.strip()
+    created_tag = False
     try:
         replace_manifest_version(root, version)
         roll_changelog(root, version)
@@ -291,6 +323,7 @@ def release_cut(root: Path, tag: str) -> None:
         git(root, "add", "manifest.toml", "CHANGELOG.md")
         git(root, "commit", "-m", f"chore(release): {version}", "-m", f"Release {tag}.")
         git(root, "tag", "-a", tag, "-m", f"groundwork {tag}")
+        created_tag = True
         push = subprocess.run(
             ["git", "push", "--atomic", "origin", "main", tag],
             cwd=root,
@@ -301,7 +334,8 @@ def release_cut(root: Path, tag: str) -> None:
         if push.returncode != 0:
             raise ReleaseError(f"atomic push failed: {push.stderr.strip() or push.stdout.strip()}")
     except Exception:
-        subprocess.run(["git", "tag", "-d", tag], cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        if created_tag:
+            subprocess.run(["git", "tag", "-d", tag], cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         subprocess.run(["git", "reset", "--hard", before], cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         raise
 

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -1,0 +1,293 @@
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(
+    args: list[str],
+    cwd: Path,
+    *,
+    check: bool = False,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        env=merged_env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"command failed: {' '.join(args)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def assert_success(test: unittest.TestCase, result: subprocess.CompletedProcess[str]) -> None:
+    test.assertEqual(
+        result.returncode,
+        0,
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+    )
+
+
+def assert_failure_contains(
+    test: unittest.TestCase,
+    result: subprocess.CompletedProcess[str],
+    expected: str,
+) -> None:
+    test.assertNotEqual(result.returncode, 0, f"command unexpectedly succeeded\n{result.stdout}")
+    test.assertIn(expected, result.stderr)
+
+
+class ReleaseFixture:
+    def __init__(self, name: str, version: str = "1.2.3") -> None:
+        self.root = Path(tempfile.mkdtemp(prefix=f"groundwork-release-{name}-"))
+        self.write_valid_surface(version)
+        self.install_scripts()
+
+    def write(self, relative: str, contents: str) -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(contents).lstrip(), encoding="utf-8")
+
+    def remove(self, relative: str) -> None:
+        path = self.root / relative
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+    def install_scripts(self) -> None:
+        scripts = self.root / "scripts"
+        scripts.mkdir(exist_ok=True)
+        for name in ["release_lib.py", "release-check", "release-cut"]:
+            source = ROOT / "scripts" / name
+            destination = scripts / name
+            shutil.copy(source, destination)
+            if name != "release_lib.py":
+                destination.chmod(destination.stat().st_mode | stat.S_IXUSR)
+
+    def write_valid_surface(self, version: str) -> None:
+        self.write(
+            "manifest.toml",
+            f"""
+            name = "groundwork"
+            version = "{version}"
+
+            [[artifact_types]]
+            name = "claim"
+
+            [[protocols]]
+            name = "take"
+            requires = ["claim"]
+            accepts = []
+            produces = ["claim"]
+            may_produce = []
+            trigger = {{ type = "on_artifact", name = "claim" }}
+            """,
+        )
+        self.write(
+            "CHANGELOG.md",
+            f"""
+            # Changelog
+
+            ## [Unreleased]
+
+            ## [{version}] — 2026-05-05
+
+            ### Added
+
+            - Release ceremony tooling.
+            """,
+        )
+        self.write("schemas/claim.schema.json", '{"type":"object"}\n')
+        self.write("protocols/take/PROTOCOL.md", "# Take\n")
+        self.write("skills/orient/SKILL.md", "# Orient\n")
+        self.write("README.md", "# Groundwork\n")
+        self.write("RELEASING.md", "scripts/release-cut vX.Y.Z\nADR-0012\n")
+        self.write(".github/workflows/release.yml", "name: Release\n")
+        self.write(".github/workflows/release-metadata.yml", "name: Release Metadata\n")
+
+    def run_release_check(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return run([sys.executable, "scripts/release-check", *args], self.root)
+
+    def run_release_cut(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return run([sys.executable, "scripts/release-cut", *args], self.root)
+
+    def init_git_with_remote(self) -> Path:
+        remote = self.root.parent / f"{self.root.name}-origin.git"
+        run(["git", "init", "-q"], self.root, check=True)
+        run(["git", "config", "user.name", "release test"], self.root, check=True)
+        run(["git", "config", "user.email", "release-test@example.invalid"], self.root, check=True)
+        run(["git", "checkout", "-q", "-b", "main"], self.root, check=True)
+        run(["git", "add", "."], self.root, check=True)
+        run(["git", "commit", "-q", "-m", "test: seed release fixture"], self.root, check=True)
+        run(["git", "init", "--bare", "-q", str(remote)], self.root, check=True)
+        run(["git", "remote", "add", "origin", str(remote)], self.root, check=True)
+        run(["git", "push", "-q", "-u", "origin", "main"], self.root, check=True)
+        return remote
+
+    def cleanup(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+class ReleaseCeremonyTests(unittest.TestCase):
+    def add_fixture(self, name: str, version: str = "1.2.3") -> ReleaseFixture:
+        fixture = ReleaseFixture(name, version)
+        self.addCleanup(fixture.cleanup)
+        return fixture
+
+    def test_metadata_accepts_a_coherent_groundwork_release_surface(self) -> None:
+        fixture = self.add_fixture("metadata-success")
+
+        result = fixture.run_release_check("metadata")
+
+        assert_success(self, result)
+
+    def test_metadata_rejects_missing_manifest_version(self) -> None:
+        fixture = self.add_fixture("metadata-missing-version")
+        fixture.write("manifest.toml", 'name = "groundwork"\n')
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(self, result, "manifest.toml top-level version not found")
+
+    def test_metadata_rejects_unsupported_version_strings(self) -> None:
+        for version in ["01.2.3", "1.2.3-rc.0", "1.2.3-beta.1", "1.2.3+build.1"]:
+            with self.subTest(version=version):
+                fixture = self.add_fixture(f"metadata-version-{version.replace('/', '-')}", version)
+
+                result = fixture.run_release_check("metadata")
+
+                assert_failure_contains(self, result, "version must look like X.Y.Z or X.Y.Z-rc.N")
+
+    def test_metadata_derives_methodology_integrity_from_filesystem(self) -> None:
+        fixture = self.add_fixture("metadata-derived-integrity")
+        fixture.remove("schemas/claim.schema.json")
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(self, result, "artifact type claim has no schema")
+
+    def test_notes_emit_matching_changelog_section_without_outer_blank_lines(self) -> None:
+        fixture = self.add_fixture("notes-success", "1.2.3-rc.1")
+
+        result = fixture.run_release_check("notes", "v1.2.3-rc.1")
+
+        assert_success(self, result)
+        self.assertEqual(result.stdout, "### Added\n\n- Release ceremony tooling.\n")
+
+    def test_release_rejects_tag_versions_that_do_not_match_manifest_version(self) -> None:
+        fixture = self.add_fixture("release-version-mismatch", "1.2.3")
+
+        result = fixture.run_release_check("release", "v1.2.4")
+
+        assert_failure_contains(self, result, "manifest version 1.2.3 does not match tag version 1.2.4")
+
+    def test_release_heading_lookup_uses_literal_version_matching(self) -> None:
+        fixture = self.add_fixture("release-literal-heading", "1.2.3-rc.1")
+
+        source = (fixture.root / "scripts" / "release_lib.py").read_text(encoding="utf-8")
+
+        self.assertIn("line.startswith(prefix)", source)
+        self.assertNotIn("re.search(prefix", source)
+        self.assertNotIn("re.fullmatch(prefix", source)
+
+    def test_release_cut_creates_stable_release_commit_and_annotated_tag(self) -> None:
+        fixture = self.add_fixture("release-cut-stable", "1.2.2")
+        remote = fixture.init_git_with_remote()
+
+        result = fixture.run_release_cut("v1.2.3")
+
+        assert_success(self, result)
+        self.assertEqual((fixture.root / "manifest.toml").read_text().count('version = "1.2.3"'), 1)
+        self.assertIn("## [1.2.3] —", (fixture.root / "CHANGELOG.md").read_text())
+        self.assertEqual(
+            run(["git", "cat-file", "-t", "v1.2.3"], fixture.root, check=True).stdout.strip(),
+            "tag",
+        )
+        self.assertTrue(
+            run(["git", "--git-dir", str(remote), "rev-parse", "--verify", "refs/tags/v1.2.3"], fixture.root).returncode
+            == 0
+        )
+        assert_success(self, fixture.run_release_check("release", "v1.2.3"))
+
+    def test_release_cut_creates_release_candidate_release_commit_and_tag(self) -> None:
+        fixture = self.add_fixture("release-cut-rc", "1.2.3")
+        fixture.init_git_with_remote()
+
+        result = fixture.run_release_cut("v1.2.3-rc.1")
+
+        assert_success(self, result)
+        self.assertIn('version = "1.2.3-rc.1"', (fixture.root / "manifest.toml").read_text())
+        assert_success(self, fixture.run_release_check("release", "v1.2.3-rc.1"))
+
+    def test_release_cut_atomic_push_leaves_remote_refs_unchanged_on_tag_rejection(self) -> None:
+        fixture = self.add_fixture("release-cut-atomic", "1.2.2")
+        remote = fixture.init_git_with_remote()
+        run(["git", "--git-dir", str(remote), "tag", "v1.2.3", "main"], fixture.root, check=True)
+
+        result = fixture.run_release_cut("v1.2.3")
+
+        assert_failure_contains(self, result, "atomic push failed")
+        self.assertEqual(
+            run(["git", "--git-dir", str(remote), "rev-parse", "refs/heads/main"], fixture.root, check=True).stdout,
+            run(["git", "--git-dir", str(remote), "rev-parse", "v1.2.3"], fixture.root, check=True).stdout,
+        )
+
+
+class ReleaseRepositoryContractTests(unittest.TestCase):
+    def read(self, relative: str) -> str:
+        return (ROOT / relative).read_text(encoding="utf-8")
+
+    def test_manifest_declares_current_methodology_version(self) -> None:
+        self.assertIn('version = "0.1.2-rc.1"', self.read("manifest.toml"))
+
+    def test_release_workflow_verifies_annotated_tags_and_has_no_path_filter(self) -> None:
+        workflow = self.read(".github/workflows/release.yml")
+
+        self.assertIn("refs/tags/$GITHUB_REF_NAME", workflow)
+        self.assertIn("./scripts/release-check release \"$GITHUB_REF_NAME\"", workflow)
+        self.assertIn("./scripts/release-check notes \"$GITHUB_REF_NAME\"", workflow)
+        self.assertNotIn("paths:", workflow)
+
+    def test_release_workflow_marks_only_documented_rc_tags_as_prereleases(self) -> None:
+        workflow = self.read(".github/workflows/release.yml")
+
+        self.assertIn("^v[0-9]+[.][0-9]+[.][0-9]+-rc[.][1-9][0-9]*$", workflow)
+        self.assertNotIn("[[ \"$GITHUB_REF_NAME\" == *-* ]]", workflow)
+
+    def test_release_metadata_workflow_is_split_from_tag_publication(self) -> None:
+        workflow = self.read(".github/workflows/release-metadata.yml")
+
+        self.assertIn("name: Release Metadata", workflow)
+        self.assertIn("pull_request:", workflow)
+        self.assertIn("paths:", workflow)
+        self.assertIn("./scripts/release-check metadata", workflow)
+
+    def test_releasing_documentation_matches_verifier_contract(self) -> None:
+        releasing = self.read("RELEASING.md")
+
+        self.assertIn("manifest.toml", releasing)
+        self.assertIn("scripts/release-cut vX.Y.Z[-rc.N]", releasing)
+        self.assertIn("ADR-0012", releasing)
+        self.assertIn("Only `vX.Y.Z-rc.N` tags are published as GitHub prereleases.", releasing)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -184,6 +184,14 @@ class ReleaseCeremonyTests(unittest.TestCase):
 
         assert_failure_contains(self, result, "artifact type claim has no schema")
 
+    def test_metadata_rejects_malformed_schema_json(self) -> None:
+        fixture = self.add_fixture("metadata-malformed-schema")
+        fixture.write("schemas/claim.schema.json", '{"type": "object"\n')
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(self, result, "schema schemas/claim.schema.json is not valid JSON")
+
     def test_notes_emit_matching_changelog_section_without_outer_blank_lines(self) -> None:
         fixture = self.add_fixture("notes-success", "1.2.3-rc.1")
 
@@ -198,6 +206,60 @@ class ReleaseCeremonyTests(unittest.TestCase):
         result = fixture.run_release_check("release", "v1.2.4")
 
         assert_failure_contains(self, result, "manifest version 1.2.3 does not match tag version 1.2.4")
+
+    def test_release_rejects_tag_with_non_empty_unreleased_entries(self) -> None:
+        fixture = self.add_fixture("release-unreleased-entries", "1.2.3")
+        fixture.write(
+            "CHANGELOG.md",
+            """
+            # Changelog
+
+            ## [Unreleased]
+
+            ### Added
+
+            - Pending release note.
+
+            ## [1.2.3] — 2026-05-05
+
+            ### Added
+
+            - Release ceremony tooling.
+            """,
+        )
+
+        result = fixture.run_release_check("release", "v1.2.3")
+
+        assert_failure_contains(
+            self,
+            result,
+            "Unreleased contains entries; roll them into the release section before tagging",
+        )
+
+    def test_release_allows_unreleased_structural_placeholders(self) -> None:
+        fixture = self.add_fixture("release-unreleased-placeholders", "1.2.3")
+        fixture.write(
+            "CHANGELOG.md",
+            """
+            # Changelog
+
+            ## [Unreleased]
+
+            ### Added
+
+            ### Changed
+
+            ## [1.2.3] — 2026-05-05
+
+            ### Added
+
+            - Release ceremony tooling.
+            """,
+        )
+
+        result = fixture.run_release_check("release", "v1.2.3")
+
+        assert_success(self, result)
 
     def test_release_heading_lookup_uses_literal_version_matching(self) -> None:
         fixture = self.add_fixture("release-literal-heading", "1.2.3-rc.1")
@@ -248,6 +310,20 @@ class ReleaseCeremonyTests(unittest.TestCase):
         self.assertEqual(
             run(["git", "--git-dir", str(remote), "rev-parse", "refs/heads/main"], fixture.root, check=True).stdout,
             run(["git", "--git-dir", str(remote), "rev-parse", "v1.2.3"], fixture.root, check=True).stdout,
+        )
+
+    def test_release_cut_preserves_pre_existing_local_tag(self) -> None:
+        fixture = self.add_fixture("release-cut-existing-local-tag", "1.2.2")
+        fixture.init_git_with_remote()
+        run(["git", "tag", "v1.2.3", "HEAD"], fixture.root, check=True)
+        before = run(["git", "rev-parse", "v1.2.3^{commit}"], fixture.root, check=True).stdout
+
+        result = fixture.run_release_cut("v1.2.3")
+
+        assert_failure_contains(self, result, "local tag v1.2.3 already exists")
+        self.assertEqual(
+            before,
+            run(["git", "rev-parse", "v1.2.3^{commit}"], fixture.root, check=True).stdout,
         )
 
 

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -192,6 +192,37 @@ class ReleaseCeremonyTests(unittest.TestCase):
 
         assert_failure_contains(self, result, "schema schemas/claim.schema.json is not valid JSON")
 
+    def test_metadata_rejects_duplicate_release_headings_for_one_version(self) -> None:
+        fixture = self.add_fixture("metadata-duplicate-release-heading", "1.2.3-rc.1")
+        fixture.write(
+            "CHANGELOG.md",
+            """
+            # Changelog
+
+            ## [Unreleased]
+
+            ## [1.2.3-rc.1] — 2026-05-06
+
+            ### Changed
+
+            - Candidate notes from a later section.
+
+            ## [1.2.3-rc.1] — 2026-05-05
+
+            ### Added
+
+            - Candidate notes from an earlier section.
+            """,
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(
+            self,
+            result,
+            "CHANGELOG.md has duplicate release heading for [1.2.3-rc.1]",
+        )
+
     def test_notes_emit_matching_changelog_section_without_outer_blank_lines(self) -> None:
         fixture = self.add_fixture("notes-success", "1.2.3-rc.1")
 
@@ -273,6 +304,11 @@ class ReleaseCeremonyTests(unittest.TestCase):
     def test_release_cut_creates_stable_release_commit_and_annotated_tag(self) -> None:
         fixture = self.add_fixture("release-cut-stable", "1.2.2")
         remote = fixture.init_git_with_remote()
+        reviewed_main = run(
+            ["git", "--git-dir", str(remote), "rev-parse", "refs/heads/main"],
+            fixture.root,
+            check=True,
+        ).stdout.strip()
 
         result = fixture.run_release_cut("v1.2.3")
 
@@ -286,6 +322,21 @@ class ReleaseCeremonyTests(unittest.TestCase):
         self.assertTrue(
             run(["git", "--git-dir", str(remote), "rev-parse", "--verify", "refs/tags/v1.2.3"], fixture.root).returncode
             == 0
+        )
+        self.assertEqual(
+            "1",
+            run(
+                [
+                    "git",
+                    "--git-dir",
+                    str(remote),
+                    "rev-list",
+                    "--count",
+                    f"{reviewed_main}..refs/heads/main",
+                ],
+                fixture.root,
+                check=True,
+            ).stdout.strip(),
         )
         assert_success(self, fixture.run_release_check("release", "v1.2.3"))
 
@@ -324,6 +375,33 @@ class ReleaseCeremonyTests(unittest.TestCase):
         self.assertEqual(
             before,
             run(["git", "rev-parse", "v1.2.3^{commit}"], fixture.root, check=True).stdout,
+        )
+
+    def test_release_cut_rejects_clean_main_with_local_commits_ahead_of_origin(self) -> None:
+        fixture = self.add_fixture("release-cut-local-ahead-main", "1.2.2")
+        remote = fixture.init_git_with_remote()
+        remote_before = run(
+            ["git", "--git-dir", str(remote), "rev-parse", "refs/heads/main"],
+            fixture.root,
+            check=True,
+        ).stdout
+        fixture.write("README.md", "# Groundwork\n\nLocal unreleased work.\n")
+        run(["git", "add", "README.md"], fixture.root, check=True)
+        run(["git", "commit", "-q", "-m", "test: local unreviewed work"], fixture.root, check=True)
+        local_before = run(["git", "rev-parse", "HEAD"], fixture.root, check=True).stdout
+
+        result = fixture.run_release_cut("v1.2.3")
+
+        assert_failure_contains(self, result, "main is 1 commit ahead of origin/main")
+        self.assertEqual(local_before, run(["git", "rev-parse", "HEAD"], fixture.root, check=True).stdout)
+        self.assertEqual("", run(["git", "status", "--short"], fixture.root, check=True).stdout)
+        self.assertEqual(
+            remote_before,
+            run(["git", "--git-dir", str(remote), "rev-parse", "refs/heads/main"], fixture.root, check=True).stdout,
+        )
+        self.assertNotEqual(
+            0,
+            run(["git", "show-ref", "--verify", "--quiet", "refs/tags/v1.2.3"], fixture.root).returncode,
         )
 
 


### PR DESCRIPTION
## Summary

- Adds Groundwork release identity via top-level `manifest.toml` version metadata.
- Adds repo-owned release ceremony tooling: `release-check`, `release-cut`, metadata/tag verification, notes extraction, and atomic release publishing behavior.
- Adds release workflows, operator documentation, changelog coverage, and unittest regression coverage for stable and RC release paths.

## Changes

- Release tooling: shared Python parser/verifier plus executable `scripts/release-check` and `scripts/release-cut` entrypoints.
- CI: split release metadata checks from tag-backed GitHub Release publication.
- Docs/tests: `RELEASING.md`, `CHANGELOG.md`, and release ceremony tests covering grammar rejection, methodology integrity, notes extraction, workflow contracts, and release-cut integration.

## GitHub Issue(s)

Closes #301

## Test plan

- `python -m unittest discover -s tests -v`
- `./scripts/release-check metadata`
- `./scripts/release-check release v0.1.2-rc.1`
