### PR TITLE
feat(architecture/step-1): mechanic schema + parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   TOML parser, graph invariant checks, registry-reference validation, and
   fixture coverage for linear, branching, loop, and multi-terminal contracts
   (closes #293).
+- Mechanic authoring substrate: a C-3 JSON Schema, TOML parser, optional
+  forge-tag validation, registry-reference validation, and fixture coverage for
+  forge-neutral, forge-tagged, and runtime-tool mechanics (closes #294).
 
 ### Fixed
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -8,6 +8,10 @@ defined only in this repository.
 contracts from ADR-0002. It is validated by `tooling.workflow_contracts`, not
 declared as a runtime artifact type in `manifest.toml`.
 
+`mechanic.schema.json` is an authoring substrate for C-3 mechanics from
+ADR-0002. It is validated by `tooling.mechanics`, not declared as a runtime
+artifact type in `manifest.toml`.
+
 `request.schema.json` is different: it is a vendored copy of the canonical
 request contract maintained by `tesserine/commons`. Groundwork keeps the runtime
 copy here so runtime consumers still read schemas from groundwork, not from

--- a/schemas/mechanic.schema.json
+++ b/schemas/mechanic.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/mechanic.schema.json",
+  "title": "Mechanic",
+  "description": "Validates C-3 mechanics: TOML-authored HOW recipes with optional forge tagging.",
+  "type": "object",
+  "required": [
+    "name",
+    "purpose",
+    "parameters",
+    "default_invocation",
+    "outcome",
+    "examples"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
+    },
+    "purpose": {
+      "type": "string",
+      "minLength": 1
+    },
+    "forge_tag": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
+    },
+    "parameters": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/parameter"
+      }
+    },
+    "default_invocation": {
+      "type": "string",
+      "minLength": 1
+    },
+    "outcome": {
+      "$ref": "#/$defs/outcome"
+    },
+    "examples": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "parameter": {
+      "type": "object",
+      "required": ["name", "purpose", "required"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9]*([_.-][a-z0-9]+)*$"
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "schema_ref": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
+        }
+      }
+    },
+    "outcome": {
+      "type": "object",
+      "required": ["description"],
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifact_type": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/mechanics/invalid-forge-tag.toml
+++ b/tests/fixtures/mechanics/invalid-forge-tag.toml
@@ -7,4 +7,3 @@ examples = ["gh pr create --title example"]
 
 [outcome]
 description = "A change proposal exists on the forge."
-

--- a/tests/fixtures/mechanics/invalid-forge-tag.toml
+++ b/tests/fixtures/mechanics/invalid-forge-tag.toml
@@ -1,0 +1,10 @@
+name = "create-change-proposal"
+purpose = "Create a change proposal on a forge."
+forge_tag = "GitHub"
+parameters = []
+default_invocation = "gh pr create --title {title}"
+examples = ["gh pr create --title example"]
+
+[outcome]
+description = "A change proposal exists on the forge."
+

--- a/tests/fixtures/mechanics/invalid-malformed-shape.toml
+++ b/tests/fixtures/mechanics/invalid-malformed-shape.toml
@@ -6,4 +6,3 @@ examples = ["git push origin branch"]
 
 [outcome]
 description = "The branch exists on the remote."
-

--- a/tests/fixtures/mechanics/invalid-malformed-shape.toml
+++ b/tests/fixtures/mechanics/invalid-malformed-shape.toml
@@ -1,0 +1,9 @@
+name = "broken-mechanic"
+purpose = 42
+parameters = "branch"
+default_invocation = "git push {branch}"
+examples = ["git push origin branch"]
+
+[outcome]
+description = "The branch exists on the remote."
+

--- a/tests/fixtures/mechanics/invalid-missing-required.toml
+++ b/tests/fixtures/mechanics/invalid-missing-required.toml
@@ -2,4 +2,3 @@ name = "missing-fields"
 parameters = []
 default_invocation = "true"
 examples = ["true"]
-

--- a/tests/fixtures/mechanics/invalid-missing-required.toml
+++ b/tests/fixtures/mechanics/invalid-missing-required.toml
@@ -1,0 +1,5 @@
+name = "missing-fields"
+parameters = []
+default_invocation = "true"
+examples = ["true"]
+

--- a/tests/fixtures/mechanics/invalid-registry-reference.toml
+++ b/tests/fixtures/mechanics/invalid-registry-reference.toml
@@ -12,4 +12,3 @@ schema_ref = "missing-schema"
 [outcome]
 description = "The artifact is persisted."
 artifact_type = "missing-artifact"
-

--- a/tests/fixtures/mechanics/invalid-registry-reference.toml
+++ b/tests/fixtures/mechanics/invalid-registry-reference.toml
@@ -1,0 +1,15 @@
+name = "deliver-artifact"
+purpose = "Deliver an artifact through a runtime tool."
+default_invocation = "call {tool_name} with {payload}"
+examples = ["call change-proposal with payload"]
+
+[[parameters]]
+name = "payload"
+purpose = "Artifact payload."
+required = true
+schema_ref = "missing-schema"
+
+[outcome]
+description = "The artifact is persisted."
+artifact_type = "missing-artifact"
+

--- a/tests/fixtures/mechanics/valid-git.toml
+++ b/tests/fixtures/mechanics/valid-git.toml
@@ -1,0 +1,20 @@
+name = "git-push"
+purpose = "Push a local branch to a remote repository."
+default_invocation = "git push {remote} {branch}"
+examples = [
+  "git push origin issue-294/feat-architecture-step-1-mechanic-schema",
+]
+
+[[parameters]]
+name = "remote"
+purpose = "Remote repository name."
+required = true
+
+[[parameters]]
+name = "branch"
+purpose = "Local branch name."
+required = true
+
+[outcome]
+description = "The named branch exists on the remote."
+

--- a/tests/fixtures/mechanics/valid-git.toml
+++ b/tests/fixtures/mechanics/valid-git.toml
@@ -17,4 +17,3 @@ required = true
 
 [outcome]
 description = "The named branch exists on the remote."
-

--- a/tests/fixtures/mechanics/valid-github.toml
+++ b/tests/fixtures/mechanics/valid-github.toml
@@ -19,4 +19,3 @@ required = true
 [outcome]
 description = "A GitHub pull request exists."
 artifact_type = "change-proposal"
-

--- a/tests/fixtures/mechanics/valid-github.toml
+++ b/tests/fixtures/mechanics/valid-github.toml
@@ -1,0 +1,22 @@
+name = "deliver-change-proposal"
+purpose = "Create a GitHub-hosted change proposal."
+forge_tag = "github"
+default_invocation = "gh pr create --title {title} --body-file {body_file}"
+examples = [
+  "gh pr create --title 'Add mechanic parser' --body-file /tmp/body.md",
+]
+
+[[parameters]]
+name = "title"
+purpose = "Change proposal title."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing the proposal body."
+required = true
+
+[outcome]
+description = "A GitHub pull request exists."
+artifact_type = "change-proposal"
+

--- a/tests/fixtures/mechanics/valid-mcp-tool.toml
+++ b/tests/fixtures/mechanics/valid-mcp-tool.toml
@@ -1,0 +1,23 @@
+name = "produce-artifact"
+purpose = "Invoke a runa-exposed artifact tool."
+forge_tag = "generic"
+default_invocation = "call {tool_name} with {payload}"
+examples = [
+  "call completion-evidence with validated payload",
+]
+
+[[parameters]]
+name = "payload"
+purpose = "Artifact payload matching the referenced schema."
+required = true
+schema_ref = "completion-evidence"
+
+[[parameters]]
+name = "tool_name"
+purpose = "Artifact tool name exposed by runa."
+required = true
+
+[outcome]
+description = "The artifact is validated and written."
+artifact_type = "completion-evidence"
+

--- a/tests/fixtures/mechanics/valid-mcp-tool.toml
+++ b/tests/fixtures/mechanics/valid-mcp-tool.toml
@@ -20,4 +20,3 @@ required = true
 [outcome]
 description = "The artifact is validated and written."
 artifact_type = "completion-evidence"
-

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -1,0 +1,93 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from tooling.mechanics import (
+    MechanicError,
+    MechanicRegistry,
+    load_mechanic,
+    validate_mechanic,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "mechanics"
+
+
+class MechanicTests(unittest.TestCase):
+    def fixture(self, name: str) -> Path:
+        return FIXTURES / name
+
+    def test_schema_accepts_forge_neutral_git_mechanic(self) -> None:
+        mechanic = load_mechanic(self.fixture("valid-git.toml"))
+
+        self.assertEqual(mechanic["name"], "git-push")
+
+    def test_schema_accepts_github_tagged_forge_mechanic(self) -> None:
+        mechanic = load_mechanic(self.fixture("valid-github.toml"))
+
+        self.assertEqual(mechanic["forge_tag"], "github")
+
+    def test_schema_accepts_generic_runtime_mcp_tool_mechanic(self) -> None:
+        mechanic = load_mechanic(self.fixture("valid-mcp-tool.toml"))
+
+        self.assertEqual(mechanic["forge_tag"], "generic")
+
+    def test_schema_rejects_malformed_shape_with_field_paths(self) -> None:
+        with self.assertRaises(MechanicError) as context:
+            load_mechanic(self.fixture("invalid-malformed-shape.toml"))
+
+        self.assertIn("purpose", context.exception.paths)
+        self.assertIn("parameters", context.exception.paths)
+        self.assertIn("purpose", str(context.exception))
+
+    def test_schema_rejects_missing_required_fields_with_field_paths(self) -> None:
+        with self.assertRaises(MechanicError) as context:
+            load_mechanic(self.fixture("invalid-missing-required.toml"))
+
+        self.assertIn("purpose", context.exception.paths)
+        self.assertIn("outcome", context.exception.paths)
+
+    def test_schema_rejects_malformed_forge_tag_with_field_path(self) -> None:
+        with self.assertRaises(MechanicError) as context:
+            load_mechanic(self.fixture("invalid-forge-tag.toml"))
+
+        self.assertIn("forge_tag", context.exception.paths)
+
+    def test_registry_resolution_can_be_deferred_when_no_registry_is_loaded(self) -> None:
+        mechanic = load_mechanic(self.fixture("invalid-registry-reference.toml"), registry=None)
+
+        self.assertEqual(mechanic["name"], "deliver-artifact")
+
+    def test_registry_resolution_rejects_unknown_references_when_registry_is_loaded(self) -> None:
+        registry = MechanicRegistry(
+            artifact_schemas={"completion-evidence"},
+            artifact_types={"completion-evidence"},
+        )
+
+        with self.assertRaises(MechanicError) as context:
+            load_mechanic(self.fixture("invalid-registry-reference.toml"), registry=registry)
+
+        self.assertIn("parameters/0/schema_ref", context.exception.paths)
+        self.assertIn("outcome/artifact_type", context.exception.paths)
+        self.assertIn("artifact schema `missing-schema` does not resolve in registry", str(context.exception))
+
+    def test_validate_mechanic_accepts_already_loaded_toml_data(self) -> None:
+        mechanic = load_mechanic(self.fixture("valid-git.toml"))
+
+        validate_mechanic(mechanic)
+
+    def test_invalid_toml_reports_source_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "bad.toml"
+            path.write_text("name = [\n", encoding="utf-8")
+
+            with self.assertRaises(MechanicError) as context:
+                load_mechanic(path)
+
+        self.assertEqual(["<toml>"], context.exception.paths)
+        self.assertIn("bad.toml is invalid TOML", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/mechanics.py
+++ b/tooling/mechanics.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MECHANIC_SCHEMA = ROOT / "schemas" / "mechanic.schema.json"
+
+
+class MechanicError(ValueError):
+    def __init__(self, errors: list[tuple[str, str]]) -> None:
+        self.errors = errors
+        self.paths = [path for path, _message in errors]
+        super().__init__(self._format())
+
+    def _format(self) -> str:
+        return "; ".join(f"{path}: {message}" for path, message in self.errors)
+
+
+@dataclass(frozen=True)
+class MechanicRegistry:
+    artifact_schemas: set[str] = field(default_factory=set)
+    artifact_types: set[str] = field(default_factory=set)
+
+
+def load_mechanic(path: Path | str, registry: MechanicRegistry | None = None) -> dict[str, Any]:
+    mechanic_path = Path(path)
+    try:
+        mechanic = tomllib.loads(mechanic_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as error:
+        raise MechanicError([("<toml>", f"{mechanic_path.name} is invalid TOML: {error}")]) from error
+
+    validate_mechanic(mechanic, registry=registry)
+    return mechanic
+
+
+def validate_mechanic(mechanic: dict[str, Any], registry: MechanicRegistry | None = None) -> None:
+    errors: list[tuple[str, str]] = []
+    errors.extend(_schema_errors(mechanic))
+    if registry is not None and not errors:
+        errors.extend(_registry_errors(mechanic, registry))
+
+    if errors:
+        raise MechanicError(errors)
+
+
+def _schema_errors(mechanic: dict[str, Any]) -> list[tuple[str, str]]:
+    schema = json.loads(MECHANIC_SCHEMA.read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema)
+    errors: list[tuple[str, str]] = []
+
+    for error in sorted(validator.iter_errors(mechanic), key=lambda item: list(item.path)):
+        path = "/".join(str(part) for part in error.path)
+        if error.validator == "required":
+            missing = error.message.split("'")[1]
+            path = f"{path}/{missing}" if path else missing
+        errors.append((path or "<root>", error.message))
+
+    return errors
+
+
+def _registry_errors(mechanic: dict[str, Any], registry: MechanicRegistry) -> list[tuple[str, str]]:
+    errors: list[tuple[str, str]] = []
+    for parameter_index, parameter in enumerate(mechanic["parameters"]):
+        schema_ref = parameter.get("schema_ref")
+        if schema_ref is not None and schema_ref not in registry.artifact_schemas:
+            errors.append(
+                (
+                    f"parameters/{parameter_index}/schema_ref",
+                    f"artifact schema `{schema_ref}` does not resolve in registry",
+                )
+            )
+
+    artifact_type = mechanic["outcome"].get("artifact_type")
+    if artifact_type is not None and artifact_type not in registry.artifact_types:
+        errors.append(
+            (
+                "outcome/artifact_type",
+                f"artifact type `{artifact_type}` does not resolve in registry",
+            )
+        )
+
+    return errors


### PR DESCRIPTION
## Summary

- Adds the ADR-0002 C-3 mechanic JSON Schema and TOML parser.
- Validates optional `forge_tag` shape and preserves free-string `default_invocation` templates.
- Adds registry-backed checks for parameter schema references and outcome artifact-type references.

## Changes

- Adds `schemas/mechanic.schema.json` for the minimal mechanic authoring substrate.
- Adds `tooling.mechanics` with structured `MechanicError` paths and deferred registry validation.
- Adds valid and invalid mechanic fixtures covering forge-neutral, GitHub-tagged, runtime-tool, malformed, and bad-reference cases.
- Documents the new authoring substrate in `schemas/README.md` and `CHANGELOG.md`.

## GitHub Issue(s)

Closes #294

## Test plan

- `python -m unittest tests.test_mechanics tests.test_workflow_contracts`
- `python -m json.tool schemas/mechanic.schema.json >/dev/null`

## Notes

- Parent #285's #220 gate relationship is treated as confirmed non-blocking for this Step-1 unit.
