### PR TITLE
feat(conformance): add narrowed Step 1 runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Step 1 conformance now validates C-2 workflow registry references and reports
   explicit path read failures as aggregate failures instead of aborting.
+- Step 1 conformance now classifies explicit relative TOML paths from inside
+  `workflow-contracts/` or `mechanics/` directories by resolving them before
+  dispatch; TOML files outside those unit directories remain unsupported.
 - Mechanic substrate validation now rejects empty `examples` arrays and
   registry-loaded mechanics whose `forge_tag` is not declared in
   `manifest.toml`; generic runtime mechanics remain forge-neutral by omitting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Step 1 conformance now classifies explicit relative TOML paths from inside
   `workflow-contracts/` or `mechanics/` directories by resolving them before
   dispatch; TOML files outside those unit directories remain unsupported.
+- Step 1 conformance directory arguments now use the same unit discovery rules
+  as the default runner, so non-unit files such as `manifest.toml` are skipped
+  during directory expansion while explicitly named non-units still fail.
 - Mechanic substrate validation now rejects empty `examples` arrays and
   registry-loaded mechanics whose `forge_tag` is not declared in
   `manifest.toml`; generic runtime mechanics remain forge-neutral by omitting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   handles, disposition/blocking-finding consistency, manifest-declared forge
   tags, format-enforced artifact validation, and `patch` schema supersession
   metadata (closes #316).
+- Narrowed Step 1 conformance runner for C-2 workflow contracts, C-3
+  mechanics, C-4 artifact instances, and JSON Schema definitions, with
+  aggregate pass/fail reporting and non-zero exit on failure (closes #297).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Step 1 conformance now validates C-2 workflow registry references and reports
+  explicit path read failures as aggregate failures instead of aborting.
 - Mechanic substrate validation now rejects empty `examples` arrays and
   registry-loaded mechanics whose `forge_tag` is not declared in
   `manifest.toml`; generic runtime mechanics remain forge-neutral by omitting

--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ Prerequisites are the stock command-line tools expected on Fedora CoreOS for
 this workflow: `bash`, `git`, and POSIX file utilities such as `cp`, `find`,
 `mkdir`, `mv`, and `rm`.
 
+## Conformance Checks
+
+Run the narrowed Step 1 methodology conformance runner with:
+
+```bash
+python -m tooling.conformance
+```
+
+By default it checks source-tree workflow contracts and mechanics when those
+directories exist, and all JSON Schema definitions under `schemas/`. Pass files
+or directories as arguments to check explicit C-2/C-3/C-4 units and aggregate
+all failures before returning a non-zero exit status.
+
 ## What Groundwork Believes
 
 These are the methodology choices embedded in groundwork's protocols and skills.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,10 @@ python -m tooling.conformance
 By default it checks source-tree workflow contracts and mechanics when those
 directories exist, and all JSON Schema definitions under `schemas/`. Pass files
 or directories as arguments to check explicit C-2/C-3/C-4 units and aggregate
-all failures before returning a non-zero exit status.
+all failures before returning a non-zero exit status. Directory arguments use
+the same discovery rules as the default runner: `workflow-contracts/` and
+`mechanics/` TOML units plus `schemas/*.schema.json`. Explicit file arguments
+that do not classify as conformance units still fail loudly.
 
 ## What Groundwork Believes
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -59,6 +59,26 @@ name = "github"
 [[forge_tags]]
 name = "sourcehut"
 
+# --- Mechanics ---
+#
+# Referenceable mechanic handles for C-2 workflow contracts. Full C-3 mechanic
+# definitions may refine these handles as the mechanic library is authored.
+
+[[mechanics]]
+name = "read-artifact"
+
+[[mechanics]]
+name = "inspect-change-proposals"
+
+[[mechanics]]
+name = "deliver-change-proposal"
+
+[[mechanics]]
+name = "inspect-worktree"
+
+[[mechanics]]
+name = "run-test"
+
 # --- Protocols ---
 #
 # Planning phase: survey → decompose

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -129,6 +129,33 @@ class ConformanceTests(unittest.TestCase):
         self.assertEqual("C-2 workflow-contract", results[0].category)
         self.assertTrue(results[0].passed)
 
+    def test_direct_schema_directory_argument_validates_schema_definitions(self) -> None:
+        results = run_conformance([SCHEMAS])
+
+        self.assertGreater(len(results), 0)
+        self.assertTrue(all(result.path.parent == SCHEMAS for result in results))
+        self.assertTrue(all(result.category == "C-4 schema-definition" for result in results))
+        self.assertTrue(all(result.passed for result in results))
+
+    def test_direct_unit_directory_argument_reports_invalid_units(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            contracts = root / "workflow-contracts"
+            contracts.mkdir()
+            invalid = contracts / "invalid.toml"
+            invalid.write_text(
+                (WORKFLOW_FIXTURES / "invalid-malformed-shape.toml").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+
+            results = run_conformance([contracts])
+
+        self.assertEqual(1, len(results))
+        self.assertEqual(invalid.resolve(), results[0].path)
+        self.assertEqual("C-2 workflow-contract", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertTrue(results[0].errors)
+
     def test_explicit_non_unit_toml_path_fails_instead_of_silently_skipping(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             manifest = Path(directory) / "manifest.toml"

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -53,6 +53,27 @@ class ConformanceTests(unittest.TestCase):
         self.assertIn("purpose", " ".join(results[1].errors))
         self.assertIn("version", results[2].errors[0])
 
+    def test_workflow_registry_references_are_validated_by_runner(self) -> None:
+        results = run_conformance([WORKFLOW_FIXTURES / "invalid-registry-reference.toml"])
+
+        self.assertEqual(1, len(results))
+        self.assertEqual("C-2 workflow-contract", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn("discipline `missing-discipline` does not resolve in registry", " ".join(results[0].errors))
+
+    def test_missing_explicit_path_fails_without_aborting_remaining_units(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            missing = Path(directory) / "missing.schema.json"
+
+            results = run_conformance([missing, WORKFLOW_FIXTURES / "valid-linear.toml"])
+
+        self.assertEqual(2, len(results))
+        self.assertEqual("C-4 schema-definition", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn("cannot read conformance unit", " ".join(results[0].errors))
+        self.assertEqual("C-2 workflow-contract", results[1].category)
+        self.assertTrue(results[1].passed)
+
     def test_invalid_schema_definition_returns_failure_result(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             schema = Path(directory) / "broken.schema.json"

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -75,6 +75,20 @@ class ConformanceTests(unittest.TestCase):
         self.assertEqual("C-2 workflow-contract", results[1].category)
         self.assertTrue(results[1].passed)
 
+    def test_non_utf8_explicit_path_fails_without_aborting_remaining_units(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            malformed = Path(directory) / "malformed.schema.json"
+            malformed.write_bytes(b"\xff")
+
+            results = run_conformance([malformed, WORKFLOW_FIXTURES / "valid-linear.toml"])
+
+        self.assertEqual(2, len(results))
+        self.assertEqual("C-4 schema-definition", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn("cannot read conformance unit", " ".join(results[0].errors))
+        self.assertEqual("C-2 workflow-contract", results[1].category)
+        self.assertTrue(results[1].passed)
+
     def test_invalid_schema_definition_returns_failure_result(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             schema = Path(directory) / "broken.schema.json"

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -113,6 +113,34 @@ class ConformanceTests(unittest.TestCase):
         self.assertFalse(results[0].passed)
         self.assertIn("unsupported conformance unit", results[0].errors)
 
+    def test_directory_argument_discovers_only_recognized_units(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "manifest.toml").write_text("name = \"example\"\n", encoding="utf-8")
+            contracts = root / "workflow-contracts"
+            contracts.mkdir()
+            contract = contracts / "verify.toml"
+            contract.write_text((WORKFLOW_FIXTURES / "valid-linear.toml").read_text(encoding="utf-8"), encoding="utf-8")
+
+            results = run_conformance([root])
+
+        self.assertEqual(1, len(results))
+        self.assertEqual(contract.resolve(), results[0].path)
+        self.assertEqual("C-2 workflow-contract", results[0].category)
+        self.assertTrue(results[0].passed)
+
+    def test_explicit_non_unit_toml_path_fails_instead_of_silently_skipping(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "manifest.toml"
+            manifest.write_text("name = \"example\"\n", encoding="utf-8")
+
+            results = run_conformance([manifest])
+
+        self.assertEqual(1, len(results))
+        self.assertEqual("unknown", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn("unsupported conformance unit", results[0].errors)
+
     def test_cli_exit_code_reflects_aggregate_result(self) -> None:
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -129,6 +130,25 @@ class ConformanceTests(unittest.TestCase):
             results = run_conformance(discovered)
 
         self.assertEqual([contract], discovered)
+        self.assertEqual(1, len(results))
+        self.assertEqual("C-2 workflow-contract", results[0].category)
+        self.assertTrue(results[0].passed)
+
+    def test_bare_relative_workflow_contract_validates_from_contract_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            contracts = root / "workflow-contracts"
+            contracts.mkdir()
+            contract = contracts / "verify.toml"
+            contract.write_text((WORKFLOW_FIXTURES / "valid-linear.toml").read_text(encoding="utf-8"), encoding="utf-8")
+
+            original_cwd = Path.cwd()
+            try:
+                os.chdir(contracts)
+                results = run_conformance([Path("verify.toml")])
+            finally:
+                os.chdir(original_cwd)
+
         self.assertEqual(1, len(results))
         self.assertEqual("C-2 workflow-contract", results[0].category)
         self.assertTrue(results[0].passed)

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,0 +1,117 @@
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tooling.conformance import discover_units, main, run_conformance
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_FIXTURES = ROOT / "tests" / "fixtures" / "artifacts"
+MECHANIC_FIXTURES = ROOT / "tests" / "fixtures" / "mechanics"
+WORKFLOW_FIXTURES = ROOT / "tests" / "fixtures" / "workflow-contracts"
+SCHEMAS = ROOT / "schemas"
+
+
+class ConformanceTests(unittest.TestCase):
+    def test_explicit_dispatch_accepts_valid_step_1_units(self) -> None:
+        results = run_conformance(
+            [
+                WORKFLOW_FIXTURES / "valid-linear.toml",
+                MECHANIC_FIXTURES / "valid-git.toml",
+                ARTIFACT_FIXTURES / "valid-change-proposal-github-v1.json",
+                SCHEMAS / "change-proposal.schema.json",
+            ]
+        )
+
+        self.assertEqual(
+            [
+                "C-2 workflow-contract",
+                "C-3 mechanic",
+                "C-4 artifact-instance",
+                "C-4 schema-definition",
+            ],
+            [result.category for result in results],
+        )
+        self.assertTrue(all(result.passed for result in results))
+
+    def test_invalid_units_return_failures_without_raising(self) -> None:
+        results = run_conformance(
+            [
+                WORKFLOW_FIXTURES / "invalid-malformed-shape.toml",
+                MECHANIC_FIXTURES / "invalid-malformed-shape.toml",
+                ARTIFACT_FIXTURES / "invalid-change-proposal-missing-version.json",
+            ]
+        )
+
+        self.assertEqual(3, len(results))
+        self.assertTrue(all(not result.passed for result in results))
+        self.assertTrue(all(result.errors for result in results))
+        self.assertIn("nodes/0/name", results[0].errors[0])
+        self.assertIn("purpose", " ".join(results[1].errors))
+        self.assertIn("version", results[2].errors[0])
+
+    def test_invalid_schema_definition_returns_failure_result(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            schema = Path(directory) / "broken.schema.json"
+            schema.write_text(json.dumps({"type": 7}), encoding="utf-8")
+
+            results = run_conformance([schema])
+
+        self.assertEqual(1, len(results))
+        self.assertEqual("C-4 schema-definition", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn("not valid under any of the given schemas", " ".join(results[0].errors))
+
+    def test_unknown_explicit_path_fails_instead_of_silently_skipping(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            unknown = Path(directory) / "unit.txt"
+            unknown.write_text("not a conformance unit", encoding="utf-8")
+
+            results = run_conformance([unknown])
+
+        self.assertEqual(1, len(results))
+        self.assertEqual("unknown", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn("unsupported conformance unit", results[0].errors)
+
+    def test_cli_exit_code_reflects_aggregate_result(self) -> None:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            passing = main([str(WORKFLOW_FIXTURES / "valid-linear.toml")])
+        with contextlib.redirect_stdout(stdout):
+            failing = main([str(WORKFLOW_FIXTURES / "invalid-malformed-shape.toml")])
+
+        self.assertEqual(0, passing)
+        self.assertEqual(1, failing)
+        self.assertIn("PASS", stdout.getvalue())
+        self.assertIn("FAIL", stdout.getvalue())
+
+    def test_default_discovery_finds_schema_definitions_without_requiring_future_dirs(self) -> None:
+        discovered = discover_units(ROOT)
+
+        self.assertIn(SCHEMAS / "change-proposal.schema.json", discovered)
+        self.assertIn(SCHEMAS / "review-findings.schema.json", discovered)
+        self.assertFalse(any("tests/fixtures" in path.as_posix() for path in discovered))
+
+    def test_future_r1_contract_is_discovered_without_runner_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            contracts = root / "workflow-contracts"
+            contracts.mkdir()
+            contract = contracts / "verify.toml"
+            contract.write_text((WORKFLOW_FIXTURES / "valid-linear.toml").read_text(encoding="utf-8"), encoding="utf-8")
+
+            discovered = discover_units(root)
+            results = run_conformance(discovered)
+
+        self.assertEqual([contract], discovered)
+        self.assertEqual(1, len(results))
+        self.assertEqual("C-2 workflow-contract", results[0].category)
+        self.assertTrue(results[0].passed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -8,6 +8,7 @@ from tooling.workflow_contracts import (
     WorkflowRegistry,
     load_workflow_contract,
     validate_workflow_contract,
+    workflow_registry_from_manifest,
 )
 
 
@@ -124,6 +125,31 @@ class WorkflowContractTests(unittest.TestCase):
 
         self.assertIn("nodes/0/mechanics/0", context.exception.paths)
         self.assertIn("mechanic `deliver-change-proposal` does not resolve in registry", str(context.exception))
+
+    def test_registry_from_manifest_resolves_nested_mechanic_directory_names(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "skills" / "orient").mkdir(parents=True)
+            nested_mechanics = root / "mechanics" / "delivery"
+            nested_mechanics.mkdir(parents=True)
+            (nested_mechanics / "valid-github.toml").write_text(
+                (MECHANIC_FIXTURES / "valid-github.toml").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            manifest = root / "manifest.toml"
+            manifest.write_text(
+                """
+[[artifact_types]]
+name = "change-proposal"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            registry = workflow_registry_from_manifest(manifest, root=root)
+            self.assertIn("deliver-change-proposal", registry.mechanics)
+            contract = load_workflow_contract(self.fixture("valid-mechanic-smoke.toml"), registry=registry)
+
+        self.assertEqual("submit-smoke", contract["name"])
 
     def test_validate_workflow_contract_accepts_already_loaded_toml_data(self) -> None:
         contract = load_workflow_contract(self.fixture("valid-linear.toml"))

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -100,7 +100,7 @@ def _check_unit(path: Path) -> ConformanceResult:
             return _check_schema_definition(path)
         if category == CATEGORY_ARTIFACT:
             return _check_artifact_instance(path)
-    except OSError as error:
+    except (OSError, UnicodeDecodeError) as error:
         return ConformanceResult(
             path=path,
             category=category,

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -77,13 +77,7 @@ def _expand_paths(paths: Iterable[Path | str]) -> list[Path]:
     for path_like in paths:
         path = Path(path_like).resolve()
         if path.is_dir():
-            units.extend(
-                sorted(
-                    candidate
-                    for candidate in path.rglob("*")
-                    if candidate.is_file() and candidate.suffix in {".json", ".toml"}
-                )
-            )
+            units.extend(discover_units(path))
         else:
             units.append(path)
     return units

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -33,7 +33,7 @@ class ConformanceResult:
 
 
 def discover_units(root: Path | str = ROOT) -> list[Path]:
-    root_path = Path(root)
+    root_path = Path(root).resolve()
     units: list[Path] = []
 
     for directory_name in ("workflow-contracts", "mechanics"):
@@ -75,7 +75,7 @@ def main(argv: list[str] | None = None) -> int:
 def _expand_paths(paths: Iterable[Path | str]) -> list[Path]:
     units: list[Path] = []
     for path_like in paths:
-        path = Path(path_like)
+        path = Path(path_like).resolve()
         if path.is_dir():
             units.extend(
                 sorted(
@@ -111,6 +111,8 @@ def _check_unit(path: Path) -> ConformanceResult:
 
 
 def _classify(path: Path) -> str:
+    # C-2 and C-3 TOML units are directory-scoped in Step 1; TOML files outside
+    # those directories intentionally remain unknown.
     if path.name.endswith(".schema.json"):
         return CATEGORY_SCHEMA
     if path.suffix == ".toml" and "workflow-contracts" in path.parts:

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -11,7 +11,7 @@ from jsonschema.exceptions import SchemaError
 
 from tooling.artifact_schemas import ArtifactSchemaError, load_artifact, registry_from_manifest
 from tooling.mechanics import MechanicError, load_mechanic
-from tooling.workflow_contracts import WorkflowContractError, load_workflow_contract
+from tooling.workflow_contracts import WorkflowContractError, load_workflow_contract, workflow_registry_from_manifest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -91,14 +91,22 @@ def _expand_paths(paths: Iterable[Path | str]) -> list[Path]:
 
 def _check_unit(path: Path) -> ConformanceResult:
     category = _classify(path)
-    if category == CATEGORY_WORKFLOW:
-        return _check_workflow_contract(path)
-    if category == CATEGORY_MECHANIC:
-        return _check_mechanic(path)
-    if category == CATEGORY_SCHEMA:
-        return _check_schema_definition(path)
-    if category == CATEGORY_ARTIFACT:
-        return _check_artifact_instance(path)
+    try:
+        if category == CATEGORY_WORKFLOW:
+            return _check_workflow_contract(path)
+        if category == CATEGORY_MECHANIC:
+            return _check_mechanic(path)
+        if category == CATEGORY_SCHEMA:
+            return _check_schema_definition(path)
+        if category == CATEGORY_ARTIFACT:
+            return _check_artifact_instance(path)
+    except OSError as error:
+        return ConformanceResult(
+            path=path,
+            category=category,
+            passed=False,
+            errors=[f"cannot read conformance unit: {error}"],
+        )
     return ConformanceResult(path=path, category=CATEGORY_UNKNOWN, passed=False, errors=["unsupported conformance unit"])
 
 
@@ -116,7 +124,7 @@ def _classify(path: Path) -> str:
 
 def _check_workflow_contract(path: Path) -> ConformanceResult:
     try:
-        load_workflow_contract(path, registry=None)
+        load_workflow_contract(path, registry=workflow_registry_from_manifest())
     except WorkflowContractError as error:
         return ConformanceResult(path=path, category=CATEGORY_WORKFLOW, passed=False, errors=_exception_errors(error))
     return ConformanceResult(path=path, category=CATEGORY_WORKFLOW, passed=True, errors=[])

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+
+from tooling.artifact_schemas import ArtifactSchemaError, load_artifact, registry_from_manifest
+from tooling.mechanics import MechanicError, load_mechanic
+from tooling.workflow_contracts import WorkflowContractError, load_workflow_contract
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMAS = ROOT / "schemas"
+
+CATEGORY_WORKFLOW = "C-2 workflow-contract"
+CATEGORY_MECHANIC = "C-3 mechanic"
+CATEGORY_ARTIFACT = "C-4 artifact-instance"
+CATEGORY_SCHEMA = "C-4 schema-definition"
+CATEGORY_UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ConformanceResult:
+    path: Path
+    category: str
+    passed: bool
+    errors: list[str]
+
+
+def discover_units(root: Path | str = ROOT) -> list[Path]:
+    root_path = Path(root)
+    units: list[Path] = []
+
+    for directory_name in ("workflow-contracts", "mechanics"):
+        directory = root_path / directory_name
+        if directory.exists():
+            units.extend(sorted(directory.rglob("*.toml")))
+
+    schemas = root_path / "schemas"
+    if schemas.exists():
+        units.extend(sorted(schemas.glob("*.schema.json")))
+
+    return units
+
+
+def run_conformance(paths: Iterable[Path | str] | None = None) -> list[ConformanceResult]:
+    units = discover_units() if paths is None else _expand_paths(paths)
+    return [_check_unit(path) for path in units]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run Groundwork Step-1 conformance checks.")
+    parser.add_argument("paths", nargs="*", help="Files or directories to check. Defaults to source-tree units.")
+    args = parser.parse_args(argv)
+
+    paths = args.paths if args.paths else None
+    results = run_conformance(paths)
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        print(f"{status} {result.category} {result.path}")
+        for error in result.errors:
+            print(f"  {error}")
+
+    passed = sum(1 for result in results if result.passed)
+    failed = len(results) - passed
+    print(f"Summary: {passed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+def _expand_paths(paths: Iterable[Path | str]) -> list[Path]:
+    units: list[Path] = []
+    for path_like in paths:
+        path = Path(path_like)
+        if path.is_dir():
+            units.extend(
+                sorted(
+                    candidate
+                    for candidate in path.rglob("*")
+                    if candidate.is_file() and candidate.suffix in {".json", ".toml"}
+                )
+            )
+        else:
+            units.append(path)
+    return units
+
+
+def _check_unit(path: Path) -> ConformanceResult:
+    category = _classify(path)
+    if category == CATEGORY_WORKFLOW:
+        return _check_workflow_contract(path)
+    if category == CATEGORY_MECHANIC:
+        return _check_mechanic(path)
+    if category == CATEGORY_SCHEMA:
+        return _check_schema_definition(path)
+    if category == CATEGORY_ARTIFACT:
+        return _check_artifact_instance(path)
+    return ConformanceResult(path=path, category=CATEGORY_UNKNOWN, passed=False, errors=["unsupported conformance unit"])
+
+
+def _classify(path: Path) -> str:
+    if path.name.endswith(".schema.json"):
+        return CATEGORY_SCHEMA
+    if path.suffix == ".toml" and "workflow-contracts" in path.parts:
+        return CATEGORY_WORKFLOW
+    if path.suffix == ".toml" and "mechanics" in path.parts:
+        return CATEGORY_MECHANIC
+    if path.suffix == ".json" and _artifact_type_for_path(path) is not None:
+        return CATEGORY_ARTIFACT
+    return CATEGORY_UNKNOWN
+
+
+def _check_workflow_contract(path: Path) -> ConformanceResult:
+    try:
+        load_workflow_contract(path, registry=None)
+    except WorkflowContractError as error:
+        return ConformanceResult(path=path, category=CATEGORY_WORKFLOW, passed=False, errors=_exception_errors(error))
+    return ConformanceResult(path=path, category=CATEGORY_WORKFLOW, passed=True, errors=[])
+
+
+def _check_mechanic(path: Path) -> ConformanceResult:
+    try:
+        load_mechanic(path, registry=registry_from_manifest())
+    except MechanicError as error:
+        return ConformanceResult(path=path, category=CATEGORY_MECHANIC, passed=False, errors=_exception_errors(error))
+    return ConformanceResult(path=path, category=CATEGORY_MECHANIC, passed=True, errors=[])
+
+
+def _check_artifact_instance(path: Path) -> ConformanceResult:
+    artifact_type = _artifact_type_for_path(path)
+    if artifact_type is None:
+        return ConformanceResult(
+            path=path,
+            category=CATEGORY_ARTIFACT,
+            passed=False,
+            errors=["artifact type could not be inferred from filename"],
+        )
+
+    try:
+        load_artifact(artifact_type, path, registry=registry_from_manifest())
+    except ArtifactSchemaError as error:
+        return ConformanceResult(path=path, category=CATEGORY_ARTIFACT, passed=False, errors=_exception_errors(error))
+    return ConformanceResult(path=path, category=CATEGORY_ARTIFACT, passed=True, errors=[])
+
+
+def _check_schema_definition(path: Path) -> ConformanceResult:
+    try:
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        Draft202012Validator.check_schema(schema)
+    except json.JSONDecodeError as error:
+        return ConformanceResult(path=path, category=CATEGORY_SCHEMA, passed=False, errors=[f"<json>: {error}"])
+    except SchemaError as error:
+        return ConformanceResult(path=path, category=CATEGORY_SCHEMA, passed=False, errors=[error.message])
+    return ConformanceResult(path=path, category=CATEGORY_SCHEMA, passed=True, errors=[])
+
+
+def _artifact_type_for_path(path: Path) -> str | None:
+    stem = path.name.removesuffix(".json")
+    for prefix in ("valid-", "invalid-"):
+        if stem.startswith(prefix):
+            stem = stem.removeprefix(prefix)
+            break
+
+    artifact_types = sorted(
+        (schema.name.removesuffix(".schema.json") for schema in SCHEMAS.glob("*.schema.json")),
+        key=len,
+        reverse=True,
+    )
+    for artifact_type in artifact_types:
+        if stem == artifact_type or stem.startswith(f"{artifact_type}-"):
+            return artifact_type
+    return None
+
+
+def _exception_errors(error: WorkflowContractError | MechanicError | ArtifactSchemaError) -> list[str]:
+    return [f"{path}: {message}" for path, message in error.errors]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -23,6 +23,8 @@ CATEGORY_ARTIFACT = "C-4 artifact-instance"
 CATEGORY_SCHEMA = "C-4 schema-definition"
 CATEGORY_UNKNOWN = "unknown"
 
+DIRECT_UNIT_DIRECTORY_NAMES = {"workflow-contracts", "mechanics", "schemas"}
+
 
 @dataclass(frozen=True)
 class ConformanceResult:
@@ -77,10 +79,24 @@ def _expand_paths(paths: Iterable[Path | str]) -> list[Path]:
     for path_like in paths:
         path = Path(path_like).resolve()
         if path.is_dir():
-            units.extend(discover_units(path))
+            units.extend(_discover_directory_argument_units(path))
         else:
             units.append(path)
     return units
+
+
+def _discover_directory_argument_units(path: Path) -> list[Path]:
+    if path.name in DIRECT_UNIT_DIRECTORY_NAMES:
+        return _discover_direct_unit_directory(path)
+    if list(path.glob("*.schema.json")):
+        return sorted(path.glob("*.schema.json"))
+    return discover_units(path)
+
+
+def _discover_direct_unit_directory(path: Path) -> list[Path]:
+    if path.name == "schemas":
+        return sorted(path.glob("*.schema.json"))
+    return sorted(path.rglob("*.toml"))
 
 
 def _check_unit(path: Path) -> ConformanceResult:

--- a/tooling/workflow_contracts.py
+++ b/tooling/workflow_contracts.py
@@ -94,7 +94,7 @@ def _mechanic_names_from_directory(directory: Path) -> set[str]:
         return set()
 
     names: set[str] = set()
-    for path in directory.glob("*.toml"):
+    for path in directory.rglob("*.toml"):
         try:
             mechanic = tomllib.loads(path.read_text(encoding="utf-8"))
         except (OSError, tomllib.TOMLDecodeError):

--- a/tooling/workflow_contracts.py
+++ b/tooling/workflow_contracts.py
@@ -10,6 +10,7 @@ from jsonschema import Draft202012Validator
 
 
 ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "manifest.toml"
 WORKFLOW_CONTRACT_SCHEMA = ROOT / "schemas" / "workflow-contract.schema.json"
 
 
@@ -28,6 +29,33 @@ class WorkflowRegistry:
     disciplines: set[str] = field(default_factory=set)
     mechanics: set[str] = field(default_factory=set)
     artifact_schemas: set[str] = field(default_factory=set)
+
+
+def workflow_registry_from_manifest(
+    path: Path | str = MANIFEST,
+    root: Path | str | None = None,
+) -> WorkflowRegistry:
+    manifest_path = Path(path)
+    root_path = Path(root) if root is not None else manifest_path.parent
+    manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+
+    artifact_types = {
+        entry["name"]
+        for entry in manifest.get("artifact_types", [])
+        if isinstance(entry, dict) and isinstance(entry.get("name"), str)
+    }
+    mechanic_names = {
+        entry["name"]
+        for entry in manifest.get("mechanics", [])
+        if isinstance(entry, dict) and isinstance(entry.get("name"), str)
+    }
+    mechanic_names.update(_mechanic_names_from_directory(root_path / "mechanics"))
+
+    return WorkflowRegistry(
+        disciplines=_directory_names(root_path / "skills") | _directory_names(root_path / "protocols"),
+        mechanics=mechanic_names,
+        artifact_schemas=artifact_types,
+    )
 
 
 def load_workflow_contract(path: Path | str, registry: WorkflowRegistry | None = None) -> dict[str, Any]:
@@ -53,6 +81,28 @@ def validate_workflow_contract(contract: dict[str, Any], registry: WorkflowRegis
 
     if errors:
         raise WorkflowContractError(errors)
+
+
+def _directory_names(directory: Path) -> set[str]:
+    if not directory.exists():
+        return set()
+    return {entry.name for entry in directory.iterdir() if entry.is_dir()}
+
+
+def _mechanic_names_from_directory(directory: Path) -> set[str]:
+    if not directory.exists():
+        return set()
+
+    names: set[str] = set()
+    for path in directory.glob("*.toml"):
+        try:
+            mechanic = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+        name = mechanic.get("name")
+        if isinstance(name, str):
+            names.add(name)
+    return names
 
 
 def _schema_errors(contract: dict[str, Any]) -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary

- Adds `python -m tooling.conformance` for narrowed Step 1 C-2/C-3/C-4 conformance checks.
- Adapts existing exception-raising validators into aggregate pass/fail results with non-zero exit on failure.
- Documents default source-tree discovery and records the user-visible runner in the changelog.

## Changes

- Adds `tooling.conformance` with source discovery, explicit path expansion, category classification, validator adapters, and CLI reporting.
- Adds conformance tests for valid dispatch, invalid aggregation, schema-definition failures, default discovery, CLI exit codes, and the #317 future C-2 contract handoff.
- Updates README usage guidance and the Unreleased changelog.

## GitHub Issue(s)

Closes #297

## Test plan

- `python -m unittest tests.test_conformance tests.test_workflow_contracts tests.test_mechanics tests.test_artifact_schemas`
- `python -m tooling.conformance`
- `python -m tooling.conformance tests/fixtures/workflow-contracts/valid-*.toml tests/fixtures/mechanics/valid-*.toml tests/fixtures/artifacts/valid-*.json`
