### PR TITLE
fix(release): restore annotated tag refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Restore annotated tag refs
+        run: git fetch --tags --force origin
+
+      - name: Verify restored tag matches event
+        run: |
+          set -euo pipefail
+          restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")
+          if [ "$restored_commit" != "$GITHUB_SHA" ]; then
+            echo "Tag $GITHUB_REF_NAME moved since trigger: expected $GITHUB_SHA, got $restored_commit" >&2
+            exit 1
+          fi
+
       - name: Require annotated tag
         run: |
           test "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Release tag-push workflows now restore annotated tag refs after checkout and
+  verify the restored tag still matches the triggering event before enforcing
+  annotated-tag trust (closes #308).
 - Interactive install now prepares every discovery root before mutating managed
   entries, so a non-preparable later root cannot leave earlier roots with
   marker-bearing entries that lack an install state record.

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -415,6 +415,20 @@ class ReleaseRepositoryContractTests(unittest.TestCase):
     def test_release_workflow_verifies_annotated_tags_and_has_no_path_filter(self) -> None:
         workflow = self.read(".github/workflows/release.yml")
 
+        self.assertIn("- name: Restore annotated tag refs", workflow)
+        self.assertIn("- name: Verify restored tag matches event", workflow)
+        self.assertIn("- name: Require annotated tag", workflow)
+        checkout = workflow.index("- name: Checkout")
+        restore = workflow.index("- name: Restore annotated tag refs")
+        verify = workflow.index("- name: Verify restored tag matches event")
+        require = workflow.index("- name: Require annotated tag")
+
+        self.assertLess(checkout, restore)
+        self.assertLess(restore, verify)
+        self.assertLess(verify, require)
+        self.assertIn("git fetch --tags --force origin", workflow)
+        self.assertIn('restored_commit=$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")', workflow)
+        self.assertIn('if [ "$restored_commit" != "$GITHUB_SHA" ]; then', workflow)
         self.assertIn("refs/tags/$GITHUB_REF_NAME", workflow)
         self.assertIn("./scripts/release-check release \"$GITHUB_REF_NAME\"", workflow)
         self.assertIn("./scripts/release-check notes \"$GITHUB_REF_NAME\"", workflow)


### PR DESCRIPTION
## Summary

- Restores annotated tag refs immediately after checkout in the release workflow.
- Verifies the restored tag still resolves to the triggering event SHA before the existing annotated-tag trust check runs.
- Documents the release workflow correction in the Unreleased changelog.

## Changes

- Added the `Restore annotated tag refs` and `Verify restored tag matches event` workflow steps between Checkout and Require annotated tag.
- Tightened the release workflow repository-contract test to lock in the trust-step content and ordering.

## GitHub Issue(s)

Closes #308

## Test plan

- `python -m unittest tests.test_release_ceremony.ReleaseRepositoryContractTests.test_release_workflow_verifies_annotated_tags_and_has_no_path_filter`
- `python -m unittest discover -s tests`
