### PR TITLE
fix(protocols): clarify MCP artifact delivery contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   examples still show the flat MCP input shape, including `instance_id`, while
   clarifying that runa extracts routing parameters before schema validation,
   injects `work_unit` for scoped protocols, and requires delivery through the
-  MCP tool rather than direct workspace writes (closes #299, closes #300).
+  MCP tool rather than direct workspace writes (refs #299, closes #300).
 
 ## [0.1.2-rc.1] — 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Unreleased entries, validates manifest-declared schemas as JSON, and
   preserves pre-existing local tags during release-cut failures (closes #301).
 
+### Fixed
+
+- Protocol artifact-delivery sections now distinguish MCP tool input from
+  artifact body content across all ten artifact-producing protocols. The
+  examples still show the flat MCP input shape, including `instance_id`, while
+  clarifying that runa extracts routing parameters before schema validation,
+  injects `work_unit` for scoped protocols, and requires delivery through the
+  MCP tool rather than direct workspace writes (closes #299, closes #300).
+
 ## [0.1.2-rc.1] — 2026-05-05
 
 ### Added

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -171,7 +171,14 @@ surfaces. Full runa-native `decompose` — where work-units live as runa
 artifacts with tracker as an optional sync target — is separate future work.
 
 Deliver each `work-unit` artifact by invoking the `work-unit` MCP tool once
-per delivered artifact. Use a fresh `instance_id` when creating a new
+per delivered artifact. The object below is MCP tool input, not artifact body.
+`instance_id` is a tool parameter that names the artifact instance; it is
+extracted before validating artifact content, becomes the workspace filename,
+and must not appear in the artifact body. `work-unit` is a planning-phase
+artifact: the agent supplies the schema fields shown below, and runa does not
+inject `work_unit`. Do not write the workspace JSON file directly.
+
+Use a fresh `instance_id` when creating a new
 work-unit. Reuse the existing `instance_id` when refining an already-delivered
 work-unit artifact so artifact identity and inbound dependency references
 remain stable. For a work-unit that exists in the tracker but has not
@@ -223,9 +230,7 @@ dependencies, first delivery uses the same reversible
 `work-unit-<N>-<short-slug>` convention, so later sessions can recover the
 tracker identifier directly from the artifact identifier without maintaining a
 separate mapping. For non-tracker-backed dependencies, use the dependency's
-bare `<short-slug>` `instance_id`. `work-unit` is a planning-phase artifact:
-the agent supplies the schema fields shown above, and runa does not inject
-`work_unit`.
+bare `<short-slug>` `instance_id`.
 
 ## Triggers
 

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -222,8 +222,9 @@ Choosing a new slug during refinement creates a duplicate artifact and leaves
 inbound `dependencies` pointing at the stale work-unit instead of the refined
 one.
 
-Runa validates the payload against the `work-unit` schema, persists the
-artifact under the given `instance_id`, and records it in the artifact store.
+Runa validates the remaining artifact body fields against the `work-unit`
+schema, persists the artifact under the given `instance_id`, and records it in
+the artifact store.
 The `dependencies` field takes the target work-units' exact `instance_id`
 values, not tracker references such as `#123`. For tracker-backed
 dependencies, first delivery uses the same reversible

--- a/protocols/document/PROTOCOL.md
+++ b/protocols/document/PROTOCOL.md
@@ -57,7 +57,12 @@ Fires after verification, before `submit`.
 6. **Apply audience test.** For each updated or created doc: "Would the
    intended reader know what to do after reading this?"
 7. **Deliver `documentation-record`.** Invoke the
-   `documentation-record` MCP tool:
+   `documentation-record` MCP tool. The object below is MCP tool input, not
+   artifact body. `instance_id` is a tool parameter that names the artifact
+   instance; it is extracted before validating artifact content, becomes the
+   workspace filename, and must not appear in the artifact body. Runa injects
+   `work_unit` from session context; the agent does not supply `work_unit`. Do
+   not write the workspace JSON file directly:
 
    ```
    documentation-record({
@@ -68,9 +73,9 @@ Fires after verification, before `submit`.
    })
    ```
 
-   Runa injects `work_unit` from session context, validates the payload
-   against the documentation-record schema, persists the artifact, and
-   records it in the artifact store.
+   Runa validates the remaining artifact body fields against the
+   documentation-record schema, persists the artifact, and records it in the
+   artifact store.
 
 ### evaluate-existing-docs
 

--- a/protocols/implement/PROTOCOL.md
+++ b/protocols/implement/PROTOCOL.md
@@ -240,7 +240,12 @@ long run.
 ### deliver-test-evidence
 
 The capstone is delivery of the `test-evidence` artifact. Invoke the
-`test-evidence` MCP tool:
+`test-evidence` MCP tool. The object below is MCP tool input, not artifact
+body. `instance_id` is a tool parameter that names the artifact instance; it is
+extracted before validating artifact content, becomes the workspace filename,
+and must not appear in the artifact body. Runa injects `work_unit` from session
+context; the agent does not supply `work_unit`. Do not write the workspace JSON
+file directly:
 
 ```
 test-evidence({
@@ -254,9 +259,8 @@ test-evidence({
 })
 ```
 
-Runa injects `work_unit` from session context, validates the payload against
-the test-evidence schema, persists the artifact, and records it in the
-artifact store.
+Runa validates the remaining artifact body fields against the test-evidence
+schema, persists the artifact, and records it in the artifact store.
 
 ## Anti-Rationalization
 

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -234,7 +234,12 @@ If any comment or close operation fails, continue processing remaining work-unit
 #### 1f. Deliver `completion-record`
 
 The capstone is delivery of the `completion-record` artifact — the terminal
-archival record for the work-unit. Invoke the `completion-record` MCP tool:
+archival record for the work-unit. Invoke the `completion-record` MCP tool. The
+object below is MCP tool input, not artifact body. `instance_id` is a tool
+parameter that names the artifact instance; it is extracted before validating
+artifact content, becomes the workspace filename, and must not appear in the
+artifact body. Runa injects `work_unit` from session context; the agent does
+not supply `work_unit`. Do not write the workspace JSON file directly:
 
 ```
 completion-record({
@@ -246,9 +251,8 @@ completion-record({
 })
 ```
 
-Runa injects `work_unit` from session context, validates the payload
-against the completion-record schema, persists the artifact, and records
-it in the artifact store.
+Runa validates the remaining artifact body fields against the completion-record
+schema, persists the artifact, and records it in the artifact store.
 
 If work-units could not be closed in the tracker (e.g., `gh` unavailable
 in step 1e), include those IDs and the reason in `gaps` so the manual

--- a/protocols/plan/PROTOCOL.md
+++ b/protocols/plan/PROTOCOL.md
@@ -124,7 +124,12 @@ mistakes.
 ### deliver-plan
 
 Deliver the `implementation-plan` artifact by invoking the
-`implementation-plan` MCP tool:
+`implementation-plan` MCP tool. The object below is MCP tool input, not
+artifact body. `instance_id` is a tool parameter that names the artifact
+instance; it is extracted before validating artifact content, becomes the
+workspace filename, and must not appear in the artifact body. Runa injects
+`work_unit` from session context; the agent does not supply `work_unit`. Do not
+write the workspace JSON file directly:
 
 ```
 implementation-plan({
@@ -136,9 +141,9 @@ implementation-plan({
 })
 ```
 
-Runa injects `work_unit` from session context, validates the payload
-against the implementation-plan schema, persists the artifact, and records
-it in the artifact store.
+Runa validates the remaining artifact body fields against the
+implementation-plan schema, persists the artifact, and records it in the
+artifact store.
 
 ## Corruption Modes
 

--- a/protocols/specify/PROTOCOL.md
+++ b/protocols/specify/PROTOCOL.md
@@ -126,7 +126,12 @@ refactor that preserves the behavior.
 ### deliver-behavior-contract
 
 The capstone is delivery of the `behavior-contract` artifact. Invoke the
-`behavior-contract` MCP tool:
+`behavior-contract` MCP tool. The object below is MCP tool input, not artifact
+body. `instance_id` is a tool parameter that names the artifact instance; it is
+extracted before validating artifact content, becomes the workspace filename,
+and must not appear in the artifact body. Runa injects `work_unit` from session
+context; the agent does not supply `work_unit`. Do not write the workspace JSON
+file directly:
 
 ```
 behavior-contract({
@@ -142,9 +147,9 @@ behavior-contract({
 })
 ```
 
-Runa injects `work_unit` from session context, validates the payload against
-the behavior-contract schema, persists the artifact, and records it in the
-artifact store.
+Runa validates the remaining artifact body fields against the
+behavior-contract schema, persists the artifact, and records it in the artifact
+store.
 
 ## Corruption Modes
 

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -291,7 +291,12 @@ gh pr edit <pr-number-or-url> --body-file /tmp/pr-body.md
 
 The capstone is delivery of the `patch` artifact via the `patch` MCP tool.
 `patch` is the complete latest PR state snapshot after submission, with the
-same shape for both a newly opened PR and an updated existing PR:
+same shape for both a newly opened PR and an updated existing PR. The object
+below is MCP tool input, not artifact body. `instance_id` is a tool parameter
+that names the artifact instance; it is extracted before validating artifact
+content, becomes the workspace filename, and must not appear in the artifact
+body. Runa injects `work_unit` from session context; the agent does not supply
+`work_unit`. Do not write the workspace JSON file directly:
 
 ```
 patch({
@@ -302,10 +307,10 @@ patch({
 })
 ```
 
-Runa injects `work_unit` from session context, validates the payload
-against the patch schema, persists the artifact, and records it in the
-artifact store. Do not emit a partial update artifact that assumes the operator
-already knows the surrounding PR context.
+Runa validates the remaining artifact body fields against the patch schema,
+persists the artifact, and records it in the artifact store. Do not emit a
+partial update artifact that assumes the operator already knows the surrounding
+PR context.
 
 ### 8. Report
 

--- a/protocols/survey/PROTOCOL.md
+++ b/protocols/survey/PROTOCOL.md
@@ -196,6 +196,11 @@ judgment about what should move forward first.
 ### deliver-requirements
 
 Deliver the `requirements` artifact by invoking the `requirements` MCP tool:
+the object below is MCP tool input, not artifact body. `instance_id` is a
+tool parameter that names the artifact instance; it is extracted before
+validating artifact content, becomes the workspace filename, and must not
+appear in the artifact body. This planning-phase artifact is unscoped; runa
+does not inject `work_unit`. Do not write the workspace JSON file directly.
 
 ```
 requirements({
@@ -209,8 +214,9 @@ requirements({
 })
 ```
 
-Runa validates the payload against the requirements schema, persists the
-artifact under the given `instance_id`, and records it in the artifact store.
+Runa validates the remaining artifact body fields against the requirements
+schema, persists the artifact under the given `instance_id`, and records it in
+the artifact store.
 
 Delivery is successful when the tool returns without error; the survey is
 transmitted when the payload preserves the inquiry that produced it. Schema

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -149,8 +149,12 @@ downstream artifact (behavior-contract, implementation-plan, test-evidence,
 completion-evidence, documentation-record, patch, completion-record) to
 the active work-unit.
 
-Invoke the `claim` MCP tool. Runa injects `work_unit` from session context;
-the agent supplies `instance_id` and `scope`:
+Invoke the `claim` MCP tool. The object below is MCP tool input, not artifact
+body. `instance_id` is a tool parameter that names the artifact instance; it is
+extracted before validating artifact content, becomes the workspace filename,
+and must not appear in the artifact body. Runa injects `work_unit` from session
+context; the agent does not supply `work_unit`. Do not write the workspace JSON
+file directly. The agent supplies `instance_id` and `scope`:
 
 ```
 claim({
@@ -164,9 +168,9 @@ agent intends to accomplish from this work-unit. It is a direction, not a
 rigid prediction; implementation will sharpen it. Name nearby work
 intentionally excluded inline in the scope statement.
 
-Runa validates the payload against the `claim` schema, persists the
-artifact, and records it in the artifact store. The agent does not write
-files, construct filenames, or supply `work_unit`.
+Runa validates the remaining artifact body fields against the `claim` schema,
+persists the artifact, and records it in the artifact store. The agent does not
+write files, construct filenames, or supply `work_unit`.
 
 ### session-close
 

--- a/protocols/verify/PROTOCOL.md
+++ b/protocols/verify/PROTOCOL.md
@@ -138,7 +138,12 @@ Unverified: Trust agent report at face value
 ### deliver-completion-evidence
 
 The capstone is delivery of the `completion-evidence` artifact. Invoke the
-`completion-evidence` MCP tool:
+`completion-evidence` MCP tool. The object below is MCP tool input, not
+artifact body. `instance_id` is a tool parameter that names the artifact
+instance; it is extracted before validating artifact content, becomes the
+workspace filename, and must not appear in the artifact body. Runa injects
+`work_unit` from session context; the agent does not supply `work_unit`. Do not
+write the workspace JSON file directly:
 
 ```
 completion-evidence({
@@ -152,8 +157,8 @@ completion-evidence({
 })
 ```
 
-Runa injects `work_unit` from session context, validates the payload against
-the completion-evidence schema, persists the artifact, and records it in the
+Runa validates the remaining artifact body fields against the
+completion-evidence schema, persists the artifact, and records it in the
 artifact store.
 
 ## Corruption Modes

--- a/tests/test_protocol_artifact_delivery_docs.py
+++ b/tests/test_protocol_artifact_delivery_docs.py
@@ -67,6 +67,22 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
                 else:
                     self.assertIn("runa does not inject `work_unit`", body.lower())
 
+    def test_artifact_validation_sentences_name_post_extraction_body_scope(self) -> None:
+        producers = [protocol for protocol in manifest_protocols() if protocol["produces"]]
+
+        for protocol in producers:
+            protocol_name = protocol["name"]
+            body = normalized_protocol(protocol_name)
+            validation_sentence = re.search(r"Runa validates [^.]+\.", body)
+
+            with self.subTest(protocol=protocol_name):
+                self.assertIsNotNone(validation_sentence)
+                self.assertIn(
+                    "remaining artifact body fields against",
+                    validation_sentence.group(0),
+                )
+                self.assertNotIn("validates the payload against", validation_sentence.group(0))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_protocol_artifact_delivery_docs.py
+++ b/tests/test_protocol_artifact_delivery_docs.py
@@ -1,0 +1,72 @@
+import re
+import tomllib
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "manifest.toml"
+PROTOCOLS_DIR = ROOT / "protocols"
+
+
+def manifest_protocols() -> list[dict]:
+    return tomllib.loads(MANIFEST_PATH.read_text(encoding="utf-8"))["protocols"]
+
+
+def normalized_protocol(name: str) -> str:
+    text = (PROTOCOLS_DIR / name / "PROTOCOL.md").read_text(encoding="utf-8")
+    return re.sub(r"\s+", " ", text)
+
+
+class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
+    def test_all_artifact_producing_protocols_explain_mcp_tool_input_boundary(self) -> None:
+        producers = [protocol for protocol in manifest_protocols() if protocol["produces"]]
+
+        self.assertEqual(
+            [
+                "survey",
+                "decompose",
+                "take",
+                "specify",
+                "plan",
+                "implement",
+                "verify",
+                "document",
+                "submit",
+                "land",
+            ],
+            [protocol["name"] for protocol in producers],
+        )
+
+        for protocol in producers:
+            protocol_name = protocol["name"]
+            artifact = protocol["produces"][0]
+            body = normalized_protocol(protocol_name)
+
+            with self.subTest(protocol=protocol_name, artifact=artifact):
+                self.assertIn(f"`{artifact}` MCP tool", body)
+                self.assertIn("MCP tool input, not artifact body", body)
+                self.assertIn("`instance_id` is a tool parameter", body)
+                self.assertIn("extracted before validating artifact content", body)
+                self.assertIn("must not appear in the artifact body", body)
+                self.assertIn("Do not write", body)
+                self.assertIn("directly", body)
+
+    def test_scoped_protocol_delivery_docs_preserve_work_unit_injection_contract(self) -> None:
+        for protocol in manifest_protocols():
+            if not protocol["produces"]:
+                continue
+
+            protocol_name = protocol["name"]
+            body = normalized_protocol(protocol_name)
+
+            with self.subTest(protocol=protocol_name):
+                if protocol.get("scoped") is True:
+                    self.assertIn("Runa injects `work_unit` from session context", body)
+                    self.assertIn("agent does not supply `work_unit`", body)
+                else:
+                    self.assertIn("runa does not inject `work_unit`", body.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Clarifies artifact delivery sections across all ten artifact-producing protocols so examples are explicitly MCP tool input, not artifact body content.
- Preserves schema strictness by documenting `instance_id` as a tool parameter extracted before artifact validation and `work_unit` as runa-injected for scoped protocols.
- Adds a regression test that checks the manifest-defined producer class for the MCP/body boundary language.

## Changes

- Updated `survey`, `decompose`, `take`, `specify`, `plan`, `implement`, `verify`, `document`, `submit`, and `land` deliver sections.
- Added `tests/test_protocol_artifact_delivery_docs.py` for class-wide documentation contract coverage.
- Added an Unreleased changelog entry for the protocol delivery clarification.

## GitHub Issue(s)

Refs #299
Closes #300

## Test plan

- `python3 -m unittest tests/test_protocol_artifact_delivery_docs.py`
- `python3 -m unittest discover -s tests -p 'test*.py'`
- `./scripts/release-check metadata`
- `git diff --check`

## Landing note

Issue #299 also asks for a full agentd integration session. This checkout does not provide the `agentd` harness, so that criterion remains open for integration verification after merge.