### PR TITLE
fix(install): adapt protocol delivery for interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Interactive install now projects the artifact delivery adapter into every
+  protocol entry without depending on protocol prose formatting, so wrapped MCP
+  delivery text cannot omit the adapter from installed protocol skills.
+
 ## [0.2.0] — 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,9 +69,12 @@ The installer writes user-owned entries only, with no root or sudo requirement:
 
 Every directory under `skills/` is copied as a skill entry. Every directory
 under `protocols/` is copied as a skill-shaped entry with `PROTOCOL.md`
-projected to `SKILL.md`, so protocol names are discoverable in the same way as
-skills. Installed entries are copies, not source-checkout symlinks, so later
-changes to the checkout do not drift into the active discovery surface.
+projected to `SKILL.md` and an interactive artifact delivery adapter inserted
+near the top of the installed protocol. The adapter tells an interactive agent
+how to present the produced artifact body to the human instead of calling the
+runa MCP artifact tool. Installed entries are copies, not source-checkout
+symlinks, so later changes to the checkout do not drift into the active
+discovery surface.
 
 The source checkout must be clean and pinned at a tag or full commit SHA. The
 command refuses branch checkouts because a branch is a moving source. To update

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -4,6 +4,7 @@ set -euo pipefail
 PROGRAM="groundwork-install"
 MARKER=".groundwork-install"
 STATE_FILE_NAME="interactive-install.tsv"
