### PR TITLE
fix(architecture): harden mechanic substrate validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Mechanic substrate validation now rejects empty `examples` arrays and
+  registry-loaded mechanics whose `forge_tag` is not declared in
+  `manifest.toml`; generic runtime mechanics remain forge-neutral by omitting
+  `forge_tag` (closes #322).
 - Interactive install now projects the artifact delivery adapter into every
   protocol entry without depending on protocol prose formatting, so wrapped MCP
   delivery text cannot omit the adapter from installed protocol skills.

--- a/manifest.toml
+++ b/manifest.toml
@@ -51,8 +51,7 @@ name = "research-record"
 
 # --- Forge Tags ---
 #
-# Canonical forge tags used by forge-tagged artifact handles. Mechanics carry
-# their own symmetric forge_tag registry check in follow-up work (#322).
+# Canonical forge tags used by forge-tagged artifact handles and mechanics.
 
 [[forge_tags]]
 name = "github"

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -20,9 +20,8 @@ classified observations against an immutable proposal version: approved reviews
 cannot carry blocking findings, and reviews needing revision must carry at
 least one blocking finding.
 
-Change-proposal handle forge tags resolve against the declarative
-`[[forge_tags]]` registry in `manifest.toml`. The symmetric check for
-mechanic-authored `forge_tag` values is tracked separately in #322.
+Change-proposal handle forge tags and mechanic-authored `forge_tag` values
+resolve against the declarative `[[forge_tags]]` registry in `manifest.toml`.
 
 `request.schema.json` is different: it is a vendored copy of the canonical
 request contract maintained by `tesserine/commons`. Groundwork keeps the runtime

--- a/schemas/mechanic.schema.json
+++ b/schemas/mechanic.schema.json
@@ -43,6 +43,7 @@
     },
     "examples": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "string",
         "minLength": 1

--- a/tests/fixtures/mechanics/invalid-empty-examples.toml
+++ b/tests/fixtures/mechanics/invalid-empty-examples.toml
@@ -1,0 +1,8 @@
+name = "empty-examples"
+purpose = "Demonstrate non-vacuous mechanic examples."
+parameters = []
+default_invocation = "true"
+examples = []
+
+[outcome]
+description = "The command succeeds."

--- a/tests/fixtures/mechanics/invalid-forge-tag-unregistered.toml
+++ b/tests/fixtures/mechanics/invalid-forge-tag-unregistered.toml
@@ -1,0 +1,9 @@
+name = "deliver-change-proposal-sourcehut-lists"
+purpose = "Create a Sourcehut mailing-list change proposal."
+forge_tag = "sourcehut-lists"
+parameters = []
+default_invocation = "git send-email --to {list}"
+examples = ["git send-email --to ~example/project-devel patch.mbox"]
+
+[outcome]
+description = "A change proposal exists on the forge."

--- a/tests/fixtures/mechanics/valid-mcp-tool.toml
+++ b/tests/fixtures/mechanics/valid-mcp-tool.toml
@@ -1,6 +1,5 @@
 name = "produce-artifact"
 purpose = "Invoke a runa-exposed artifact tool."
