### PR TITLE
fix(release): restore annotated tag identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
+      - name: Verify restored tag matches event
+        run: |
+          set -euo pipefail
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
+
       - name: Require annotated tag
         run: |
           test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Release publication now restores annotated tag refs after checkout, verifies
   the restored tag target still matches the triggering event commit before
   trusting the tag, and rejects future release workflow edits that run
-  repository scripts before tag trust is established (refs tesserine/commons#34,
-  closes #304).
+  repository scripts before tag trust is established. The metadata verifier also
+  rejects event-identity checks split across multiple `run:` steps, where GitHub
+  Actions shell isolation would discard the captured tag target (refs
+  tesserine/commons#34, closes #304).
 - Protocol artifact-delivery sections now distinguish MCP tool input from
   artifact body content across all ten artifact-producing protocols. The
   examples still show the flat MCP input shape, including `instance_id`, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   requires the canonical trust-check commands exactly and also rejects
   event-identity checks split across multiple `run:` steps, same-step
   event-identity checks with intervening executable commands, and named
-  `bash ./scripts/...` / `sh ./scripts/...` wrapper forms before tag trust. More
-  exotic indirect script execution remains a known limit of the current
-  line-scanner validator architecture (refs tesserine/commons#34, closes #304).
+  `bash ./scripts/...` / `sh ./scripts/...` wrapper forms before tag trust.
+  The current metadata verifier validates the single-job release workflow shape
+  used by the lockstep release repos; it does not enforce trust-before-repo-code
+  across multi-job workflow boundaries. More exotic indirect script execution
+  and multi-job handling remain known limits of the current line-scanner
+  validator architecture pending the validator-family ADR at
+  tesserine/commons#36 (refs tesserine/commons#34, closes #304).
 - Protocol artifact-delivery sections now distinguish MCP tool input from
   artifact body content across all ten artifact-producing protocols. The
   examples still show the flat MCP input shape, including `instance_id`, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Release publication now restores annotated tag refs after checkout, verifies
+  the restored tag target still matches the triggering event commit before
+  trusting the tag, and rejects future release workflow edits that run
+  repository scripts before tag trust is established (refs tesserine/commons#34,
+  closes #304).
 - Protocol artifact-delivery sections now distinguish MCP tool input from
   artifact body content across all ten artifact-producing protocols. The
   examples still show the flat MCP input shape, including `instance_id`, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Release publication now restores annotated tag refs after checkout, verifies
   the restored tag target still matches the triggering event commit before
   trusting the tag, and rejects future release workflow edits that run
-  repository scripts before tag trust is established. The metadata verifier also
-  rejects event-identity checks split across multiple `run:` steps, where GitHub
-  Actions shell isolation would discard the captured tag target (refs
-  tesserine/commons#34, closes #304).
+  repository scripts before tag trust is established. The metadata verifier
+  requires the canonical trust-check commands exactly and also rejects
+  event-identity checks split across multiple `run:` steps, where GitHub Actions
+  shell isolation would discard the captured tag target (refs tesserine/commons#34,
+  closes #304).
 - Protocol artifact-delivery sections now distinguish MCP tool input from
   artifact body content across all ten artifact-producing protocols. The
   examples still show the flat MCP input shape, including `instance_id`, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   trusting the tag, and rejects future release workflow edits that run
   repository scripts before tag trust is established. The metadata verifier
   requires the canonical trust-check commands exactly and also rejects
-  event-identity checks split across multiple `run:` steps, where GitHub Actions
-  shell isolation would discard the captured tag target (refs tesserine/commons#34,
-  closes #304).
+  event-identity checks split across multiple `run:` steps, same-step
+  event-identity checks with intervening executable commands, and named
+  `bash ./scripts/...` / `sh ./scripts/...` wrapper forms before tag trust. More
+  exotic indirect script execution remains a known limit of the current
+  line-scanner validator architecture (refs tesserine/commons#34, closes #304).
 - Protocol artifact-delivery sections now distinguish MCP tool input from
   artifact body content across all ten artifact-producing protocols. The
   examples still show the flat MCP input shape, including `instance_id`, while

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,6 +66,11 @@ requires the tag target to be reachable from `main`. It then runs
 `release-check release`, extracts release notes from `CHANGELOG.md`, and
 publishes the GitHub Release.
 
+Known limit: the metadata verifier currently validates this single-job release
+workflow shape. If you add a second job to `release.yml`, the verifier does not
+yet enforce trust-before-repository-code across job boundaries; multi-job
+handling is pending the validator-family ADR at tesserine/commons#36.
+
 Only `vX.Y.Z-rc.N` tags are published as GitHub prereleases.
 
 Manual stable GitHub Release recovery, when needed after a workflow failure:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -59,7 +59,10 @@ the release, creates an annotated tag, verifies the tag identity, and pushes
 ## Post-Release Gate
 
 The tag push runs `.github/workflows/release.yml`. That workflow verifies the
-annotated tag, requires the tag target to be reachable from `main`, runs
+release tag's git-local identity before any repository script runs: it restores
+annotated tag refs after checkout, verifies the restored tag target still
+matches the triggering GitHub event commit, verifies the tag is annotated, and
+requires the tag target to be reachable from `main`. It then runs
 `release-check release`, extracts release notes from `CHANGELOG.md`, and
 publishes the GitHub Release.
 

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -31,6 +31,7 @@ class CommandResult:
 @dataclass(frozen=True)
 class WorkflowCommand:
     line_number: int
+    step_index: int
     text: str
 
 
@@ -242,16 +243,21 @@ def _strip_shell_comment(value: str) -> str:
     return re.sub(r"(^|\s)#.*", "", value)
 
 
-def _emit_workflow_command(commands: list[WorkflowCommand], line_number: int, command: str) -> None:
+def _starts_workflow_step(stripped: str) -> bool:
+    return re.match(r"^-\s*(?:name|run|uses):(?:\s|$)", stripped) is not None
+
+
+def _emit_workflow_command(commands: list[WorkflowCommand], line_number: int, step_index: int, command: str) -> None:
     command = _trim(_strip_shell_comment(command))
     if command:
-        commands.append(WorkflowCommand(line_number, command))
+        commands.append(WorkflowCommand(line_number, step_index, command))
 
 
 def workflow_executable_lines(workflow: Path) -> list[WorkflowCommand]:
     commands: list[WorkflowCommand] = []
     in_run_block = False
     run_indent = 0
+    current_step_index = -1
 
     for line_number, raw_line in enumerate(workflow.read_text(encoding="utf-8").splitlines(), start=1):
         line = raw_line.rstrip("\r")
@@ -262,11 +268,13 @@ def workflow_executable_lines(workflow: Path) -> list[WorkflowCommand]:
             if stripped and indent <= run_indent:
                 in_run_block = False
             else:
-                _emit_workflow_command(commands, line_number, line)
+                _emit_workflow_command(commands, line_number, current_step_index, line)
                 continue
 
         if stripped.startswith("#"):
             continue
+        if _starts_workflow_step(stripped):
+            current_step_index += 1
 
         match = re.match(r"^\s*(?:-\s*)?run:\s*(.*)$", line)
         if not match:
@@ -278,18 +286,21 @@ def workflow_executable_lines(workflow: Path) -> list[WorkflowCommand]:
             run_indent = indent
             continue
 
-        _emit_workflow_command(commands, line_number, _unquote(value))
+        _emit_workflow_command(commands, line_number, current_step_index, _unquote(value))
 
     return commands
 
 
 def workflow_uses_lines(workflow: Path) -> list[WorkflowCommand]:
     commands: list[WorkflowCommand] = []
+    current_step_index = -1
     for line_number, raw_line in enumerate(workflow.read_text(encoding="utf-8").splitlines(), start=1):
         line = raw_line.rstrip("\r")
         stripped = _trim(line)
         if stripped.startswith("#"):
             continue
+        if _starts_workflow_step(stripped):
+            current_step_index += 1
 
         match = re.match(r"^\s*(?:-\s*)?uses:\s*(.*)$", line)
         if not match:
@@ -297,7 +308,7 @@ def workflow_uses_lines(workflow: Path) -> list[WorkflowCommand]:
 
         value = _trim(re.sub(r"\s+#.*", "", match.group(1)))
         if value:
-            commands.append(WorkflowCommand(line_number, _unquote(value)))
+            commands.append(WorkflowCommand(line_number, current_step_index, _unquote(value)))
     return commands
 
 
@@ -308,15 +319,18 @@ def _first_line(commands: list[WorkflowCommand], predicate) -> int | None:
     return None
 
 
-def _event_identity_lines(commands: list[WorkflowCommand]) -> tuple[int | None, int | None]:
-    assignment_line: int | None = None
+def _event_identity_lines(commands: list[WorkflowCommand]) -> tuple[int | None, int | None, bool]:
+    assignment_command: WorkflowCommand | None = None
+    saw_split_identity = False
     for command in commands:
         if command.text == 'restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")':
-            assignment_line = command.line_number
+            assignment_command = command
             continue
-        if assignment_line is not None and command.text == 'if [ "$restored_commit" != "$GITHUB_SHA" ]; then':
-            return assignment_line, command.line_number
-    return None, None
+        if assignment_command is not None and command.text == 'if [ "$restored_commit" != "$GITHUB_SHA" ]; then':
+            if assignment_command.step_index == command.step_index:
+                return assignment_command.line_number, command.line_number, False
+            saw_split_identity = True
+    return None, None, saw_split_identity
 
 
 def check_release_workflow_surface(root: Path) -> None:
@@ -329,7 +343,7 @@ def check_release_workflow_surface(root: Path) -> None:
 
     checkout_line = _first_line(uses_lines, lambda text: re.match(r"^actions/checkout(@|$)", text) is not None)
     tag_ref_restore_line = _first_line(executable_lines, lambda text: text == "git fetch --tags --force origin")
-    event_assignment_line, event_if_line = _event_identity_lines(executable_lines)
+    event_assignment_line, event_if_line, split_event_identity = _event_identity_lines(executable_lines)
     annotated_tag_line = _first_line(executable_lines, lambda text: "git cat-file -t" in text)
     main_ancestry_line = _first_line(executable_lines, lambda text: "git merge-base --is-ancestor" in text)
     repository_code_line = _first_line(executable_lines, lambda text: "./scripts/" in text)
@@ -342,6 +356,11 @@ def check_release_workflow_surface(root: Path) -> None:
         die(".github/workflows/release.yml must restore annotated tag refs before checking tag type")
 
     if event_assignment_line is None or event_if_line is None:
+        if split_event_identity:
+            die(
+                ".github/workflows/release.yml event identity commands must run in one workflow step; "
+                "GitHub Actions shell-state isolation prevents variables from crossing steps"
+            )
         die(".github/workflows/release.yml must verify the restored tag matches the triggering event before checking tag type")
     if tag_ref_restore_line >= event_assignment_line or tag_ref_restore_line >= event_if_line:
         die(".github/workflows/release.yml must capture the restored tag target after restoring annotated tag refs")

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -344,9 +344,18 @@ def check_release_workflow_surface(root: Path) -> None:
     checkout_line = _first_line(uses_lines, lambda text: re.match(r"^actions/checkout(@|$)", text) is not None)
     tag_ref_restore_line = _first_line(executable_lines, lambda text: text == "git fetch --tags --force origin")
     event_assignment_line, event_if_line, split_event_identity = _event_identity_lines(executable_lines)
-    annotated_tag_line = _first_line(executable_lines, lambda text: "git cat-file -t" in text)
-    main_ancestry_line = _first_line(executable_lines, lambda text: "git merge-base --is-ancestor" in text)
-    repository_code_line = _first_line(executable_lines, lambda text: "./scripts/" in text)
+    annotated_tag_line = _first_line(
+        executable_lines,
+        lambda text: text == 'test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag',
+    )
+    main_ancestry_line = _first_line(
+        executable_lines,
+        lambda text: text == 'git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main',
+    )
+    repository_code_line = _first_line(
+        executable_lines,
+        lambda text: text == './scripts/release-check release "$GITHUB_REF_NAME"',
+    )
 
     if tag_ref_restore_line is None:
         die(".github/workflows/release.yml must restore annotated tag refs before checking tag type")

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -326,11 +326,27 @@ def _event_identity_lines(commands: list[WorkflowCommand]) -> tuple[int | None, 
         if command.text == 'restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")':
             assignment_command = command
             continue
-        if assignment_command is not None and command.text == 'if [ "$restored_commit" != "$GITHUB_SHA" ]; then':
-            if assignment_command.step_index == command.step_index:
+        if assignment_command is not None:
+            if (
+                command.step_index == assignment_command.step_index
+                and command.text == 'if [ "$restored_commit" != "$GITHUB_SHA" ]; then'
+            ):
                 return assignment_command.line_number, command.line_number, False
+            if command.step_index == assignment_command.step_index:
+                assignment_command = None
+                continue
             saw_split_identity = True
+            assignment_command = None
     return None, None, saw_split_identity
+
+
+def _is_local_script_invocation(text: str) -> bool:
+    if text.startswith("./scripts/"):
+        return True
+    for wrapper in ("bash", "sh"):
+        if text.startswith(f"{wrapper} ./scripts/"):
+            return True
+    return False
 
 
 def check_release_workflow_surface(root: Path) -> None:
@@ -354,7 +370,7 @@ def check_release_workflow_surface(root: Path) -> None:
     )
     repository_code_line = _first_line(
         executable_lines,
-        lambda text: text.startswith("./scripts/"),
+        _is_local_script_invocation,
     )
 
     if tag_ref_restore_line is None:

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -354,7 +354,7 @@ def check_release_workflow_surface(root: Path) -> None:
     )
     repository_code_line = _first_line(
         executable_lines,
-        lambda text: text == './scripts/release-check release "$GITHUB_REF_NAME"',
+        lambda text: text.startswith("./scripts/"),
     )
 
     if tag_ref_restore_line is None:

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -28,6 +28,12 @@ class CommandResult:
     stderr: str
 
 
+@dataclass(frozen=True)
+class WorkflowCommand:
+    line_number: int
+    text: str
+
+
 def die(message: str) -> None:
     raise ReleaseError(message)
 
@@ -218,11 +224,148 @@ def check_release_surface_files(root: Path) -> None:
             die(f"{relative} not found")
 
 
+def _indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _trim(value: str) -> str:
+    return value.strip()
+
+
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _strip_shell_comment(value: str) -> str:
+    return re.sub(r"(^|\s)#.*", "", value)
+
+
+def _emit_workflow_command(commands: list[WorkflowCommand], line_number: int, command: str) -> None:
+    command = _trim(_strip_shell_comment(command))
+    if command:
+        commands.append(WorkflowCommand(line_number, command))
+
+
+def workflow_executable_lines(workflow: Path) -> list[WorkflowCommand]:
+    commands: list[WorkflowCommand] = []
+    in_run_block = False
+    run_indent = 0
+
+    for line_number, raw_line in enumerate(workflow.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.rstrip("\r")
+        indent = _indent_of(line)
+        stripped = _trim(line)
+
+        if in_run_block:
+            if stripped and indent <= run_indent:
+                in_run_block = False
+            else:
+                _emit_workflow_command(commands, line_number, line)
+                continue
+
+        if stripped.startswith("#"):
+            continue
+
+        match = re.match(r"^\s*(?:-\s*)?run:\s*(.*)$", line)
+        if not match:
+            continue
+
+        value = _trim(match.group(1))
+        if value.startswith("|") or value.startswith(">"):
+            in_run_block = True
+            run_indent = indent
+            continue
+
+        _emit_workflow_command(commands, line_number, _unquote(value))
+
+    return commands
+
+
+def workflow_uses_lines(workflow: Path) -> list[WorkflowCommand]:
+    commands: list[WorkflowCommand] = []
+    for line_number, raw_line in enumerate(workflow.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.rstrip("\r")
+        stripped = _trim(line)
+        if stripped.startswith("#"):
+            continue
+
+        match = re.match(r"^\s*(?:-\s*)?uses:\s*(.*)$", line)
+        if not match:
+            continue
+
+        value = _trim(re.sub(r"\s+#.*", "", match.group(1)))
+        if value:
+            commands.append(WorkflowCommand(line_number, _unquote(value)))
+    return commands
+
+
+def _first_line(commands: list[WorkflowCommand], predicate) -> int | None:
+    for command in commands:
+        if predicate(command.text):
+            return command.line_number
+    return None
+
+
+def _event_identity_lines(commands: list[WorkflowCommand]) -> tuple[int | None, int | None]:
+    assignment_line: int | None = None
+    for command in commands:
+        if command.text == 'restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")':
+            assignment_line = command.line_number
+            continue
+        if assignment_line is not None and command.text == 'if [ "$restored_commit" != "$GITHUB_SHA" ]; then':
+            return assignment_line, command.line_number
+    return None, None
+
+
+def check_release_workflow_surface(root: Path) -> None:
+    workflow = root / ".github" / "workflows" / "release.yml"
+    if not workflow.is_file():
+        die(".github/workflows/release.yml not found")
+
+    executable_lines = workflow_executable_lines(workflow)
+    uses_lines = workflow_uses_lines(workflow)
+
+    checkout_line = _first_line(uses_lines, lambda text: re.match(r"^actions/checkout(@|$)", text) is not None)
+    tag_ref_restore_line = _first_line(executable_lines, lambda text: text == "git fetch --tags --force origin")
+    event_assignment_line, event_if_line = _event_identity_lines(executable_lines)
+    annotated_tag_line = _first_line(executable_lines, lambda text: "git cat-file -t" in text)
+    main_ancestry_line = _first_line(executable_lines, lambda text: "git merge-base --is-ancestor" in text)
+    repository_code_line = _first_line(executable_lines, lambda text: "./scripts/" in text)
+
+    if tag_ref_restore_line is None:
+        die(".github/workflows/release.yml must restore annotated tag refs before checking tag type")
+    if checkout_line is None or checkout_line >= tag_ref_restore_line:
+        die(".github/workflows/release.yml must restore annotated tag refs after checkout and before checking tag type")
+    if annotated_tag_line is not None and tag_ref_restore_line >= annotated_tag_line:
+        die(".github/workflows/release.yml must restore annotated tag refs before checking tag type")
+
+    if event_assignment_line is None or event_if_line is None:
+        die(".github/workflows/release.yml must verify the restored tag matches the triggering event before checking tag type")
+    if tag_ref_restore_line >= event_assignment_line or tag_ref_restore_line >= event_if_line:
+        die(".github/workflows/release.yml must capture the restored tag target after restoring annotated tag refs")
+    if annotated_tag_line is not None and (
+        event_assignment_line >= annotated_tag_line or event_if_line >= annotated_tag_line
+    ):
+        die(".github/workflows/release.yml must compare the restored tag target before checking tag type")
+
+    if (
+        annotated_tag_line is None
+        or main_ancestry_line is None
+        or repository_code_line is None
+        or annotated_tag_line >= repository_code_line
+        or main_ancestry_line >= repository_code_line
+    ):
+        die(".github/workflows/release.yml must establish tag trust before running repository code")
+
+
 def run_metadata(root: Path) -> None:
     manifest_version(root)
     check_changelog_structure(root)
     check_methodology_integrity(root)
     check_release_surface_files(root)
+    check_release_workflow_surface(root)
 
 
 def run_release(root: Path, tag: str) -> None:

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -354,6 +354,8 @@ def check_release_workflow_surface(root: Path) -> None:
     if not workflow.is_file():
         die(".github/workflows/release.yml not found")
 
+    # This line scanner validates the current single-job release workflow shape;
+    # multi-job trust ordering is deferred to tesserine/commons#36.
     executable_lines = workflow_executable_lines(workflow)
     uses_lines = workflow_uses_lines(workflow)
 

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -120,8 +120,46 @@ class ReleaseFixture:
         self.write("skills/orient/SKILL.md", "# Orient\n")
         self.write("README.md", "# Groundwork\n")
         self.write("RELEASING.md", "scripts/release-cut vX.Y.Z\nADR-0012\n")
-        self.write(".github/workflows/release.yml", "name: Release\n")
+        self.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Restore annotated tag refs
+                    run: git fetch --tags --force origin
+
+                  - name: Verify restored tag matches event
+                    run: |
+                      restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+                      if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                        echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+                        exit 1
+                      fi
+
+                  - name: Require annotated tag
+                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                  - name: Require tag target on main
+                    run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+            """
+        )
         self.write(".github/workflows/release-metadata.yml", "name: Release Metadata\n")
+
+    def write_release_workflow(self, contents: str) -> None:
+        self.write(".github/workflows/release.yml", contents)
 
     def run_release_check(self, *args: str) -> subprocess.CompletedProcess[str]:
         return run([sys.executable, "scripts/release-check", *args], self.root)
@@ -222,6 +260,251 @@ class ReleaseCeremonyTests(unittest.TestCase):
             result,
             "CHANGELOG.md has duplicate release heading for [1.2.3-rc.1]",
         )
+
+    def test_metadata_rejects_release_workflow_without_tag_ref_restore(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-missing-tag-ref-restore")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Verify restored tag matches event
+                    run: |
+                      restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+                      if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                        exit 1
+                      fi
+
+                  - name: Require annotated tag
+                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                  - name: Require tag target on main
+                    run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(self, result, "must restore annotated tag refs before checking tag type")
+
+    def test_metadata_rejects_release_workflow_without_event_identity_verification(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-missing-event-identity")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Restore annotated tag refs
+                    run: git fetch --tags --force origin
+
+                  - name: Require annotated tag
+                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                  - name: Require tag target on main
+                    run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(
+            self,
+            result,
+            "must verify the restored tag matches the triggering event before checking tag type",
+        )
+
+    def test_metadata_rejects_release_workflow_that_captures_event_identity_before_restore(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-event-assignment-before-restore")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Capture stale tag target
+                    run: restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+
+                  - name: Restore annotated tag refs
+                    run: git fetch --tags --force origin
+
+                  - name: Verify restored tag matches event
+                    run: |
+                      if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                        exit 1
+                      fi
+
+                  - name: Require annotated tag
+                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                  - name: Require tag target on main
+                    run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(
+            self,
+            result,
+            "must capture the restored tag target after restoring annotated tag refs",
+        )
+
+    def test_metadata_rejects_release_workflow_that_compares_event_identity_after_tag_type(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-event-comparison-after-tag-type")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Restore annotated tag refs
+                    run: git fetch --tags --force origin
+
+                  - name: Capture restored tag target
+                    run: restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+
+                  - name: Require annotated tag
+                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                  - name: Compare restored tag target
+                    run: |
+                      if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                        exit 1
+                      fi
+
+                  - name: Require tag target on main
+                    run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(self, result, "must compare the restored tag target before checking tag type")
+
+    def test_metadata_rejects_release_workflow_that_runs_repository_code_before_tag_trust(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-repository-code-before-tag-trust")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Restore annotated tag refs
+                    run: git fetch --tags --force origin
+
+                  - name: Verify restored tag matches event
+                    run: |
+                      restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+                      if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                        exit 1
+                      fi
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+
+                  - name: Require annotated tag
+                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                  - name: Require tag target on main
+                    run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(self, result, "must establish tag trust before running repository code")
+
+    def test_metadata_ignores_workflow_comments_when_validating_release_trust_shape(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-comment-only-trust")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  # run: git fetch --tags --force origin
+                  # run: ./scripts/release-check release "$GITHUB_REF_NAME"
+                  - name: Commented checks
+                    run: |
+                      true  # git cat-file -t "refs/tags/$GITHUB_REF_NAME"
+                      true  # git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(self, result, "must restore annotated tag refs before checking tag type")
 
     def test_notes_emit_matching_changelog_section_without_outer_blank_lines(self) -> None:
         fixture = self.add_fixture("notes-success", "1.2.3-rc.1")
@@ -415,6 +698,9 @@ class ReleaseRepositoryContractTests(unittest.TestCase):
     def test_release_workflow_verifies_annotated_tags_and_has_no_path_filter(self) -> None:
         workflow = self.read(".github/workflows/release.yml")
 
+        self.assertIn("git fetch --tags --force origin", workflow)
+        self.assertIn('restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")', workflow)
+        self.assertIn('if [ "$restored_commit" != "$GITHUB_SHA" ]; then', workflow)
         self.assertIn("refs/tags/$GITHUB_REF_NAME", workflow)
         self.assertIn("./scripts/release-check release \"$GITHUB_REF_NAME\"", workflow)
         self.assertIn("./scripts/release-check notes \"$GITHUB_REF_NAME\"", workflow)

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -513,6 +513,132 @@ class ReleaseCeremonyTests(unittest.TestCase):
 
         assert_failure_contains(self, result, "must establish tag trust before running repository code")
 
+    def test_metadata_rejects_noncanonical_annotated_tag_command_mentions(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-noncanonical-annotated-tag")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Restore annotated tag refs
+                    run: git fetch --tags --force origin
+
+                  - name: Verify restored tag matches event
+                    run: |
+                      restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+                      if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                        exit 1
+                      fi
+
+                  - name: Mention annotated tag check
+                    run: echo "Running git cat-file -t before release"
+
+                  - name: Require tag target on main
+                    run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(self, result, "must establish tag trust before running repository code")
+
+    def test_metadata_rejects_noncanonical_main_ancestry_command_mentions(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-noncanonical-main-ancestry")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Restore annotated tag refs
+                    run: git fetch --tags --force origin
+
+                  - name: Verify restored tag matches event
+                    run: |
+                      restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+                      if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                        exit 1
+                      fi
+
+                  - name: Require annotated tag
+                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                  - name: Mention main ancestry check
+                    run: echo "Running git merge-base --is-ancestor before release"
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(self, result, "must establish tag trust before running repository code")
+
+    def test_metadata_rejects_noncanonical_repository_code_command_mentions(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-noncanonical-repository-code")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Restore annotated tag refs
+                    run: git fetch --tags --force origin
+
+                  - name: Verify restored tag matches event
+                    run: |
+                      restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+                      if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                        exit 1
+                      fi
+
+                  - name: Require annotated tag
+                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                  - name: Require tag target on main
+                    run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                  - name: Mention release check
+                    run: echo "Running ./scripts/release-check release before release"
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(self, result, "must establish tag trust before running repository code")
+
     def test_metadata_ignores_workflow_comments_when_validating_release_trust_shape(self) -> None:
         fixture = self.add_fixture("metadata-workflow-comment-only-trust")
         fixture.write_release_workflow(

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -339,6 +339,54 @@ class ReleaseCeremonyTests(unittest.TestCase):
             "must verify the restored tag matches the triggering event before checking tag type",
         )
 
+    def test_metadata_rejects_release_workflow_that_splits_event_identity_across_run_steps(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-split-event-identity")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Restore annotated tag refs
+                    run: git fetch --tags --force origin
+
+                  - name: Capture restored tag target
+                    run: restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+
+                  - name: Verify restored tag matches event
+                    run: |
+                      if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                        exit 1
+                      fi
+
+                  - name: Require annotated tag
+                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                  - name: Require tag target on main
+                    run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(
+            self,
+            result,
+            "GitHub Actions shell-state isolation prevents variables from crossing steps",
+        )
+
     def test_metadata_rejects_release_workflow_that_captures_event_identity_before_restore(self) -> None:
         fixture = self.add_fixture("metadata-workflow-event-assignment-before-restore")
         fixture.write_release_workflow(
@@ -356,14 +404,10 @@ class ReleaseCeremonyTests(unittest.TestCase):
                   - name: Checkout
                     uses: actions/checkout@v4
 
-                  - name: Capture stale tag target
-                    run: restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
-
-                  - name: Restore annotated tag refs
-                    run: git fetch --tags --force origin
-
-                  - name: Verify restored tag matches event
+                  - name: Verify stale tag target matches event
                     run: |
+                      restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+                      git fetch --tags --force origin
                       if [ "$restored_commit" != "$GITHUB_SHA" ]; then
                         exit 1
                       fi
@@ -407,14 +451,10 @@ class ReleaseCeremonyTests(unittest.TestCase):
                   - name: Restore annotated tag refs
                     run: git fetch --tags --force origin
 
-                  - name: Capture restored tag target
-                    run: restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
-
-                  - name: Require annotated tag
-                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
-
-                  - name: Compare restored tag target
+                  - name: Compare restored tag target after tag type
                     run: |
+                      restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+                      test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
                       if [ "$restored_commit" != "$GITHUB_SHA" ]; then
                         exit 1
                       fi

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -513,6 +513,51 @@ class ReleaseCeremonyTests(unittest.TestCase):
 
         assert_failure_contains(self, result, "must establish tag trust before running repository code")
 
+    def test_metadata_rejects_release_workflow_that_runs_any_local_script_before_tag_trust(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-local-script-before-tag-trust")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Restore annotated tag refs
+                    run: git fetch --tags --force origin
+
+                  - name: Verify restored tag matches event
+                    run: |
+                      restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+                      if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                        exit 1
+                      fi
+
+                  - name: Extract release notes
+                    run: ./scripts/release-check notes "$GITHUB_REF_NAME" > release-notes.md
+
+                  - name: Require annotated tag
+                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                  - name: Require tag target on main
+                    run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(self, result, "must establish tag trust before running repository code")
+
     def test_metadata_rejects_noncanonical_annotated_tag_command_mentions(self) -> None:
         fixture = self.add_fixture("metadata-workflow-noncanonical-annotated-tag")
         fixture.write_release_workflow(

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -387,6 +387,53 @@ class ReleaseCeremonyTests(unittest.TestCase):
             "GitHub Actions shell-state isolation prevents variables from crossing steps",
         )
 
+    def test_metadata_rejects_release_workflow_with_intervening_event_identity_command(self) -> None:
+        fixture = self.add_fixture("metadata-workflow-intervening-event-identity-command")
+        fixture.write_release_workflow(
+            """
+            name: Release
+
+            on:
+              push:
+                tags:
+                  - "v*"
+
+            jobs:
+              publish:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+
+                  - name: Restore annotated tag refs
+                    run: git fetch --tags --force origin
+
+                  - name: Verify restored tag matches event
+                    run: |
+                      restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+                      restored_commit="$GITHUB_SHA"
+                      if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                        exit 1
+                      fi
+
+                  - name: Require annotated tag
+                    run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                  - name: Require tag target on main
+                    run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                  - name: Verify release identity
+                    run: ./scripts/release-check release "$GITHUB_REF_NAME"
+            """
+        )
+
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(
+            self,
+            result,
+            "must verify the restored tag matches the triggering event before checking tag type",
+        )
+
     def test_metadata_rejects_release_workflow_that_captures_event_identity_before_restore(self) -> None:
         fixture = self.add_fixture("metadata-workflow-event-assignment-before-restore")
         fixture.write_release_workflow(
@@ -428,7 +475,7 @@ class ReleaseCeremonyTests(unittest.TestCase):
         assert_failure_contains(
             self,
             result,
-            "must capture the restored tag target after restoring annotated tag refs",
+            "must verify the restored tag matches the triggering event before checking tag type",
         )
 
     def test_metadata_rejects_release_workflow_that_compares_event_identity_after_tag_type(self) -> None:
@@ -469,7 +516,11 @@ class ReleaseCeremonyTests(unittest.TestCase):
 
         result = fixture.run_release_check("metadata")
 
-        assert_failure_contains(self, result, "must compare the restored tag target before checking tag type")
+        assert_failure_contains(
+            self,
+            result,
+            "must verify the restored tag matches the triggering event before checking tag type",
+        )
 
     def test_metadata_rejects_release_workflow_that_runs_repository_code_before_tag_trust(self) -> None:
         fixture = self.add_fixture("metadata-workflow-repository-code-before-tag-trust")
@@ -557,6 +608,53 @@ class ReleaseCeremonyTests(unittest.TestCase):
         result = fixture.run_release_check("metadata")
 
         assert_failure_contains(self, result, "must establish tag trust before running repository code")
+
+    def test_metadata_rejects_release_workflow_that_runs_wrapped_local_script_before_tag_trust(self) -> None:
+        for wrapper in ("bash", "sh"):
+            with self.subTest(wrapper=wrapper):
+                fixture = self.add_fixture(f"metadata-workflow-{wrapper}-wrapped-local-script-before-tag-trust")
+                fixture.write_release_workflow(
+                    f"""
+                    name: Release
+
+                    on:
+                      push:
+                        tags:
+                          - "v*"
+
+                    jobs:
+                      publish:
+                        steps:
+                          - name: Checkout
+                            uses: actions/checkout@v4
+
+                          - name: Restore annotated tag refs
+                            run: git fetch --tags --force origin
+
+                          - name: Verify restored tag matches event
+                            run: |
+                              restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{{commit}}")
+                              if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+                                exit 1
+                              fi
+
+                          - name: Verify release identity through shell
+                            run: {wrapper} ./scripts/release-check release "$GITHUB_REF_NAME"
+
+                          - name: Require annotated tag
+                            run: test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag
+
+                          - name: Require tag target on main
+                            run: git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main
+
+                          - name: Verify release identity
+                            run: ./scripts/release-check release "$GITHUB_REF_NAME"
+                    """
+                )
+
+                result = fixture.run_release_check("metadata")
+
+                assert_failure_contains(self, result, "must establish tag trust before running repository code")
 
     def test_metadata_rejects_noncanonical_annotated_tag_command_mentions(self) -> None:
         fixture = self.add_fixture("metadata-workflow-noncanonical-annotated-tag")


### PR DESCRIPTION
## Summary

- Restores annotated tag refs after checkout before release trust checks.
- Verifies the restored tag target still matches the triggering event commit before checking tag type.
- Adds release-check metadata workflow-shape validation so repository scripts cannot run before tag trust is established.

## Changes

- Release workflow now restores tag refs and performs event-identity verification before annotated-tag and main-ancestry checks.
- `release-check metadata` now scans release workflow commands and enforces checkout, restore, event identity, annotated tag, main ancestry, and repository-code ordering.
- Regression tests cover missing/misordered restore, event identity assignment position, repository code before trust, and comment-only false positives.
- `RELEASING.md` and `CHANGELOG.md` document the corrected release trust surface.

## GitHub Issue(s)

Closes #304
Refs tesserine/commons#34

## Test plan

- `python -m unittest discover -s tests`
- `./scripts/release-check metadata`
