### PR TITLE
fix(install): adapt protocol delivery for interactive sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ projected to `SKILL.md`, so protocol names are discoverable in the same way as
 skills. Installed entries are copies, not source-checkout symlinks, so later
 changes to the checkout do not drift into the active discovery surface.
 
+Projected protocol entries also receive one installer-supplied interactive IO
+adapter. Source protocols remain written for runa: their artifact capstones
+deliver through runa MCP tools, which validate, persist, and thread artifacts.
+Interactive Claude Code and Codex sessions do not have that artifact store or
+autonomous downstream runtime, so the adapter supplies the single substitution:
+the produced artifact is rendered in the terminal for the human to read and
+carry forward. The protocol bodies under `protocols/` are not rewritten.
+
 The source checkout must be clean and pinned at a tag or full commit SHA. The
 command refuses branch checkouts because a branch is a moving source. To update
 to a different pinned Groundwork version, check out that ref and run:

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -4,6 +4,7 @@ set -euo pipefail
 PROGRAM="groundwork-install"
 MARKER=".groundwork-install"
 STATE_FILE_NAME="interactive-install.tsv"
+INTERACTIVE_IO_ADAPTER_REL="scripts/groundwork-install-interactive-io-adapter.md"
 
 usage() {
   cat <<'EOF'
@@ -101,6 +102,8 @@ validate_source() {
   if git -C "$source_path" symbolic-ref -q --short HEAD >/dev/null; then
     die "source must be a pinned checkout at a tag or full commit SHA, not a branch"
   fi
+  git -C "$source_path" cat-file -e "$(source_sha):$INTERACTIVE_IO_ADAPTER_REL" 2>/dev/null ||
+    die "source has no interactive IO adapter at $INTERACTIVE_IO_ADAPTER_REL"
 }
 
 source_sha() {
@@ -221,6 +224,39 @@ kind=$kind
 EOF
 }
 
+inject_interactive_io_adapter() {
+  local skill_path="$1"
+  local sha="$2"
+  local adapter tmp
+  adapter="$(mktemp "${skill_path}.adapter.XXXXXX")"
+  tmp="$(mktemp "${skill_path}.tmp.XXXXXX")"
+  git -C "$source_path" show "$sha:$INTERACTIVE_IO_ADAPTER_REL" > "$adapter" ||
+    die "source has no interactive IO adapter at $INTERACTIVE_IO_ADAPTER_REL"
+  if ! awk -v adapter="$adapter" '
+    BEGIN { inserted = 0; fence_count = 0 }
+    {
+      print
+      if ($0 == "---") {
+        fence_count += 1
+        if (fence_count == 2 && inserted == 0) {
+          while ((getline line < adapter) > 0) {
+            print line
+          }
+          close(adapter)
+          print ""
+          inserted = 1
+        }
+      }
+    }
+    END { exit inserted ? 0 : 1 }
+  ' "$skill_path" > "$tmp"; then
+    rm -f "$adapter" "$tmp"
+    die "protocol entry has no frontmatter boundary for interactive IO adapter: $skill_path"
+  fi
+  mv "$tmp" "$skill_path"
+  rm -f "$adapter"
+}
+
 project_entry() {
   local kind="$1"
   local name="$2"
@@ -232,6 +268,7 @@ project_entry() {
   if [[ "$kind" == "protocol" ]]; then
     rm -f "$target/SKILL.md"
     mv "$target/PROTOCOL.md" "$target/SKILL.md"
+    inject_interactive_io_adapter "$target/SKILL.md" "$sha"
   fi
   write_marker "$target/$MARKER" "$kind" "$name" "$sha"
 }

--- a/scripts/groundwork-install-interactive-io-adapter.md
+++ b/scripts/groundwork-install-interactive-io-adapter.md
@@ -1,0 +1,20 @@
+## Interactive IO Adapter
+
+This installed protocol entry is running in an interactive Claude Code or Codex
+session, not in a runa-served protocol session. The protocol body below remains
+the runa-served source of truth. This adapter supplies the interactive delivery
+substitution for the one contract that differs.
+
+When the protocol says to deliver a produced artifact by invoking its runa MCP
+tool, produce the same artifact payload and render the same tool-input object in
+the terminal for the human. The human reads that output and carries continuity
+to any later protocol. Interactive sessions have no artifact store and no
+autonomous downstream protocol.
+
+Do not require runa or MCP tools in interactive mode. Do not write workspace
+JSON files directly. Do not claim that the artifact was validated, persisted,
+or recorded in runa's artifact store.
+
+Interactive delivery is complete when the produced artifact is visible in the
+terminal for the human as the protocol's executable outcome.
+

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -3,12 +3,15 @@ import shutil
 import subprocess
 import tempfile
 import textwrap
+import tomllib
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "scripts" / "groundwork-install"
+ADAPTER_SOURCE = ROOT / "scripts" / "groundwork-install-interactive-io-adapter.md"
+MANIFEST_PATH = ROOT / "manifest.toml"
 
 
 def run(
@@ -65,6 +68,10 @@ class MethodologyFixture:
             path.unlink()
 
     def write_initial_surface(self) -> None:
+        self.write(
+            "scripts/groundwork-install-interactive-io-adapter.md",
+            ADAPTER_SOURCE.read_text(encoding="utf-8"),
+        )
         self.write("skills/orient/SKILL.md", "---\nname: orient\n---\n# Orient\n")
         self.write("skills/reckon/SKILL.md", "---\nname: reckon\n---\n# Reckon\n")
         self.write("skills/reckon/references/example.md", "reckon reference\n")
@@ -166,6 +173,29 @@ class GroundworkInstallTests(unittest.TestCase):
                 )
         return stats
 
+    def producer_protocols(self) -> list[tuple[str, str]]:
+        manifest = tomllib.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        return [
+            (protocol["name"], protocol["produces"][0])
+            for protocol in manifest["protocols"]
+            if protocol["produces"]
+        ]
+
+    def adapter_text(self) -> str:
+        return ADAPTER_SOURCE.read_text(encoding="utf-8")
+
+    def assert_protocol_has_interactive_adapter(self, skill_text: str) -> None:
+        adapter = self.adapter_text()
+        self.assertEqual(skill_text.count(adapter), 1)
+        self.assertIn("render the same tool-input object", skill_text)
+        self.assertIn("terminal for the human", skill_text)
+        self.assertIn("Do not require runa or MCP tools in interactive mode.", skill_text)
+        self.assertIn("Interactive delivery is complete", skill_text)
+        self.assertIn("produced artifact is visible in the", skill_text)
+        self.assertLess(skill_text.index(adapter), skill_text.rindex("# "))
+        if "MCP tool" in skill_text:
+            self.assertLess(skill_text.index(adapter), skill_text.rindex("MCP tool"))
+
     def test_install_projects_skills_and_protocols_into_both_discovery_roots(self) -> None:
         fixture = self.add_fixture("clean-install")
         install = InstallRun(self, fixture.root)
@@ -174,9 +204,62 @@ class GroundworkInstallTests(unittest.TestCase):
 
         assert_success(self, result)
         self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
-        self.assertEqual((install.target(".claude", "take") / "SKILL.md").read_text(), "---\nname: take\n---\n# Take\n")
+        take_skill = (install.target(".claude", "take") / "SKILL.md").read_text(encoding="utf-8")
+        self.assertTrue(take_skill.startswith("---\nname: take\n---\n"))
+        self.assertTrue(take_skill.endswith("# Take\n"))
+        self.assert_protocol_has_interactive_adapter(take_skill)
         self.assertTrue((install.target(".agents", "take") / "references" / "example.md").is_file())
         self.assertTrue((install.target(".agents", "reckon") / "references" / "example.md").is_file())
+
+    def test_install_supplies_one_shared_interactive_adapter_to_each_protocol_only(self) -> None:
+        fixture = self.add_fixture("interactive-adapter")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            for protocol_name in ["take", "submit"]:
+                skill_text = (install.target(root, protocol_name) / "SKILL.md").read_text(
+                    encoding="utf-8"
+                )
+                self.assert_protocol_has_interactive_adapter(skill_text)
+
+            for skill_name in ["orient", "reckon"]:
+                skill_text = (install.target(root, skill_name) / "SKILL.md").read_text(
+                    encoding="utf-8"
+                )
+                self.assertNotIn(self.adapter_text(), skill_text)
+                self.assertNotIn("Interactive IO Adapter", skill_text)
+
+    def test_install_supplies_interactive_adapter_to_all_producer_protocols(self) -> None:
+        fixture = self.add_fixture("all-producer-protocols")
+        for protocol_name, artifact in self.producer_protocols():
+            fixture.write(
+                f"protocols/{protocol_name}/PROTOCOL.md",
+                f"""
+                ---
+                name: {protocol_name}
+                ---
+                # {protocol_name.title()}
+
+                Invoke the `{artifact}` MCP tool.
+                """,
+            )
+        fixture.commit_new_ref("v2")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        expected = {"orient", "reckon"} | {name for name, _artifact in self.producer_protocols()}
+        self.assert_installed_inventory(install, expected)
+        for root in [".claude", ".agents"]:
+            for protocol_name, _artifact in self.producer_protocols():
+                skill_text = (install.target(root, protocol_name) / "SKILL.md").read_text(
+                    encoding="utf-8"
+                )
+                self.assert_protocol_has_interactive_adapter(skill_text)
 
     def test_install_is_idempotent_for_the_same_pinned_source(self) -> None:
         fixture = self.add_fixture("idempotent")
@@ -253,7 +336,9 @@ class GroundworkInstallTests(unittest.TestCase):
         assert_success(self, result)
         self.assertEqual(
             (install.target(".agents", "orient") / "SKILL.md").read_text(encoding="utf-8"),
-            "---\nname: orient\n---\n# Orient Protocol\n",
+            "---\nname: orient\n---\n"
+            f"{self.adapter_text()}\n"
+            "# Orient Protocol\n",
         )
         self.assertIn("kind=protocol\n", (install.target(".agents", "orient") / ".groundwork-install").read_text(encoding="utf-8"))
         self.assertIn("\torient\tprotocol\t", install.state_file().read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- Adds one shared interactive IO adapter for protocol entries projected by `groundwork-install`.
- Keeps source protocol bodies and the runa MCP delivery invariant unchanged.
- Documents the interactive projection behavior for Claude Code and Codex installs.

## Changes

- Installer projection now injects `scripts/groundwork-install-interactive-io-adapter.md` into generated protocol `SKILL.md` files after frontmatter.
- Installer tests verify the adapter is shared, protocol-only, present before MCP delivery text, and applied across all ten producer protocols.
- README explains that interactive installs render produced artifacts to the terminal instead of delivering them through runa.

## GitHub Issue(s)

Closes #312

## Test plan

- `python -m unittest tests.test_groundwork_install tests.test_protocol_artifact_delivery_docs`
- `bash -n scripts/groundwork-install`
- `git diff --check`
- `python -m unittest discover -s tests -v` currently has one unrelated existing failure: `test_manifest_declares_current_methodology_version` expects `0.1.2-rc.1`, while `manifest.toml` at `HEAD` already declares `0.2.0`.
