### PR TITLE
feat(install): add interactive groundwork installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   uninstalls Groundwork skills and protocols from a clean pinned checkout into
   `~/.claude/skills/` and `~/.agents/skills/`. Installed entries are copied
   rather than symlinked, protocols are projected as skill-shaped entries, and
-  ownership tracking prevents uninstall from removing operator-managed entries
+  ownership tracking prevents uninstall from removing operator-managed entries.
+  Re-running install against the same unchanged pinned source leaves current
+  managed entries untouched while still restoring managed target drift
   (closes #306).
 - Release ceremony tooling for the Groundwork methodology release surface:
   `manifest.toml` is now the version-of-record, `scripts/release-check`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Official interactive install tooling for Claude Code and Codex:
+  `scripts/groundwork-install` installs, syncs, reports status for, and
+  uninstalls Groundwork skills and protocols from a clean pinned checkout into
+  `~/.claude/skills/` and `~/.agents/skills/`. Installed entries are copied
+  rather than symlinked, protocols are projected as skill-shaped entries, and
+  ownership tracking prevents uninstall from removing operator-managed entries
+  (closes #306).
 - Release ceremony tooling for the Groundwork methodology release surface:
   `manifest.toml` is now the version-of-record, `scripts/release-check`
   verifies release metadata and tag identity, `scripts/release-cut` performs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Interactive install now prepares every discovery root before mutating managed
+  entries, so a non-preparable later root cannot leave earlier roots with
+  marker-bearing entries that lack an install state record.
 - Interactive install now derives installed skill and protocol payloads from the
   pinned commit content instead of the checkout working tree, so ignored local
   artifacts under `skills/` or `protocols/` cannot leak into discovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Interactive install now derives installed skill and protocol payloads from the
+  pinned commit content instead of the checkout working tree, so ignored local
+  artifacts under `skills/` or `protocols/` cannot leak into discovery
+  directories.
 - Protocol artifact-delivery sections now distinguish MCP tool input from
   artifact body content across all ten artifact-producing protocols. The
   examples still show the flat MCP input shape, including `instance_id`, while

--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ uninstall` removes only entries the command created.
 Ownership is tracked in both a per-entry marker file and an XDG state file at
 `${XDG_STATE_HOME:-~/.local/state}/groundwork-install/interactive-install.tsv`.
 Pre-existing entries, including unofficial symlinks with the same names, are
-reported as unmanaged conflicts rather than overwritten or adopted.
+reported as unmanaged conflicts rather than overwritten or adopted. When the
+state file records ownership but the marker is missing at a deletion boundary,
+the command fails and leaves state intact so the operator can inspect the
+disagreement before anything irreversible happens.
 
 Prerequisites are the stock command-line tools expected on Fedora CoreOS for
 this workflow: `bash`, `git`, and POSIX file utilities such as `cp`, `find`,

--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ Claude Code and Codex sessions can install the same skills and protocols into
 their local discovery directories from a pinned Groundwork checkout:
 
 ```bash
-git checkout --detach v0.1.2-rc.1
+git checkout --detach v0.2.0
 scripts/groundwork-install install
 ```
+
+The first release containing `scripts/groundwork-install` is v0.2.0.
 
 The installer writes user-owned entries only, with no root or sudo requirement:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,50 @@ not completeness.
 For how runa orchestrates this topology at runtime, see the
 [interface contract](https://github.com/tesserine/runa/blob/main/docs/interface-contract.md).
 
+## Interactive Installation
+
+Runa-served agents consume Groundwork through the methodology mount. Interactive
+Claude Code and Codex sessions can install the same skills and protocols into
+their local discovery directories from a pinned Groundwork checkout:
+
+```bash
+git checkout --detach v0.1.2-rc.1
+scripts/groundwork-install install
+```
+
+The installer writes user-owned entries only, with no root or sudo requirement:
+
+- `~/.claude/skills/{name}/`
+- `~/.agents/skills/{name}/`
+
+Every directory under `skills/` is copied as a skill entry. Every directory
+under `protocols/` is copied as a skill-shaped entry with `PROTOCOL.md`
+projected to `SKILL.md`, so protocol names are discoverable in the same way as
+skills. Installed entries are copies, not source-checkout symlinks, so later
+changes to the checkout do not drift into the active discovery surface.
+
+The source checkout must be clean and pinned at a tag or full commit SHA. The
+command refuses branch checkouts because a branch is a moving source. To update
+to a different pinned Groundwork version, check out that ref and run:
+
+```bash
+scripts/groundwork-install sync
+```
+
+`sync` converges the discovery directories to the new pinned source, including
+removing entries that no longer exist upstream. `scripts/groundwork-install
+status` reports the recorded install state, and `scripts/groundwork-install
+uninstall` removes only entries the command created.
+
+Ownership is tracked in both a per-entry marker file and an XDG state file at
+`${XDG_STATE_HOME:-~/.local/state}/groundwork-install/interactive-install.tsv`.
+Pre-existing entries, including unofficial symlinks with the same names, are
+reported as unmanaged conflicts rather than overwritten or adopted.
+
+Prerequisites are the stock command-line tools expected on Fedora CoreOS for
+this workflow: `bash`, `git`, and POSIX file utilities such as `cp`, `find`,
+`mkdir`, `mv`, and `rm`.
+
 ## What Groundwork Believes
 
 These are the methodology choices embedded in groundwork's protocols and skills.

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -157,6 +157,35 @@ remove_obsolete_entries() {
   done < "$state_file"
 }
 
+write_marker() {
+  local marker_path="$1"
+  local kind="$2"
+  local name="$3"
+  local sha="$4"
+  cat > "$marker_path" <<EOF
+managed-by=$PROGRAM
+source=$source_path
+source-sha=$sha
+name=$name
+kind=$kind
+EOF
+}
+
+project_entry() {
+  local kind="$1"
+  local name="$2"
+  local src="$3"
+  local target="$4"
+  local sha="$5"
+  mkdir -p "$target"
+  cp -R "$src/." "$target/"
+  if [[ "$kind" == "protocol" ]]; then
+    rm -f "$target/SKILL.md"
+    mv "$target/PROTOCOL.md" "$target/SKILL.md"
+  fi
+  write_marker "$target/$MARKER" "$kind" "$name" "$sha"
+}
+
 copy_entry() {
   local kind="$1"
   local name="$2"
@@ -165,22 +194,59 @@ copy_entry() {
   local sha="$5"
   local tmp
   tmp="$(mktemp -d "${target}.tmp.XXXXXX")"
-  rm -rf "$tmp"
-  mkdir -p "$tmp"
-  cp -R "$src/." "$tmp/"
-  if [[ "$kind" == "protocol" ]]; then
-    rm -f "$tmp/SKILL.md"
-    mv "$tmp/PROTOCOL.md" "$tmp/SKILL.md"
-  fi
-  cat > "$tmp/$MARKER" <<EOF
-managed-by=$PROGRAM
-source=$source_path
-source-sha=$sha
-name=$name
-kind=$kind
-EOF
+  project_entry "$kind" "$name" "$src" "$tmp" "$sha"
   rm -rf "$target"
   mv "$tmp" "$target"
+}
+
+state_records_current_sha() {
+  [[ -f "$state_file" ]] || return 1
+  local expected_target="$1"
+  local expected_name="$2"
+  local expected_kind="$3"
+  local expected_sha="$4"
+  local expected_root="$5"
+  local target name kind sha root
+  while IFS=$'\t' read -r target name kind sha root; do
+    if [[ "$target" == "$expected_target" &&
+      "$name" == "$expected_name" &&
+      "$kind" == "$expected_kind" &&
+      "$sha" == "$expected_sha" &&
+      "$root" == "$expected_root" ]]; then
+      return 0
+    fi
+  done < "$state_file"
+  return 1
+}
+
+target_matches_source() {
+  local kind="$1"
+  local name="$2"
+  local src="$3"
+  local target="$4"
+  local sha="$5"
+  local snapshot
+  snapshot="$(mktemp -d "${target}.snapshot.XXXXXX")"
+  project_entry "$kind" "$name" "$src" "$snapshot" "$sha"
+  if git diff --no-index --quiet "$snapshot" "$target" >/dev/null 2>&1; then
+    rm -rf "$snapshot"
+    return 0
+  fi
+  rm -rf "$snapshot"
+  return 1
+}
+
+entry_is_current() {
+  local kind="$1"
+  local name="$2"
+  local src="$3"
+  local root="$4"
+  local target="$5"
+  local sha="$6"
+  state_records_current_sha "$target" "$name" "$kind" "$sha" "$root" || return 1
+  [[ -d "$target" ]] || return 1
+  [[ -f "$target/$MARKER" ]] || return 1
+  target_matches_source "$kind" "$name" "$src" "$target" "$sha"
 }
 
 write_state() {
@@ -208,7 +274,9 @@ install_or_sync() {
     while IFS= read -r root; do
       mkdir -p "$root"
       target="$root/$name"
-      copy_entry "$kind" "$name" "$src" "$target" "$sha"
+      if ! entry_is_current "$kind" "$name" "$src" "$root" "$target" "$sha"; then
+        copy_entry "$kind" "$name" "$src" "$target" "$sha"
+      fi
     done < <(target_roots)
   done < <(desired_entries)
   write_state

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGRAM="groundwork-install"
+MARKER=".groundwork-install"
+STATE_FILE_NAME="interactive-install.tsv"
+
+usage() {
+  cat <<'EOF'
+usage: groundwork-install [install|sync|status|uninstall] [--source PATH] [--home PATH] [--state-dir PATH]
+
+Installs this pinned Groundwork checkout into Claude Code and Codex skill
+discovery directories. The default subcommand is install.
+EOF
+}
+
+die() {
+  printf '%s: %s\n' "$PROGRAM" "$*" >&2
+  exit 1
+}
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+abs_path() {
+  local path="$1"
+  if [[ -d "$path" ]]; then
+    (cd "$path" && pwd -P)
+  else
+    local dir
+    dir="$(dirname "$path")"
+    local base
+    base="$(basename "$path")"
+    (cd "$dir" && printf '%s/%s\n' "$(pwd -P)" "$base")
+  fi
+}
+
+mode="install"
+source_path="."
+home_path="${HOME:-}"
+state_dir="${XDG_STATE_HOME:-${HOME:-}/.local/state}/groundwork-install"
+
+if [[ "${1:-}" == "install" || "${1:-}" == "sync" || "${1:-}" == "status" || "${1:-}" == "uninstall" ]]; then
+  mode="$1"
+  shift
+fi
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --source)
+      [[ "$#" -ge 2 ]] || die "--source requires a path"
+      source_path="$2"
+      shift 2
+      ;;
+    --home)
+      [[ "$#" -ge 2 ]] || die "--home requires a path"
+      home_path="$2"
+      shift 2
+      ;;
+    --state-dir)
+      [[ "$#" -ge 2 ]] || die "--state-dir requires a path"
+      state_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$home_path" ]] || die "HOME is not set; pass --home"
+command_exists git || die "git is required"
+
+source_path="$(abs_path "$source_path")"
+home_path="$(abs_path "$home_path")"
+mkdir -p "$state_dir"
+state_dir="$(abs_path "$state_dir")"
+state_file="$state_dir/$STATE_FILE_NAME"
+
+validate_source() {
+  [[ -d "$source_path" ]] || die "source not found: $source_path"
+  git -C "$source_path" rev-parse --show-toplevel >/dev/null 2>&1 || die "source must be a git checkout"
+  local root
+  root="$(git -C "$source_path" rev-parse --show-toplevel)"
+  [[ "$(abs_path "$root")" == "$source_path" ]] || die "source must be the groundwork checkout root"
+  [[ -d "$source_path/skills" ]] || die "source has no skills directory"
+  [[ -d "$source_path/protocols" ]] || die "source has no protocols directory"
+  [[ -z "$(git -C "$source_path" status --porcelain)" ]] || die "source checkout is dirty; install from a pinned clean checkout"
+  if git -C "$source_path" symbolic-ref -q --short HEAD >/dev/null; then
+    die "source must be a pinned checkout at a tag or full commit SHA, not a branch"
+  fi
+}
+
+source_sha() {
+  git -C "$source_path" rev-parse HEAD
+}
+
+target_roots() {
+  printf '%s\n' "$home_path/.claude/skills" "$home_path/.agents/skills"
+}
+
+desired_entries() {
+  local dir name
+  if [[ -d "$source_path/skills" ]]; then
+    while IFS= read -r dir; do
+      name="$(basename "$dir")"
+      [[ -f "$dir/SKILL.md" ]] && printf 'skill\t%s\t%s\n' "$name" "$dir"
+    done < <(find "$source_path/skills" -mindepth 1 -maxdepth 1 -type d | sort)
+  fi
+  if [[ -d "$source_path/protocols" ]]; then
+    while IFS= read -r dir; do
+      name="$(basename "$dir")"
+      [[ -f "$dir/PROTOCOL.md" ]] && printf 'protocol\t%s\t%s\n' "$name" "$dir"
+    done < <(find "$source_path/protocols" -mindepth 1 -maxdepth 1 -type d | sort)
+  fi
+}
+
+is_managed_entry() {
+  [[ -f "$1/$MARKER" ]]
+}
+
+preflight_conflicts() {
+  local kind name src root target conflict=0
+  while IFS=$'\t' read -r kind name src; do
+    while IFS= read -r root; do
+      target="$root/$name"
+      if [[ -e "$target" || -L "$target" ]]; then
+        if ! is_managed_entry "$target"; then
+          printf '%s: unmanaged conflict at %s\n' "$PROGRAM" "$target" >&2
+          conflict=1
+        fi
+      fi
+    done < <(target_roots)
+  done < <(desired_entries)
+  [[ "$conflict" -eq 0 ]] || exit 1
+}
+
+remove_obsolete_entries() {
+  [[ -f "$state_file" ]] || return 0
+  local old_target old_name old_kind old_sha old_root target_still_desired
+  local desired_kind desired_name desired_src
+  while IFS=$'\t' read -r old_target old_name old_kind old_sha old_root; do
+    target_still_desired=0
+    while IFS=$'\t' read -r desired_kind desired_name desired_src; do
+      if [[ "$old_name" == "$desired_name" ]]; then
+        target_still_desired=1
+      fi
+    done < <(desired_entries)
+    if [[ "$target_still_desired" -eq 0 && -d "$old_target" && -f "$old_target/$MARKER" ]]; then
+      rm -rf "$old_target"
+    fi
+  done < "$state_file"
+}
+
+copy_entry() {
+  local kind="$1"
+  local name="$2"
+  local src="$3"
+  local target="$4"
+  local sha="$5"
+  local tmp
+  tmp="$(mktemp -d "${target}.tmp.XXXXXX")"
+  rm -rf "$tmp"
+  mkdir -p "$tmp"
+  cp -R "$src/." "$tmp/"
+  if [[ "$kind" == "protocol" ]]; then
+    rm -f "$tmp/SKILL.md"
+    mv "$tmp/PROTOCOL.md" "$tmp/SKILL.md"
+  fi
+  cat > "$tmp/$MARKER" <<EOF
+managed-by=$PROGRAM
+source=$source_path
+source-sha=$sha
+name=$name
+kind=$kind
+EOF
+  rm -rf "$target"
+  mv "$tmp" "$target"
+}
+
+write_state() {
+  local tmp="$state_file.tmp"
+  local kind name src root sha target
+  mkdir -p "$state_dir"
+  : > "$tmp"
+  sha="$(source_sha)"
+  while IFS=$'\t' read -r kind name src; do
+    while IFS= read -r root; do
+      target="$root/$name"
+      printf '%s\t%s\t%s\t%s\t%s\n' "$target" "$name" "$kind" "$sha" "$root" >> "$tmp"
+    done < <(target_roots)
+  done < <(desired_entries)
+  mv "$tmp" "$state_file"
+}
+
+install_or_sync() {
+  validate_source
+  preflight_conflicts
+  remove_obsolete_entries
+  local sha kind name src root target
+  sha="$(source_sha)"
+  while IFS=$'\t' read -r kind name src; do
+    while IFS= read -r root; do
+      mkdir -p "$root"
+      target="$root/$name"
+      copy_entry "$kind" "$name" "$src" "$target" "$sha"
+    done < <(target_roots)
+  done < <(desired_entries)
+  write_state
+  printf '%s: installed %s\n' "$PROGRAM" "$sha"
+}
+
+status_install() {
+  if [[ ! -f "$state_file" ]]; then
+    die "not installed"
+  fi
+  local missing=0 target name kind sha root
+  while IFS=$'\t' read -r target name kind sha root; do
+    if [[ ! -f "$target/$MARKER" ]]; then
+      printf '%s: missing managed entry %s\n' "$PROGRAM" "$target" >&2
+      missing=1
+    fi
+  done < "$state_file"
+  [[ "$missing" -eq 0 ]] || exit 1
+  printf '%s: installed\n' "$PROGRAM"
+}
+
+uninstall() {
+  if [[ ! -f "$state_file" ]]; then
+    die "not installed"
+  fi
+  local target name kind sha root
+  while IFS=$'\t' read -r target name kind sha root; do
+    if [[ -d "$target" && -f "$target/$MARKER" ]]; then
+      rm -rf "$target"
+    fi
+  done < "$state_file"
+  rm -f "$state_file"
+  printf '%s: uninstalled\n' "$PROGRAM"
+}
+
+case "$mode" in
+  install|sync)
+    install_or_sync
+    ;;
+  status)
+    status_install
+    ;;
+  uninstall)
+    uninstall
+    ;;
+esac

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -131,18 +131,27 @@ target_has_marker() {
   [[ -f "$1/$MARKER" ]]
 }
 
-state_records_entry() {
+target_exists() {
+  [[ -e "$1" || -L "$1" ]]
+}
+
+desired_name_exists() {
+  local expected_name="$1"
+  local kind name src
+  while IFS=$'\t' read -r kind name src; do
+    if [[ "$name" == "$expected_name" ]]; then
+      return 0
+    fi
+  done < <(desired_entries)
+  return 1
+}
+
+state_owns_target() {
   [[ -f "$state_file" ]] || return 1
   local expected_target="$1"
-  local expected_name="$2"
-  local expected_kind="$3"
-  local expected_root="$4"
   local target name kind sha root
   while IFS=$'\t' read -r target name kind sha root; do
-    if [[ "$target" == "$expected_target" &&
-      "$name" == "$expected_name" &&
-      "$kind" == "$expected_kind" &&
-      "$root" == "$expected_root" ]]; then
+    if [[ "$target" == "$expected_target" ]]; then
       return 0
     fi
   done < "$state_file"
@@ -154,8 +163,8 @@ preflight_conflicts() {
   while IFS=$'\t' read -r kind name src; do
     while IFS= read -r root; do
       target="$root/$name"
-      if [[ -e "$target" || -L "$target" ]]; then
-        if ! state_records_entry "$target" "$name" "$kind" "$root"; then
+      if target_exists "$target"; then
+        if ! state_owns_target "$target"; then
           printf '%s: unmanaged conflict at %s\n' "$PROGRAM" "$target" >&2
           conflict=1
         fi
@@ -167,16 +176,19 @@ preflight_conflicts() {
 
 remove_obsolete_entries() {
   [[ -f "$state_file" ]] || return 0
-  local old_target old_name old_kind old_sha old_root target_still_desired
-  local desired_kind desired_name desired_src
+  local old_target old_name old_kind old_sha old_root missing_marker=0
   while IFS=$'\t' read -r old_target old_name old_kind old_sha old_root; do
-    target_still_desired=0
-    while IFS=$'\t' read -r desired_kind desired_name desired_src; do
-      if [[ "$old_name" == "$desired_name" ]]; then
-        target_still_desired=1
-      fi
-    done < <(desired_entries)
-    if [[ "$target_still_desired" -eq 0 && -d "$old_target" ]] && target_has_marker "$old_target"; then
+    if ! desired_name_exists "$old_name" &&
+      target_exists "$old_target" &&
+      ! target_has_marker "$old_target"; then
+      printf '%s: missing marker on obsolete managed entry %s\n' "$PROGRAM" "$old_target" >&2
+      missing_marker=1
+    fi
+  done < "$state_file"
+  [[ "$missing_marker" -eq 0 ]] || exit 1
+
+  while IFS=$'\t' read -r old_target old_name old_kind old_sha old_root; do
+    if ! desired_name_exists "$old_name" && [[ -d "$old_target" ]] && target_has_marker "$old_target"; then
       rm -rf "$old_target"
     fi
   done < "$state_file"
@@ -244,20 +256,39 @@ state_records_current_sha() {
   return 1
 }
 
-target_matches_source() {
+target_payload_matches_source() {
   local kind="$1"
   local name="$2"
   local src="$3"
   local target="$4"
   local sha="$5"
-  local snapshot
+  local snapshot target_snapshot
   snapshot="$(mktemp -d "${target}.snapshot.XXXXXX")"
+  target_snapshot="$(mktemp -d "${target}.target.XXXXXX")"
   project_entry "$kind" "$name" "$src" "$snapshot" "$sha"
-  if git diff --no-index --quiet "$snapshot" "$target" >/dev/null 2>&1; then
-    rm -rf "$snapshot"
+  cp -R "$target/." "$target_snapshot/"
+  rm -f "$snapshot/$MARKER" "$target_snapshot/$MARKER"
+  if git diff --no-index --quiet "$snapshot" "$target_snapshot" >/dev/null 2>&1; then
+    rm -rf "$snapshot" "$target_snapshot"
     return 0
   fi
-  rm -rf "$snapshot"
+  rm -rf "$snapshot" "$target_snapshot"
+  return 1
+}
+
+marker_matches_current() {
+  local target="$1"
+  local kind="$2"
+  local name="$3"
+  local sha="$4"
+  local marker
+  marker="$(mktemp "${target}.marker.XXXXXX")"
+  write_marker "$marker" "$kind" "$name" "$sha"
+  if cmp -s "$marker" "$target/$MARKER"; then
+    rm -f "$marker"
+    return 0
+  fi
+  rm -f "$marker"
   return 1
 }
 
@@ -271,7 +302,18 @@ entry_is_current() {
   state_records_current_sha "$target" "$name" "$kind" "$sha" "$root" || return 1
   [[ -d "$target" ]] || return 1
   target_has_marker "$target" || return 1
-  target_matches_source "$kind" "$name" "$src" "$target" "$sha"
+  marker_matches_current "$target" "$kind" "$name" "$sha" || return 1
+  target_payload_matches_source "$kind" "$name" "$src" "$target" "$sha"
+}
+
+entry_payload_is_current() {
+  local kind="$1"
+  local name="$2"
+  local src="$3"
+  local target="$4"
+  local sha="$5"
+  [[ -d "$target" ]] || return 1
+  target_payload_matches_source "$kind" "$name" "$src" "$target" "$sha"
 }
 
 write_state() {
@@ -300,7 +342,12 @@ install_or_sync() {
       mkdir -p "$root"
       target="$root/$name"
       if ! entry_is_current "$kind" "$name" "$src" "$root" "$target" "$sha"; then
-        copy_entry "$kind" "$name" "$src" "$target" "$sha"
+        if state_owns_target "$target" &&
+          entry_payload_is_current "$kind" "$name" "$src" "$target" "$sha"; then
+          write_marker "$target/$MARKER" "$kind" "$name" "$sha"
+        else
+          copy_entry "$kind" "$name" "$src" "$target" "$sha"
+        fi
       fi
     done < <(target_roots)
   done < <(desired_entries)
@@ -327,7 +374,15 @@ uninstall() {
   if [[ ! -f "$state_file" ]]; then
     die "not installed"
   fi
-  local target name kind sha root
+  local target name kind sha root missing_marker=0
+  while IFS=$'\t' read -r target name kind sha root; do
+    if target_exists "$target" && ! target_has_marker "$target"; then
+      printf '%s: missing marker on managed entry %s\n' "$PROGRAM" "$target" >&2
+      missing_marker=1
+    fi
+  done < "$state_file"
+  [[ "$missing_marker" -eq 0 ]] || exit 1
+
   while IFS=$'\t' read -r target name kind sha root; do
     if [[ -d "$target" ]] && target_has_marker "$target"; then
       rm -rf "$target"

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -127,8 +127,26 @@ desired_entries() {
   fi
 }
 
-is_managed_entry() {
+target_has_marker() {
   [[ -f "$1/$MARKER" ]]
+}
+
+state_records_entry() {
+  [[ -f "$state_file" ]] || return 1
+  local expected_target="$1"
+  local expected_name="$2"
+  local expected_kind="$3"
+  local expected_root="$4"
+  local target name kind sha root
+  while IFS=$'\t' read -r target name kind sha root; do
+    if [[ "$target" == "$expected_target" &&
+      "$name" == "$expected_name" &&
+      "$kind" == "$expected_kind" &&
+      "$root" == "$expected_root" ]]; then
+      return 0
+    fi
+  done < "$state_file"
+  return 1
 }
 
 preflight_conflicts() {
@@ -137,7 +155,7 @@ preflight_conflicts() {
     while IFS= read -r root; do
       target="$root/$name"
       if [[ -e "$target" || -L "$target" ]]; then
-        if ! is_managed_entry "$target"; then
+        if ! state_records_entry "$target" "$name" "$kind" "$root"; then
           printf '%s: unmanaged conflict at %s\n' "$PROGRAM" "$target" >&2
           conflict=1
         fi
@@ -158,7 +176,7 @@ remove_obsolete_entries() {
         target_still_desired=1
       fi
     done < <(desired_entries)
-    if [[ "$target_still_desired" -eq 0 && -d "$old_target" && -f "$old_target/$MARKER" ]]; then
+    if [[ "$target_still_desired" -eq 0 && -d "$old_target" ]] && target_has_marker "$old_target"; then
       rm -rf "$old_target"
     fi
   done < "$state_file"
@@ -252,7 +270,7 @@ entry_is_current() {
   local sha="$6"
   state_records_current_sha "$target" "$name" "$kind" "$sha" "$root" || return 1
   [[ -d "$target" ]] || return 1
-  [[ -f "$target/$MARKER" ]] || return 1
+  target_has_marker "$target" || return 1
   target_matches_source "$kind" "$name" "$src" "$target" "$sha"
 }
 
@@ -296,7 +314,7 @@ status_install() {
   fi
   local missing=0 target name kind sha root
   while IFS=$'\t' read -r target name kind sha root; do
-    if [[ ! -f "$target/$MARKER" ]]; then
+    if ! target_has_marker "$target"; then
       printf '%s: missing managed entry %s\n' "$PROGRAM" "$target" >&2
       missing=1
     fi
@@ -311,7 +329,7 @@ uninstall() {
   fi
   local target name kind sha root
   while IFS=$'\t' read -r target name kind sha root; do
-    if [[ -d "$target" && -f "$target/$MARKER" ]]; then
+    if [[ -d "$target" ]] && target_has_marker "$target"; then
       rm -rf "$target"
     fi
   done < "$state_file"

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -112,18 +112,21 @@ target_roots() {
 }
 
 desired_entries() {
-  local dir name
+  local sha name rel
+  sha="$(source_sha)"
   if [[ -d "$source_path/skills" ]]; then
-    while IFS= read -r dir; do
-      name="$(basename "$dir")"
-      [[ -f "$dir/SKILL.md" ]] && printf 'skill\t%s\t%s\n' "$name" "$dir"
-    done < <(find "$source_path/skills" -mindepth 1 -maxdepth 1 -type d | sort)
+    while IFS= read -r name; do
+      rel="skills/$name"
+      git -C "$source_path" cat-file -e "$sha:$rel/SKILL.md" 2>/dev/null &&
+        printf 'skill\t%s\t%s\n' "$name" "$rel"
+    done < <(git -C "$source_path" ls-tree -d --name-only "$sha:skills" | sort)
   fi
   if [[ -d "$source_path/protocols" ]]; then
-    while IFS= read -r dir; do
-      name="$(basename "$dir")"
-      [[ -f "$dir/PROTOCOL.md" ]] && printf 'protocol\t%s\t%s\n' "$name" "$dir"
-    done < <(find "$source_path/protocols" -mindepth 1 -maxdepth 1 -type d | sort)
+    while IFS= read -r name; do
+      rel="protocols/$name"
+      git -C "$source_path" cat-file -e "$sha:$rel/PROTOCOL.md" 2>/dev/null &&
+        printf 'protocol\t%s\t%s\n' "$name" "$rel"
+    done < <(git -C "$source_path" ls-tree -d --name-only "$sha:protocols" | sort)
   fi
 }
 
@@ -215,7 +218,7 @@ project_entry() {
   local target="$4"
   local sha="$5"
   mkdir -p "$target"
-  cp -R "$src/." "$target/"
+  git -C "$source_path" archive --format=tar "$sha:$src" | tar -xf - -C "$target"
   if [[ "$kind" == "protocol" ]]; then
     rm -f "$target/SKILL.md"
     mv "$target/PROTOCOL.md" "$target/SKILL.md"

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -177,6 +177,16 @@ preflight_conflicts() {
   [[ "$conflict" -eq 0 ]] || exit 1
 }
 
+prepare_target_roots() {
+  local root probe
+  while IFS= read -r root; do
+    mkdir -p "$root" || die "target root is not preparable: $root"
+    probe="$(mktemp -d "$root/.groundwork-install-preflight.XXXXXX")" ||
+      die "target root is not writable: $root"
+    rmdir "$probe" || die "target root preflight cleanup failed: $probe"
+  done < <(target_roots)
+}
+
 remove_obsolete_entries() {
   [[ -f "$state_file" ]] || return 0
   local old_target old_name old_kind old_sha old_root missing_marker=0
@@ -337,12 +347,12 @@ write_state() {
 install_or_sync() {
   validate_source
   preflight_conflicts
+  prepare_target_roots
   remove_obsolete_entries
   local sha kind name src root target
   sha="$(source_sha)"
   while IFS=$'\t' read -r kind name src; do
     while IFS= read -r root; do
-      mkdir -p "$root"
       target="$root/$name"
       if ! entry_is_current "$kind" "$name" "$src" "$root" "$target" "$sha"; then
         if state_owns_target "$target" &&

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -39,7 +39,7 @@ abs_path() {
 mode="install"
 source_path="."
 home_path="${HOME:-}"
-state_dir="${XDG_STATE_HOME:-${HOME:-}/.local/state}/groundwork-install"
+state_dir=""
 
 if [[ "${1:-}" == "install" || "${1:-}" == "sync" || "${1:-}" == "status" || "${1:-}" == "uninstall" ]]; then
   mode="$1"
@@ -78,6 +78,13 @@ command_exists git || die "git is required"
 
 source_path="$(abs_path "$source_path")"
 home_path="$(abs_path "$home_path")"
+if [[ -z "$state_dir" ]]; then
+  if [[ -n "${XDG_STATE_HOME:-}" ]]; then
+    state_dir="$XDG_STATE_HOME/groundwork-install"
+  else
+    state_dir="$home_path/.local/state/groundwork-install"
+  fi
+fi
 mkdir -p "$state_dir"
 state_dir="$(abs_path "$state_dir")"
 state_file="$state_dir/$STATE_FILE_NAME"

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -387,6 +387,35 @@ class GroundworkInstallTests(unittest.TestCase):
 
         assert_failure_contains(self, result, "dirty")
 
+    def test_install_omits_ignored_files_inside_entry_directories(self) -> None:
+        fixture = self.add_fixture("ignored-entry-files")
+        fixture.write(".gitignore", "*.swp\n")
+        fixture.commit_new_ref("v2")
+        fixture.write("skills/orient/local.swp", "ignored skill artifact\n")
+        fixture.write("protocols/take/local.swp", "ignored protocol artifact\n")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            self.assertFalse((install.target(root, "orient") / "local.swp").exists())
+            self.assertFalse((install.target(root, "take") / "local.swp").exists())
+
+    def test_install_omits_ignored_top_level_files_under_skills(self) -> None:
+        fixture = self.add_fixture("ignored-top-level-skill-files")
+        fixture.write(".gitignore", "*.swp\n")
+        fixture.commit_new_ref("v2")
+        fixture.write("skills/local.swp", "ignored top-level artifact\n")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
+        for root in [".claude", ".agents"]:
+            self.assertFalse((install.home / root / "skills" / "local.swp").exists())
+
     def test_status_reports_missing_install_state_without_modifying_targets(self) -> None:
         fixture = self.add_fixture("status-empty")
         install = InstallRun(self, fixture.root)

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -240,6 +240,78 @@ class GroundworkInstallTests(unittest.TestCase):
         self.assert_installed_inventory(install, {"orient", "take", "submit", "verify"})
         self.assertFalse(install.target(".claude", "reckon").exists())
 
+    def test_sync_upgrades_state_owned_entry_when_kind_changes(self) -> None:
+        fixture = self.add_fixture("kind-change")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        fixture.remove("skills/orient")
+        fixture.write("protocols/orient/PROTOCOL.md", "---\nname: orient\n---\n# Orient Protocol\n")
+        fixture.commit_new_ref("v2")
+
+        result = install.run_installer("sync")
+
+        assert_success(self, result)
+        self.assertEqual(
+            (install.target(".agents", "orient") / "SKILL.md").read_text(encoding="utf-8"),
+            "---\nname: orient\n---\n# Orient Protocol\n",
+        )
+        self.assertIn("kind=protocol\n", (install.target(".agents", "orient") / ".groundwork-install").read_text(encoding="utf-8"))
+        self.assertIn("\torient\tprotocol\t", install.state_file().read_text(encoding="utf-8"))
+
+    def test_sync_fails_and_retains_state_when_obsolete_entry_is_missing_marker(self) -> None:
+        fixture = self.add_fixture("obsolete-missing-marker")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        (install.target(".agents", "reckon") / ".groundwork-install").unlink()
+        before_state = install.state_file().read_text(encoding="utf-8")
+        fixture.remove("skills/reckon")
+        fixture.commit_new_ref("v2")
+
+        result = install.run_installer("sync")
+
+        assert_failure_contains(self, result, "missing marker")
+        self.assertTrue(install.target(".claude", "reckon").is_dir())
+        self.assertTrue(install.target(".agents", "reckon").is_dir())
+        self.assertEqual(install.state_file().read_text(encoding="utf-8"), before_state)
+
+    def test_sync_fails_and_preserves_drift_when_obsolete_entry_is_missing_marker(self) -> None:
+        fixture = self.add_fixture("obsolete-missing-marker-drift")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        agents_entry = install.target(".agents", "reckon")
+        (agents_entry / ".groundwork-install").unlink()
+        (agents_entry / "SKILL.md").write_text("# local drift\n", encoding="utf-8")
+        before_state = install.state_file().read_text(encoding="utf-8")
+        fixture.remove("skills/reckon")
+        fixture.commit_new_ref("v2")
+
+        result = install.run_installer("sync")
+
+        assert_failure_contains(self, result, "missing marker")
+        self.assertTrue(install.target(".claude", "reckon").is_dir())
+        self.assertEqual((agents_entry / "SKILL.md").read_text(encoding="utf-8"), "# local drift\n")
+        self.assertEqual(install.state_file().read_text(encoding="utf-8"), before_state)
+
+    def test_sync_refreshes_stale_sha_metadata_without_rewriting_matching_payload(self) -> None:
+        fixture = self.add_fixture("stale-sha-matching-payload")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        entry = install.target(".agents", "orient")
+        payload = entry / "SKILL.md"
+        before_entry_stat = (entry.stat().st_ino, entry.stat().st_mtime_ns)
+        before_payload_stat = (payload.stat().st_ino, payload.stat().st_mtime_ns)
+        fixture.write("README.md", "source-only change\n")
+        fixture.commit_new_ref("v2")
+        new_sha = run(["git", "rev-parse", "HEAD"], fixture.root, check=True).stdout.strip()
+
+        result = install.run_installer("sync")
+
+        assert_success(self, result)
+        self.assertEqual((entry.stat().st_ino, entry.stat().st_mtime_ns), before_entry_stat)
+        self.assertEqual((payload.stat().st_ino, payload.stat().st_mtime_ns), before_payload_stat)
+        self.assertIn(f"source-sha={new_sha}\n", (entry / ".groundwork-install").read_text(encoding="utf-8"))
+        self.assertIn(new_sha, install.state_file().read_text(encoding="utf-8"))
+
     def test_uninstall_removes_only_entries_owned_by_groundwork_install(self) -> None:
         fixture = self.add_fixture("uninstall")
         install = InstallRun(self, fixture.root)
@@ -254,6 +326,20 @@ class GroundworkInstallTests(unittest.TestCase):
         self.assertTrue((unrelated / "SKILL.md").is_file())
         self.assertFalse(install.target(".agents", "orient").exists())
         self.assertFalse(install.target(".claude", "take").exists())
+
+    def test_uninstall_fails_and_retains_state_when_managed_entry_is_missing_marker(self) -> None:
+        fixture = self.add_fixture("uninstall-missing-marker")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        (install.target(".agents", "orient") / ".groundwork-install").unlink()
+        before_state = install.state_file().read_text(encoding="utf-8")
+
+        result = install.run_installer("uninstall")
+
+        assert_failure_contains(self, result, "missing marker")
+        self.assertTrue(install.target(".claude", "orient").is_dir())
+        self.assertTrue(install.target(".agents", "orient").is_dir())
+        self.assertEqual(install.state_file().read_text(encoding="utf-8"), before_state)
 
     def test_install_rejects_unmanaged_conflicts_before_changing_targets(self) -> None:
         fixture = self.add_fixture("conflict")

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -1,0 +1,237 @@
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "scripts" / "groundwork-install"
+
+
+def run(
+    args: list[str],
+    cwd: Path,
+    *,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"command failed: {' '.join(args)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def assert_success(test: unittest.TestCase, result: subprocess.CompletedProcess[str]) -> None:
+    test.assertEqual(result.returncode, 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+
+
+def assert_failure_contains(
+    test: unittest.TestCase,
+    result: subprocess.CompletedProcess[str],
+    expected: str,
+) -> None:
+    test.assertNotEqual(result.returncode, 0, "command unexpectedly succeeded")
+    test.assertIn(expected, result.stderr)
+
+
+class MethodologyFixture:
+    def __init__(self, name: str) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix=f"groundwork-install-source-{name}-"))
+        self.write_initial_surface()
+        self.init_git()
+
+    def write(self, relative: str, contents: str) -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(contents).lstrip(), encoding="utf-8")
+
+    def remove(self, relative: str) -> None:
+        path = self.root / relative
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+    def write_initial_surface(self) -> None:
+        self.write("skills/orient/SKILL.md", "---\nname: orient\n---\n# Orient\n")
+        self.write("skills/reckon/SKILL.md", "---\nname: reckon\n---\n# Reckon\n")
+        self.write("skills/reckon/references/example.md", "reckon reference\n")
+        self.write("protocols/take/PROTOCOL.md", "---\nname: take\n---\n# Take\n")
+        self.write("protocols/take/references/example.md", "take reference\n")
+        self.write("protocols/submit/PROTOCOL.md", "---\nname: submit\n---\n# Submit\n")
+
+    def init_git(self) -> None:
+        run(["git", "init", "-q"], self.root, check=True)
+        run(["git", "config", "user.name", "installer test"], self.root, check=True)
+        run(["git", "config", "user.email", "installer-test@example.invalid"], self.root, check=True)
+        run(["git", "checkout", "-q", "-b", "main"], self.root, check=True)
+        run(["git", "add", "."], self.root, check=True)
+        run(["git", "commit", "-q", "-m", "test: seed methodology"], self.root, check=True)
+        run(["git", "tag", "v1"], self.root, check=True)
+        run(["git", "checkout", "-q", "--detach", "v1"], self.root, check=True)
+
+    def commit_new_ref(self, tag: str) -> None:
+        run(["git", "checkout", "-q", "main"], self.root, check=True)
+        run(["git", "add", "."], self.root, check=True)
+        run(["git", "commit", "-q", "-m", f"test: {tag}"], self.root, check=True)
+        run(["git", "tag", tag], self.root, check=True)
+        run(["git", "checkout", "-q", "--detach", tag], self.root, check=True)
+
+    def checkout_branch(self) -> None:
+        run(["git", "checkout", "-q", "main"], self.root, check=True)
+
+    def cleanup(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+class InstallRun:
+    def __init__(self, test: unittest.TestCase, source: Path) -> None:
+        self.test = test
+        self.source = source
+        self.home = Path(tempfile.mkdtemp(prefix="groundwork-install-home-"))
+        self.state = Path(tempfile.mkdtemp(prefix="groundwork-install-state-"))
+        test.addCleanup(lambda: shutil.rmtree(self.home, ignore_errors=True))
+        test.addCleanup(lambda: shutil.rmtree(self.state, ignore_errors=True))
+
+    def run_installer(self, *args: str) -> subprocess.CompletedProcess[str]:
+        self.test.assertTrue(INSTALLER.is_file(), f"installer missing at {INSTALLER}")
+        return run(
+            [
+                str(INSTALLER),
+                *args,
+                "--source",
+                str(self.source),
+                "--home",
+                str(self.home),
+                "--state-dir",
+                str(self.state),
+            ],
+            self.source,
+        )
+
+    def target(self, root: str, name: str) -> Path:
+        return self.home / root / "skills" / name
+
+
+class GroundworkInstallTests(unittest.TestCase):
+    def add_fixture(self, name: str) -> MethodologyFixture:
+        fixture = MethodologyFixture(name)
+        self.addCleanup(fixture.cleanup)
+        return fixture
+
+    def assert_installed_inventory(self, install: InstallRun, expected: set[str]) -> None:
+        for root in [".claude", ".agents"]:
+            skills_dir = install.home / root / "skills"
+            self.assertEqual({path.name for path in skills_dir.iterdir()}, expected)
+            for name in expected:
+                entry = skills_dir / name
+                self.assertTrue((entry / "SKILL.md").is_file(), entry)
+                self.assertFalse((entry / "SKILL.md").is_symlink(), entry)
+                self.assertTrue((entry / ".groundwork-install").is_file(), entry)
+
+    def test_install_projects_skills_and_protocols_into_both_discovery_roots(self) -> None:
+        fixture = self.add_fixture("clean-install")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
+        self.assertEqual((install.target(".claude", "take") / "SKILL.md").read_text(), "---\nname: take\n---\n# Take\n")
+        self.assertTrue((install.target(".agents", "take") / "references" / "example.md").is_file())
+        self.assertTrue((install.target(".agents", "reckon") / "references" / "example.md").is_file())
+
+    def test_install_is_idempotent_for_the_same_pinned_source(self) -> None:
+        fixture = self.add_fixture("idempotent")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        marker = install.target(".agents", "orient") / ".groundwork-install"
+        before = marker.read_text(encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertEqual(marker.read_text(encoding="utf-8"), before)
+        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
+
+    def test_sync_converges_to_a_different_pinned_source_state(self) -> None:
+        fixture = self.add_fixture("sync")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        fixture.remove("skills/reckon")
+        fixture.write("protocols/verify/PROTOCOL.md", "---\nname: verify\n---\n# Verify\n")
+        fixture.commit_new_ref("v2")
+
+        result = install.run_installer("sync")
+
+        assert_success(self, result)
+        self.assert_installed_inventory(install, {"orient", "take", "submit", "verify"})
+        self.assertFalse(install.target(".claude", "reckon").exists())
+
+    def test_uninstall_removes_only_entries_owned_by_groundwork_install(self) -> None:
+        fixture = self.add_fixture("uninstall")
+        install = InstallRun(self, fixture.root)
+        unrelated = install.home / ".agents" / "skills" / "operator"
+        unrelated.mkdir(parents=True)
+        (unrelated / "SKILL.md").write_text("# Operator\n", encoding="utf-8")
+        assert_success(self, install.run_installer("install"))
+
+        result = install.run_installer("uninstall")
+
+        assert_success(self, result)
+        self.assertTrue((unrelated / "SKILL.md").is_file())
+        self.assertFalse(install.target(".agents", "orient").exists())
+        self.assertFalse(install.target(".claude", "take").exists())
+
+    def test_install_rejects_unmanaged_conflicts_before_changing_targets(self) -> None:
+        fixture = self.add_fixture("conflict")
+        install = InstallRun(self, fixture.root)
+        conflict = install.home / ".claude" / "skills" / "orient"
+        conflict.mkdir(parents=True)
+        (conflict / "SKILL.md").write_text("# Mine\n", encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "unmanaged conflict")
+        self.assertEqual((conflict / "SKILL.md").read_text(encoding="utf-8"), "# Mine\n")
+        self.assertFalse((install.home / ".agents" / "skills" / "take").exists())
+
+    def test_install_rejects_branch_checkouts(self) -> None:
+        fixture = self.add_fixture("branch")
+        fixture.checkout_branch()
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "pinned checkout")
+
+    def test_install_rejects_dirty_source_checkouts(self) -> None:
+        fixture = self.add_fixture("dirty")
+        fixture.write("skills/orient/SKILL.md", "# changed\n")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "dirty")
+
+    def test_status_reports_missing_install_state_without_modifying_targets(self) -> None:
+        fixture = self.add_fixture("status-empty")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("status")
+
+        assert_failure_contains(self, result, "not installed")
+        self.assertFalse((install.home / ".agents").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 import tempfile
@@ -15,10 +16,12 @@ def run(
     cwd: Path,
     *,
     check: bool = False,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
         args,
         cwd=cwd,
+        env=env,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -102,24 +105,30 @@ class InstallRun:
         test.addCleanup(lambda: shutil.rmtree(self.home, ignore_errors=True))
         test.addCleanup(lambda: shutil.rmtree(self.state, ignore_errors=True))
 
-    def run_installer(self, *args: str) -> subprocess.CompletedProcess[str]:
+    def run_installer(
+        self,
+        *args: str,
+        include_state_dir: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         self.test.assertTrue(INSTALLER.is_file(), f"installer missing at {INSTALLER}")
-        return run(
-            [
-                str(INSTALLER),
-                *args,
-                "--source",
-                str(self.source),
-                "--home",
-                str(self.home),
-                "--state-dir",
-                str(self.state),
-            ],
-            self.source,
-        )
+        command = [
+            str(INSTALLER),
+            *args,
+            "--source",
+            str(self.source),
+            "--home",
+            str(self.home),
+        ]
+        if include_state_dir:
+            command.extend(["--state-dir", str(self.state)])
+        return run(command, self.source, env=env)
 
     def target(self, root: str, name: str) -> Path:
         return self.home / root / "skills" / name
+
+    def default_state_file(self) -> Path:
+        return self.home / ".local" / "state" / "groundwork-install" / "interactive-install.tsv"
 
 
 class GroundworkInstallTests(unittest.TestCase):
@@ -263,6 +272,24 @@ class GroundworkInstallTests(unittest.TestCase):
 
         assert_failure_contains(self, result, "not installed")
         self.assertFalse((install.home / ".agents").exists())
+
+    def test_home_option_supplies_default_state_dir_when_home_environment_is_unset(self) -> None:
+        fixture = self.add_fixture("unset-home")
+        install = InstallRun(self, fixture.root)
+        env = os.environ.copy()
+        env.pop("HOME", None)
+        env.pop("XDG_STATE_HOME", None)
+
+        install_result = install.run_installer("install", include_state_dir=False, env=env)
+
+        assert_success(self, install_result)
+        self.assertTrue(install.default_state_file().is_file())
+        status_result = install.run_installer("status", include_state_dir=False, env=env)
+        assert_success(self, status_result)
+        uninstall_result = install.run_installer("uninstall", include_state_dir=False, env=env)
+        assert_success(self, uninstall_result)
+        self.assertFalse(install.default_state_file().exists())
+        self.assertFalse(install.target(".agents", "orient").exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -130,6 +130,9 @@ class InstallRun:
     def default_state_file(self) -> Path:
         return self.home / ".local" / "state" / "groundwork-install" / "interactive-install.tsv"
 
+    def state_file(self) -> Path:
+        return self.state / "interactive-install.tsv"
+
 
 class GroundworkInstallTests(unittest.TestCase):
     def add_fixture(self, name: str) -> MethodologyFixture:
@@ -204,6 +207,25 @@ class GroundworkInstallTests(unittest.TestCase):
         self.assertFalse((entry / "local-only.md").exists())
         self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
 
+    def test_install_restores_state_recorded_target_when_marker_is_missing(self) -> None:
+        fixture = self.add_fixture("missing-marker-drift")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        entry = install.target(".agents", "orient")
+        skill = entry / "SKILL.md"
+        expected = skill.read_text(encoding="utf-8")
+        (entry / ".groundwork-install").unlink()
+        skill.write_text("# drifted\n", encoding="utf-8")
+        (entry / "local-only.md").write_text("local drift\n", encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertTrue((entry / ".groundwork-install").is_file())
+        self.assertEqual(skill.read_text(encoding="utf-8"), expected)
+        self.assertFalse((entry / "local-only.md").exists())
+        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
+
     def test_sync_converges_to_a_different_pinned_source_state(self) -> None:
         fixture = self.add_fixture("sync")
         install = InstallRun(self, fixture.root)
@@ -245,6 +267,21 @@ class GroundworkInstallTests(unittest.TestCase):
         assert_failure_contains(self, result, "unmanaged conflict")
         self.assertEqual((conflict / "SKILL.md").read_text(encoding="utf-8"), "# Mine\n")
         self.assertFalse((install.home / ".agents" / "skills" / "take").exists())
+
+    def test_install_rejects_marker_only_targets_as_unmanaged_conflicts(self) -> None:
+        fixture = self.add_fixture("marker-only-conflict")
+        install = InstallRun(self, fixture.root)
+        conflict = install.target(".claude", "orient")
+        conflict.mkdir(parents=True)
+        (conflict / "SKILL.md").write_text("# Mine\n", encoding="utf-8")
+        (conflict / ".groundwork-install").write_text("managed-by=groundwork-install\n", encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "unmanaged conflict")
+        self.assertEqual((conflict / "SKILL.md").read_text(encoding="utf-8"), "# Mine\n")
+        self.assertFalse((install.home / ".agents" / "skills" / "take").exists())
+        self.assertFalse(install.state_file().exists())
 
     def test_install_rejects_branch_checkouts(self) -> None:
         fixture = self.add_fixture("branch")

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -369,6 +369,23 @@ class GroundworkInstallTests(unittest.TestCase):
         self.assertFalse((install.home / ".agents" / "skills" / "take").exists())
         self.assertFalse(install.state_file().exists())
 
+    def test_install_fails_without_writing_entries_when_any_target_root_is_not_preparable(self) -> None:
+        fixture = self.add_fixture("target-root-file")
+        install = InstallRun(self, fixture.root)
+        first_root = install.home / ".claude" / "skills"
+        first_root.mkdir(parents=True)
+        before_first_root = sorted(path.name for path in first_root.iterdir())
+        blocked_root = install.home / ".agents" / "skills"
+        blocked_root.parent.mkdir(parents=True)
+        blocked_root.write_text("not a directory\n", encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        self.assertNotEqual(result.returncode, 0, "command unexpectedly succeeded")
+        self.assertEqual(sorted(path.name for path in first_root.iterdir()), before_first_root)
+        self.assertEqual(blocked_root.read_text(encoding="utf-8"), "not a directory\n")
+        self.assertFalse(install.state_file().exists())
+
     def test_install_rejects_branch_checkouts(self) -> None:
         fixture = self.add_fixture("branch")
         fixture.checkout_branch()

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -138,6 +138,22 @@ class GroundworkInstallTests(unittest.TestCase):
                 self.assertFalse((entry / "SKILL.md").is_symlink(), entry)
                 self.assertTrue((entry / ".groundwork-install").is_file(), entry)
 
+    def installed_entry_stats(self, install: InstallRun) -> dict[str, tuple[int, int]]:
+        stats = {}
+        for root in [".claude", ".agents"]:
+            skills_dir = install.home / root / "skills"
+            for entry in sorted(skills_dir.iterdir()):
+                marker = entry / ".groundwork-install"
+                stats[str(entry.relative_to(install.home))] = (
+                    entry.stat().st_ino,
+                    entry.stat().st_mtime_ns,
+                )
+                stats[str(marker.relative_to(install.home))] = (
+                    marker.stat().st_ino,
+                    marker.stat().st_mtime_ns,
+                )
+        return stats
+
     def test_install_projects_skills_and_protocols_into_both_discovery_roots(self) -> None:
         fixture = self.add_fixture("clean-install")
         install = InstallRun(self, fixture.root)
@@ -154,13 +170,29 @@ class GroundworkInstallTests(unittest.TestCase):
         fixture = self.add_fixture("idempotent")
         install = InstallRun(self, fixture.root)
         assert_success(self, install.run_installer("install"))
-        marker = install.target(".agents", "orient") / ".groundwork-install"
-        before = marker.read_text(encoding="utf-8")
+        before = self.installed_entry_stats(install)
 
         result = install.run_installer("install")
 
         assert_success(self, result)
-        self.assertEqual(marker.read_text(encoding="utf-8"), before)
+        self.assertEqual(self.installed_entry_stats(install), before)
+        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
+
+    def test_install_restores_same_sha_managed_target_drift(self) -> None:
+        fixture = self.add_fixture("same-sha-drift")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        entry = install.target(".agents", "orient")
+        skill = entry / "SKILL.md"
+        expected = skill.read_text(encoding="utf-8")
+        skill.write_text("# drifted\n", encoding="utf-8")
+        (entry / "local-only.md").write_text("local drift\n", encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertEqual(skill.read_text(encoding="utf-8"), expected)
+        self.assertFalse((entry / "local-only.md").exists())
         self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
 
     def test_sync_converges_to_a_different_pinned_source_state(self) -> None:


### PR DESCRIPTION
## Summary

- Adds `scripts/groundwork-install` as the official interactive installer for Claude Code and Codex discovery roots.
- Projects both source skills and protocols as skill-shaped copied entries with marker/state ownership tracking.
- Documents pinned-checkout usage, lifecycle commands, conflict behavior, and Fedora CoreOS-appropriate prerequisites.

## Changes

- `install`/`sync` copy entries from a clean detached Groundwork checkout into `~/.claude/skills/` and `~/.agents/skills/`.
- Protocol directories expose `PROTOCOL.md` as discovery-root `SKILL.md` while preserving references, scripts, and licenses.
- Uninstall removes only marker-backed, state-recorded entries; unmanaged conflicts are surfaced before target mutation.

## GitHub Issue(s)

Closes #306

## Test plan

- `bash -n scripts/groundwork-install`
- `git diff --check -- README.md CHANGELOG.md scripts/groundwork-install tests/test_groundwork_install.py`
- `python -m unittest tests.test_groundwork_install`
- `python -m unittest discover -s tests`
