### PR TITLE
feat(architecture): exercise C-2 contract format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Narrowed Step 1 conformance runner for C-2 workflow contracts, C-3
   mechanics, C-4 artifact instances, and JSON Schema definitions, with
   aggregate pass/fail reporting and non-zero exit on failure (closes #297).
+- Source C-2 workflow contract exercise for the forge-neutral `verify`
+  protocol, including default conformance coverage and a Step 1 R1 note
+  recording that the format held for `verify`'s shape without schema/parser
+  revision (closes #317).
 
 ### Fixed
 

--- a/docs/architecture/step-1-r1-c2-contract-exercise.md
+++ b/docs/architecture/step-1-r1-c2-contract-exercise.md
@@ -1,0 +1,29 @@
+# Step 1 R1 C-2 Contract Exercise
+
+## Audience and Purpose
+
+This note is for agents and contributors preparing Step 2 of ADR-0002's
+methodology-sovereignty rollout. It records what the first source C-2 workflow
+contract exercise proved, and what it did not prove.
+
+## Result
+
+Issue #317 exercised the C-2 workflow-contract format on the forge-neutral
+`verify` protocol. The authored `workflow-contracts/verify.toml` contract held
+as-authored against the current C-2 schema, parser graph checks, and manifest
+registry resolution. No schema or parser revision was needed for this shape.
+
+The exercise covered a three-node workflow with `always` edges, one
+single-field `case` plus `default` branch, and two reachable terminals that
+produce the same `completion-evidence` artifact.
+
+## Remaining R1 Limits
+
+This is narrow evidence, not broad validation of every C-2 capability. The
+forge-touching arc still needs to exercise larger case sets, multi-field
+decision pressure, loops with exits, and registry failures in production
+authoring conditions.
+
+Step 2 can proceed against the current C-2 format with that limitation named:
+the format held for `verify`'s shape, while the arc remains the broader
+format-fidelity test.

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -5,8 +5,10 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from tooling.conformance import discover_units, main, run_conformance
+from tooling.workflow_contracts import WorkflowRegistry
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -202,6 +204,31 @@ class ConformanceTests(unittest.TestCase):
         self.assertEqual(1, len(results))
         self.assertEqual("C-2 workflow-contract", results[0].category)
         self.assertTrue(results[0].passed)
+
+    def test_source_verify_workflow_contract_is_discovered_and_registry_validated(self) -> None:
+        contract = ROOT / "workflow-contracts" / "verify.toml"
+
+        discovered = discover_units(ROOT)
+        self.assertIn(contract, discovered)
+
+        results = run_conformance([contract])
+        self.assertEqual(1, len(results))
+        self.assertEqual("C-2 workflow-contract", results[0].category)
+        self.assertTrue(results[0].passed)
+        self.assertEqual([], results[0].errors)
+
+        with mock.patch(
+            "tooling.conformance.workflow_registry_from_manifest",
+            return_value=WorkflowRegistry(),
+        ):
+            registry_results = run_conformance([contract])
+
+        self.assertEqual(1, len(registry_results))
+        self.assertFalse(registry_results[0].passed)
+        self.assertIn(
+            "discipline `orient` does not resolve in registry",
+            " ".join(registry_results[0].errors),
+        )
 
     def test_bare_relative_workflow_contract_validates_from_contract_directory(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/workflow-contracts/verify.toml
+++ b/workflow-contracts/verify.toml
@@ -1,0 +1,64 @@
+name = "verify"
+purpose = "Gate completion claims by comparing fresh verification evidence against the behavior contract."
+session_role = "verification gate"
+preconditions = ["behavior-contract, test-evidence, and work-unit artifacts exist"]
+start_node = "identify-verification"
+failure_modes = [
+  "verification command is stale or partial",
+  "test evidence does not cover claimed behavior",
+]
+corruption_modes = [
+  "evidence-before-assertion loss",
+  "partial verification treated as completion",
+]
+
+[[nodes]]
+name = "identify-verification"
+intent = "Identify the command and artifacts required to prove the requested completion claim."
+disciplines = ["orient", "contract"]
+mechanics = ["read-artifact"]
+outcomes = ["verification command and required behavior coverage are known"]
+
+[[nodes]]
+name = "run-verification"
+intent = "Run the full verification command freshly and capture its output."
+disciplines = ["contract"]
+mechanics = ["run-test"]
+outcomes = ["fresh command output and exit status are available"]
+
+[[nodes]]
+name = "assess-completion"
+intent = "Compare fresh output and test evidence against the behavior contract and work-unit criteria."
+disciplines = ["contract"]
+mechanics = ["read-artifact"]
+outcomes = ["criterion coverage status is determined"]
+
+[[edges]]
+from = "identify-verification"
+to = "run-verification"
+condition = { type = "always" }
+
+[[edges]]
+from = "run-verification"
+to = "assess-completion"
+condition = { type = "always" }
+
+[[edges]]
+from = "assess-completion"
+to = "completion-covered"
+condition = { type = "case", field = "coverage_status", equals = "covered" }
+
+[[edges]]
+from = "assess-completion"
+to = "completion-incomplete"
+condition = { type = "default", field = "coverage_status" }
+
+[[terminals]]
+name = "completion-covered"
+outcome = "Completion evidence records all criteria covered."
+artifact_produced = "completion-evidence"
+
+[[terminals]]
+name = "completion-incomplete"
+outcome = "Completion evidence records partial or uncovered criteria and blocks unsupported completion claims."
+artifact_produced = "completion-evidence"


### PR DESCRIPTION
## Summary

- Adds the first source C-2 workflow contract exercise, targeting the forge-neutral `verify` protocol.
- Records the R1 result narrowly: the format held for `verify`'s shape without C-2 schema/parser changes, while broader graph capabilities remain for the forge-touching arc.
- Extends conformance coverage so default discovery and registry validation both exercise the source `verify.toml` contract.

## Changes

- Add `workflow-contracts/verify.toml` with a three-node `verify` graph, `always` edges, a `case` plus `default` branch, and two `completion-evidence` terminals.
- Add `docs/architecture/step-1-r1-c2-contract-exercise.md` documenting what R1 proved and what remains unexercised.
- Add a conformance test for source contract discovery plus manifest registry validation.
- Update the Unreleased changelog.

## GitHub Issue(s)

Closes #317

## Test plan

- `python -m unittest tests.test_workflow_contracts tests.test_conformance`
- `python -m tooling.conformance`
- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests`