+INTERACTIVE_ADAPTER_PATH="scripts/interactive-artifact-delivery-adapter.md"
 
 usage() {
   cat <<'EOF'
@@ -101,6 +102,8 @@ validate_source() {
   if git -C "$source_path" symbolic-ref -q --short HEAD >/dev/null; then
     die "source must be a pinned checkout at a tag or full commit SHA, not a branch"
   fi
+  git -C "$source_path" cat-file -e "$(source_sha):$INTERACTIVE_ADAPTER_PATH" 2>/dev/null ||
+    die "source has no interactive artifact delivery adapter at $INTERACTIVE_ADAPTER_PATH"
 }
 
 source_sha() {
@@ -221,6 +224,65 @@ kind=$kind
 EOF
 }
 
+insert_interactive_adapter() {
+  local skill_path="$1"
+  local sha="$2"
+  local adapter_tmp output_tmp
+  adapter_tmp="$(mktemp "${skill_path}.adapter.XXXXXX")"
+  output_tmp="$(mktemp "${skill_path}.projected.XXXXXX")"
+  git -C "$source_path" show "$sha:$INTERACTIVE_ADAPTER_PATH" > "$adapter_tmp" ||
+    die "source has no interactive artifact delivery adapter at $INTERACTIVE_ADAPTER_PATH"
+
+  awk -v adapter="$adapter_tmp" '
+    function print_adapter(  line) {
+      while ((getline line < adapter) > 0) {
+        print line
+      }
+      close(adapter)
+    }
+
+    NR == 1 && $0 == "---" {
+      in_frontmatter = 1
+      print
+      next
+    }
+
+    in_frontmatter {
+      print
+      if ($0 == "---") {
+        in_frontmatter = 0
+      }
+      next
+    }
+
+    !inserted && /^# / {
+      print
+      print ""
+      print_adapter()
+      inserted = 1
+      next
+    }
+
+    {
+      print
+    }
+
+    END {
+      if (!inserted) {
+        print ""
+        print_adapter()
+      }
+    }
+  ' "$skill_path" > "$output_tmp"
+
+  mv "$output_tmp" "$skill_path"
+  rm -f "$adapter_tmp"
+}
+
+protocol_uses_runa_delivery() {
+  grep -q "MCP tool input, not artifact body" "$1"
+}
+
 project_entry() {
   local kind="$1"
   local name="$2"
@@ -232,6 +294,9 @@ project_entry() {
   if [[ "$kind" == "protocol" ]]; then
     rm -f "$target/SKILL.md"
     mv "$target/PROTOCOL.md" "$target/SKILL.md"
+    if protocol_uses_runa_delivery "$target/SKILL.md"; then
+      insert_interactive_adapter "$target/SKILL.md" "$sha"
+    fi
   fi
   write_marker "$target/$MARKER" "$kind" "$name" "$sha"
 }

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -279,10 +279,6 @@ insert_interactive_adapter() {
   rm -f "$adapter_tmp"
 }
 
-protocol_uses_runa_delivery() {
-  grep -q "MCP tool input, not artifact body" "$1"
-}
-
 project_entry() {
   local kind="$1"
   local name="$2"
@@ -294,9 +290,7 @@ project_entry() {
   if [[ "$kind" == "protocol" ]]; then
     rm -f "$target/SKILL.md"
     mv "$target/PROTOCOL.md" "$target/SKILL.md"
-    if protocol_uses_runa_delivery "$target/SKILL.md"; then
-      insert_interactive_adapter "$target/SKILL.md" "$sha"
-    fi
+    insert_interactive_adapter "$target/SKILL.md" "$sha"
   fi
   write_marker "$target/$MARKER" "$kind" "$name" "$sha"
 }

--- a/scripts/interactive-artifact-delivery-adapter.md
+++ b/scripts/interactive-artifact-delivery-adapter.md
@@ -1,0 +1,31 @@
+<!-- groundwork-install:interactive-artifact-delivery-adapter begin -->
+## Interactive Artifact Delivery Adapter
+
+Interactive sessions have no runa runtime, MCP artifact tool, artifact store,
+or automatic downstream threading. When this projected protocol reaches a
+runa-served delivery step, substitute this adapter for the complete runa-served
+artifact delivery transform.
+
+Do not call the MCP tool in interactive mode. Assemble and present the produced
+artifact body: the artifact object as this protocol and its schema define it
+after runa would have consumed tool-only parameters and injected session
+context. Present that artifact body to the human in the terminal. The object
+presented to the human is not the MCP tool-input object shown in the protocol
+body.
+
+`instance_id` is tool-only identity metadata for runa-served delivery. In
+interactive mode, consume it as optional human continuity metadata outside the
+artifact body if it helps name the output, but `instance_id` must not appear
+inside the artifact body.
+
+`work_unit` exists only when the produced artifact is scoped to a work unit.
+For scoped artifacts, fill `work_unit` from the active interactive work-unit or
+session context when it is unambiguous. If no single active work unit is clear,
+ask the human for the work-unit identity before presenting the artifact body.
+For unscoped artifacts, do not add `work_unit`.
+
+Interactive delivery is complete when the schema-shaped artifact body has been
+presented to the human. Interactive mode does not persist artifacts, does not
+create workspace JSON files, and does not thread artifacts automatically to
+downstream protocols.
+<!-- groundwork-install:interactive-artifact-delivery-adapter end -->

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -173,6 +173,10 @@ class GroundworkInstallTests(unittest.TestCase):
     def adapter_text(self, fixture: MethodologyFixture) -> str:
         return (fixture.root / ADAPTER_RELATIVE_PATH).read_text(encoding="utf-8")
 
+    def assert_adapter_projected_once(self, body: str) -> None:
+        self.assertEqual(body.count(ADAPTER_BEGIN), 1)
+        self.assertEqual(body.count(ADAPTER_END), 1)
+
     def test_install_projects_skills_and_protocols_into_both_discovery_roots(self) -> None:
         fixture = self.add_fixture("clean-install")
         install = InstallRun(self, fixture.root)
@@ -181,10 +185,8 @@ class GroundworkInstallTests(unittest.TestCase):
 
         assert_success(self, result)
         self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
-        self.assertEqual(
-            (install.target(".claude", "take") / "SKILL.md").read_text(encoding="utf-8"),
-            "---\nname: take\n---\n# Take\n",
-        )
+        take_body = (install.target(".claude", "take") / "SKILL.md").read_text(encoding="utf-8")
+        self.assert_adapter_projected_once(take_body)
         self.assertTrue((install.target(".agents", "take") / "references" / "example.md").is_file())
         self.assertTrue((install.target(".agents", "reckon") / "references" / "example.md").is_file())
 
@@ -213,8 +215,7 @@ class GroundworkInstallTests(unittest.TestCase):
 
                 ## Procedures
 
-                Deliver the artifact by invoking the MCP tool.
-                The object below is MCP tool input, not artifact body.
+                Follow the protocol.
                 """,
             )
         fixture.commit_new_ref("v2")
@@ -228,11 +229,28 @@ class GroundworkInstallTests(unittest.TestCase):
             for protocol in producer_protocols:
                 body = (install.target(root, protocol) / "SKILL.md").read_text(encoding="utf-8")
                 with self.subTest(root=root, protocol=protocol):
-                    self.assertEqual(body.count(ADAPTER_BEGIN), 1)
-                    self.assertEqual(body.count(ADAPTER_END), 1)
+                    self.assert_adapter_projected_once(body)
                     self.assertIn(adapter, body)
                     self.assertLess(body.index("# "), body.index(ADAPTER_BEGIN))
                     self.assertLess(body.index(ADAPTER_END), body.index("## Procedures"))
+
+    def test_install_projects_interactive_adapter_into_every_real_protocol_entry(self) -> None:
+        source = Path(tempfile.mkdtemp(prefix="groundwork-install-real-source-"))
+        self.addCleanup(lambda: shutil.rmtree(source, ignore_errors=True))
+        run(["git", "clone", "-q", str(ROOT), str(source)], ROOT, check=True)
+        run(["git", "checkout", "-q", "--detach", "HEAD"], source, check=True)
+        protocol_names = sorted(path.parent.name for path in source.glob("protocols/*/PROTOCOL.md"))
+        self.assertNotEqual(protocol_names, [])
+        install = InstallRun(self, source)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            for protocol in protocol_names:
+                body = (install.target(root, protocol) / "SKILL.md").read_text(encoding="utf-8")
+                with self.subTest(root=root, protocol=protocol):
+                    self.assert_adapter_projected_once(body)
 
     def test_install_does_not_project_interactive_adapter_into_skill_entries(self) -> None:
         fixture = self.add_fixture("adapter-skills")
@@ -340,10 +358,8 @@ class GroundworkInstallTests(unittest.TestCase):
         result = install.run_installer("sync")
 
         assert_success(self, result)
-        self.assertEqual(
-            (install.target(".agents", "orient") / "SKILL.md").read_text(encoding="utf-8"),
-            "---\nname: orient\n---\n# Orient Protocol\n",
-        )
+        orient_body = (install.target(".agents", "orient") / "SKILL.md").read_text(encoding="utf-8")
+        self.assert_adapter_projected_once(orient_body)
         self.assertIn("kind=protocol\n", (install.target(".agents", "orient") / ".groundwork-install").read_text(encoding="utf-8"))
         self.assertIn("\torient\tprotocol\t", install.state_file().read_text(encoding="utf-8"))
 

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -9,6 +9,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "scripts" / "groundwork-install"
+ADAPTER_RELATIVE_PATH = "scripts/interactive-artifact-delivery-adapter.md"
+ADAPTER_BEGIN = "<!-- groundwork-install:interactive-artifact-delivery-adapter begin -->"
+ADAPTER_END = "<!-- groundwork-install:interactive-artifact-delivery-adapter end -->"
 
 
 def run(
@@ -65,6 +68,7 @@ class MethodologyFixture:
             path.unlink()
 
     def write_initial_surface(self) -> None:
+        self.write(ADAPTER_RELATIVE_PATH, (ROOT / ADAPTER_RELATIVE_PATH).read_text(encoding="utf-8"))
         self.write("skills/orient/SKILL.md", "---\nname: orient\n---\n# Orient\n")
         self.write("skills/reckon/SKILL.md", "---\nname: reckon\n---\n# Reckon\n")
         self.write("skills/reckon/references/example.md", "reckon reference\n")
@@ -166,6 +170,9 @@ class GroundworkInstallTests(unittest.TestCase):
                 )
         return stats
 
+    def adapter_text(self, fixture: MethodologyFixture) -> str:
+        return (fixture.root / ADAPTER_RELATIVE_PATH).read_text(encoding="utf-8")
+
     def test_install_projects_skills_and_protocols_into_both_discovery_roots(self) -> None:
         fixture = self.add_fixture("clean-install")
         install = InstallRun(self, fixture.root)
@@ -174,9 +181,91 @@ class GroundworkInstallTests(unittest.TestCase):
 
         assert_success(self, result)
         self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
-        self.assertEqual((install.target(".claude", "take") / "SKILL.md").read_text(), "---\nname: take\n---\n# Take\n")
+        self.assertEqual(
+            (install.target(".claude", "take") / "SKILL.md").read_text(encoding="utf-8"),
+            "---\nname: take\n---\n# Take\n",
+        )
         self.assertTrue((install.target(".agents", "take") / "references" / "example.md").is_file())
         self.assertTrue((install.target(".agents", "reckon") / "references" / "example.md").is_file())
+
+    def test_install_projects_interactive_adapter_into_every_protocol_entry(self) -> None:
+        fixture = self.add_fixture("adapter-all-protocols")
+        producer_protocols = [
+            "survey",
+            "decompose",
+            "take",
+            "specify",
+            "plan",
+            "implement",
+            "verify",
+            "document",
+            "submit",
+            "land",
+        ]
+        for protocol in producer_protocols:
+            fixture.write(
+                f"protocols/{protocol}/PROTOCOL.md",
+                f"""
+                ---
+                name: {protocol}
+                ---
+                # {protocol.title()}
+
+                ## Procedures
+
+                Deliver the artifact by invoking the MCP tool.
+                The object below is MCP tool input, not artifact body.
+                """,
+            )
+        fixture.commit_new_ref("v2")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        adapter = self.adapter_text(fixture)
+        for root in [".claude", ".agents"]:
+            for protocol in producer_protocols:
+                body = (install.target(root, protocol) / "SKILL.md").read_text(encoding="utf-8")
+                with self.subTest(root=root, protocol=protocol):
+                    self.assertEqual(body.count(ADAPTER_BEGIN), 1)
+                    self.assertEqual(body.count(ADAPTER_END), 1)
+                    self.assertIn(adapter, body)
+                    self.assertLess(body.index("# "), body.index(ADAPTER_BEGIN))
+                    self.assertLess(body.index(ADAPTER_END), body.index("## Procedures"))
+
+    def test_install_does_not_project_interactive_adapter_into_skill_entries(self) -> None:
+        fixture = self.add_fixture("adapter-skills")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            for skill in ["orient", "reckon"]:
+                body = (install.target(root, skill) / "SKILL.md").read_text(encoding="utf-8")
+                with self.subTest(root=root, skill=skill):
+                    self.assertNotIn(ADAPTER_BEGIN, body)
+                    self.assertNotIn(ADAPTER_END, body)
+
+    def test_interactive_adapter_prose_carries_delivery_substitution_commitments(self) -> None:
+        fixture = self.add_fixture("adapter-prose")
+        adapter = " ".join(self.adapter_text(fixture).split())
+
+        for expected in [
+            "complete runa-served artifact delivery transform",
+            "produced artifact body",
+            "not the MCP tool-input object",
+            "`instance_id`",
+            "must not appear inside the artifact body",
+            "`work_unit`",
+            "scoped",
+            "unscoped",
+            "ask the human",
+            "does not persist artifacts",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, adapter)
 
     def test_install_is_idempotent_for_the_same_pinned_source(self) -> None:
         fixture = self.add_fixture("idempotent")

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -410,7 +410,7 @@ class ReleaseRepositoryContractTests(unittest.TestCase):
         return (ROOT / relative).read_text(encoding="utf-8")
 
     def test_manifest_declares_current_methodology_version(self) -> None:
-        self.assertIn('version = "0.1.2-rc.1"', self.read("manifest.toml"))
+        self.assertIn('version = "0.2.0"', self.read("manifest.toml"))
 
     def test_release_workflow_verifies_annotated_tags_and_has_no_path_filter(self) -> None:
         workflow = self.read(".github/workflows/release.yml")


### PR DESCRIPTION
## Summary

- Adds a single interactive artifact delivery adapter for projected protocol entries.
- Inserts the adapter inside the installer protocol-projection path so install/sync/drift convergence still compares the adapted projected payload.
- Covers all ten artifact-producing protocols with static installer tests while preserving the runa delivery-doc invariant.

## Changes

- Adds installer-owned adapter prose that substitutes for the complete runa-served delivery transform in interactive sessions.
- Updates `groundwork-install` protocol projection to insert the adapter before executable procedures for protocols with runa artifact-delivery prose.
- Adds tests for adapter presence, position, absence from ordinary skills, and reader-facing delivery commitments.

## GitHub Issue(s)

Closes #312

## Test plan

- `python -m unittest tests.test_groundwork_install tests.test_protocol_artifact_delivery_docs`
- `bash -n scripts/groundwork-install && git diff --check`
- `python -m unittest discover -s tests` currently has one unrelated existing failure: `test_manifest_declares_current_methodology_version` expects `version = "0.1.2-rc.1"`, while `manifest.toml` declares `version = "0.2.0"`.