-forge_tag = "generic"
 default_invocation = "call {tool_name} with {payload}"
 examples = [
   "call completion-evidence with validated payload",

--- a/tests/fixtures/workflow-contracts/valid-mechanic-smoke.toml
+++ b/tests/fixtures/workflow-contracts/valid-mechanic-smoke.toml
@@ -1,0 +1,24 @@
+name = "submit-smoke"
+purpose = "Exercise workflow mechanic registry resolution with a mechanic parser output."
+session_role = "integration smoke"
+preconditions = ["a mechanic parser registry exists"]
+start_node = "deliver-change-proposal"
+failure_modes = ["mechanic reference drifts"]
+corruption_modes = ["cross-parser drift"]
+
+[[nodes]]
+name = "deliver-change-proposal"
+intent = "Deliver the change proposal through the selected forge mechanic."
+disciplines = ["orient"]
+mechanics = ["deliver-change-proposal"]
+outcomes = ["change proposal delivered"]
+
+[[edges]]
+from = "deliver-change-proposal"
+to = "delivered"
+condition = { type = "always" }
+
+[[terminals]]
+name = "delivered"
+outcome = "The change proposal exists."
+artifact_produced = "change-proposal"

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -2,6 +2,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from tooling.artifact_schemas import registry_from_manifest
 from tooling.mechanics import (
     MechanicError,
     MechanicRegistry,
@@ -87,6 +88,18 @@ class MechanicTests(unittest.TestCase):
         mechanic = load_mechanic(self.fixture("valid-github.toml"), registry=registry)
 
         self.assertEqual(mechanic["forge_tag"], "github")
+
+    def test_registry_resolution_accepts_manifest_backed_artifact_declaring_mechanic(self) -> None:
+        mechanic = load_mechanic(self.fixture("valid-github.toml"), registry=registry_from_manifest())
+
+        self.assertEqual(mechanic["outcome"]["artifact_type"], "change-proposal")
+        self.assertEqual(mechanic["forge_tag"], "github")
+
+    def test_registry_resolution_accepts_manifest_backed_schema_ref_declaring_mechanic(self) -> None:
+        mechanic = load_mechanic(self.fixture("valid-mcp-tool.toml"), registry=registry_from_manifest())
+
+        self.assertEqual(mechanic["parameters"][0]["schema_ref"], "completion-evidence")
+        self.assertEqual(mechanic["outcome"]["artifact_type"], "completion-evidence")
 
     def test_registry_resolution_rejects_unknown_forge_tag_when_registry_is_loaded(self) -> None:
         registry = MechanicRegistry(forge_tags={"github"})

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -31,7 +31,7 @@ class MechanicTests(unittest.TestCase):
     def test_schema_accepts_generic_runtime_mcp_tool_mechanic(self) -> None:
         mechanic = load_mechanic(self.fixture("valid-mcp-tool.toml"))
 
-        self.assertEqual(mechanic["forge_tag"], "generic")
+        self.assertNotIn("forge_tag", mechanic)
 
     def test_schema_rejects_malformed_shape_with_field_paths(self) -> None:
         with self.assertRaises(MechanicError) as context:
@@ -54,6 +54,12 @@ class MechanicTests(unittest.TestCase):
 
         self.assertIn("forge_tag", context.exception.paths)
 
+    def test_schema_rejects_empty_examples_with_field_path(self) -> None:
+        with self.assertRaises(MechanicError) as context:
+            load_mechanic(self.fixture("invalid-empty-examples.toml"))
+
+        self.assertIn("examples", context.exception.paths)
+
     def test_registry_resolution_can_be_deferred_when_no_registry_is_loaded(self) -> None:
         mechanic = load_mechanic(self.fixture("invalid-registry-reference.toml"), registry=None)
 
@@ -71,6 +77,25 @@ class MechanicTests(unittest.TestCase):
         self.assertIn("parameters/0/schema_ref", context.exception.paths)
         self.assertIn("outcome/artifact_type", context.exception.paths)
         self.assertIn("artifact schema `missing-schema` does not resolve in registry", str(context.exception))
+
+    def test_registry_resolution_accepts_known_forge_tag_when_registry_is_loaded(self) -> None:
+        registry = MechanicRegistry(
+            artifact_types={"change-proposal"},
+            forge_tags={"github"},
+        )
+
+        mechanic = load_mechanic(self.fixture("valid-github.toml"), registry=registry)
+
+        self.assertEqual(mechanic["forge_tag"], "github")
+
+    def test_registry_resolution_rejects_unknown_forge_tag_when_registry_is_loaded(self) -> None:
+        registry = MechanicRegistry(forge_tags={"github"})
+
+        with self.assertRaises(MechanicError) as context:
+            load_mechanic(self.fixture("invalid-forge-tag-unregistered.toml"), registry=registry)
+
+        self.assertIn("forge_tag", context.exception.paths)
+        self.assertIn("forge tag `sourcehut-lists` does not resolve in registry", str(context.exception))
 
     def test_validate_mechanic_accepts_already_loaded_toml_data(self) -> None:
         mechanic = load_mechanic(self.fixture("valid-git.toml"))

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -2,6 +2,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from tooling.mechanics import load_mechanic
 from tooling.workflow_contracts import (
     WorkflowContractError,
     WorkflowRegistry,
@@ -12,6 +13,7 @@ from tooling.workflow_contracts import (
 
 ROOT = Path(__file__).resolve().parents[1]
 FIXTURES = ROOT / "tests" / "fixtures" / "workflow-contracts"
+MECHANIC_FIXTURES = ROOT / "tests" / "fixtures" / "mechanics"
 
 
 class WorkflowContractTests(unittest.TestCase):
@@ -99,6 +101,29 @@ class WorkflowContractTests(unittest.TestCase):
 
         self.assertIn("nodes/0/disciplines/1", context.exception.paths)
         self.assertIn("discipline `missing-discipline` does not resolve in registry", str(context.exception))
+
+    def test_parser_registries_resolve_mechanic_names_across_parsers(self) -> None:
+        mechanic = load_mechanic(MECHANIC_FIXTURES / "valid-github.toml")
+        registry = WorkflowRegistry(
+            disciplines={"orient"},
+            mechanics={mechanic["name"]},
+            artifact_schemas={"change-proposal"},
+        )
+
+        contract = load_workflow_contract(self.fixture("valid-mechanic-smoke.toml"), registry=registry)
+
+        self.assertEqual("submit-smoke", contract["name"])
+
+        renamed_registry = WorkflowRegistry(
+            disciplines={"orient"},
+            mechanics={f"{mechanic['name']}-renamed"},
+            artifact_schemas={"change-proposal"},
+        )
+        with self.assertRaises(WorkflowContractError) as context:
+            load_workflow_contract(self.fixture("valid-mechanic-smoke.toml"), registry=renamed_registry)
+
+        self.assertIn("nodes/0/mechanics/0", context.exception.paths)
+        self.assertIn("mechanic `deliver-change-proposal` does not resolve in registry", str(context.exception))
 
     def test_validate_workflow_contract_accepts_already_loaded_toml_data(self) -> None:
         contract = load_workflow_contract(self.fixture("valid-linear.toml"))

--- a/tooling/artifact_schemas.py
+++ b/tooling/artifact_schemas.py
@@ -33,7 +33,14 @@ class ArtifactSchemaError(ValueError):
 
 def registry_from_manifest(path: Path | str = MANIFEST) -> MechanicRegistry:
     manifest = tomllib.loads(Path(path).read_text(encoding="utf-8"))
+    artifact_types = {
+        entry["name"]
+        for entry in manifest.get("artifact_types", [])
+        if isinstance(entry, dict) and isinstance(entry.get("name"), str)
+    }
     return MechanicRegistry(
+        artifact_schemas=set(artifact_types),
+        artifact_types=artifact_types,
         forge_tags={
             entry["name"]
             for entry in manifest.get("forge_tags", [])

--- a/tooling/mechanics.py
+++ b/tooling/mechanics.py
@@ -87,4 +87,8 @@ def _registry_errors(mechanic: dict[str, Any], registry: MechanicRegistry) -> li
             )
         )
 
+    forge_tag = mechanic.get("forge_tag")
+    if forge_tag is not None and forge_tag not in registry.forge_tags:
+        errors.append(("forge_tag", f"forge tag `{forge_tag}` does not resolve in registry"))
+
     return errors


### PR DESCRIPTION
## Summary

- Enforces mechanic `forge_tag` values against the existing `forge_tags` registry when a registry is loaded.
- Rejects vacuous mechanic `examples = []` and keeps generic runtime mechanics forge-neutral by omitting `forge_tag`.
- Adds cross-parser smoke coverage so workflow mechanic references are checked against mechanic parser output.

## Changes

- Adds `minItems: 1` to `schemas/mechanic.schema.json` examples.
- Extends `tooling.mechanics` registry validation to reject unknown mechanic `forge_tag` values while preserving deferred validation when no registry is supplied.
- Adds fixtures and tests for empty examples, unknown/known forge tags, and workflow-contract mechanic registry composition.
- Updates schema docs, manifest comments, and the changelog for the now-implemented validation behavior.

## GitHub Issue(s)

Closes #322

## Test plan

- `python -m unittest tests.test_mechanics tests.test_workflow_contracts`
- `python -m unittest tests.test_artifact_schemas`
- `python -m unittest tests.test_artifact_schemas tests.test_groundwork_install tests.test_mechanics tests.test_protocol_artifact_delivery_docs tests.test_request_schema_vendoring tests.test_submit_protocol tests.test_workflow_contracts`

Note: `python -m unittest discover -s tests` still hits 5 pre-existing release-cut failures on clean `origin/main`; this PR does not touch that release path.
