### PR TITLE
fix(release): tolerate workflow bytecode cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Release-cut now ignores its own generated `release_lib` bytecode cache during
+  the clean-tree pre-check, so the documented release ceremony works from a
+  fresh checkout after prior `release-check` invocations (closes #311, #315).
 - Step 1 conformance now validates C-2 workflow registry references and reports
   explicit path read failures as aggregate failures instead of aborting.
 - Step 1 conformance now classifies explicit relative TOML paths from inside

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -295,10 +295,24 @@ def git(root: Path, *args: str, check: bool = True) -> CommandResult:
     return CommandResult(result.stdout, result.stderr)
 
 
+def remove_release_lib_bytecode_cache(root: Path) -> None:
+    cache = root / "scripts" / "__pycache__"
+    if not cache.is_dir():
+        return
+    for path in cache.glob("release_lib.*.pyc"):
+        if path.is_file() and not path.is_symlink():
+            path.unlink()
+    try:
+        cache.rmdir()
+    except OSError:
+        pass
+
+
 def require_clean_main(root: Path) -> None:
     branch = git(root, "branch", "--show-current").stdout.strip()
     if branch != "main":
         die(f"release-cut must run on main, not {branch or 'detached HEAD'}")
+    remove_release_lib_bytecode_cache(root)
     status = git(root, "status", "--short").stdout.strip()
     if status:
         die("release-cut requires a clean working tree")

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -4,6 +4,7 @@ import argparse
 import datetime as _dt
 import json
 import re
+import stat as _stat
 import subprocess
 import sys
 import tomllib
@@ -297,10 +298,23 @@ def git(root: Path, *args: str, check: bool = True) -> CommandResult:
 
 def remove_release_lib_bytecode_cache(root: Path) -> None:
     cache = root / "scripts" / "__pycache__"
-    if not cache.is_dir():
+    try:
+        cache_mode = cache.stat(follow_symlinks=False).st_mode
+    except FileNotFoundError:
         return
+    if not _stat.S_ISDIR(cache_mode):
+        return
+    current = root
+    for part in cache.relative_to(root).parts:
+        current = current / part
+        if current.is_symlink():
+            return
     for path in cache.glob("release_lib.*.pyc"):
-        if path.is_file() and not path.is_symlink():
+        try:
+            path_mode = path.stat(follow_symlinks=False).st_mode
+        except FileNotFoundError:
+            continue
+        if _stat.S_ISREG(path_mode):
             path.unlink()
     try:
         cache.rmdir()

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -362,6 +362,22 @@ class ReleaseCeremonyTests(unittest.TestCase):
 
         assert_failure_contains(self, result, "release-cut requires a clean working tree")
 
+    def test_release_cut_rejects_symlinked_bytecode_cache_without_deleting_target_files(self) -> None:
+        fixture = self.add_fixture("release-cut-symlinked-bytecode-cache", "1.2.2")
+        fixture.init_git_with_remote()
+        target = Path(tempfile.mkdtemp(prefix=f"{fixture.root.name}-cache-target-"))
+        self.addCleanup(lambda: shutil.rmtree(target, ignore_errors=True))
+        target_file = target / "release_lib.cpython-312.pyc"
+        target_file.write_bytes(b"outside repo bytecode")
+        cache = fixture.root / "scripts" / "__pycache__"
+        cache.symlink_to(target, target_is_directory=True)
+
+        result = fixture.run_release_cut("v1.2.3")
+
+        assert_failure_contains(self, result, "release-cut requires a clean working tree")
+        self.assertTrue(cache.is_symlink())
+        self.assertTrue(target_file.exists())
+
     def test_release_cut_creates_release_candidate_release_commit_and_tag(self) -> None:
         fixture = self.add_fixture("release-cut-rc", "1.2.3")
         fixture.init_git_with_remote()

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -340,6 +340,28 @@ class ReleaseCeremonyTests(unittest.TestCase):
         )
         assert_success(self, fixture.run_release_check("release", "v1.2.3"))
 
+    def test_release_cut_accepts_bytecode_cache_from_prior_release_check(self) -> None:
+        fixture = self.add_fixture("release-cut-prior-release-check-cache", "1.2.2")
+        fixture.init_git_with_remote()
+
+        assert_success(self, fixture.run_release_check("metadata"))
+        assert_success(self, fixture.run_release_check("release", "v1.2.2"))
+        self.assertTrue((fixture.root / "scripts" / "__pycache__").is_dir())
+
+        result = fixture.run_release_cut("v1.2.3")
+
+        assert_success(self, result)
+        assert_success(self, fixture.run_release_check("release", "v1.2.3"))
+
+    def test_release_cut_rejects_genuine_untracked_artifacts(self) -> None:
+        fixture = self.add_fixture("release-cut-untracked-artifact", "1.2.2")
+        fixture.init_git_with_remote()
+        fixture.write("operator-notes.txt", "not part of the release\n")
+
+        result = fixture.run_release_cut("v1.2.3")
+
+        assert_failure_contains(self, result, "release-cut requires a clean working tree")
+
     def test_release_cut_creates_release_candidate_release_commit_and_tag(self) -> None:
         fixture = self.add_fixture("release-cut-rc", "1.2.3")
         fixture.init_git_with_remote()


### PR DESCRIPTION
## Summary

- Fixes `release-cut` so the documented release ceremony can run after prior `release-check` invocations have imported `release_lib`.
- Keeps the clean-tree guard strict for genuine untracked artifacts.
- Records that #315 is satisfied by the current manifest-version contract once the full suite is green.

## Changes

- Remove generated `scripts/__pycache__/release_lib.*.pyc` files immediately before `release-cut` checks `git status --short`.
- Add regression coverage for the documented `release-check metadata` + `release-check release` + `release-cut` path.
- Add guard coverage proving an unrelated untracked file still fails the clean-tree pre-check.

## GitHub Issue(s)

Closes #311
Closes #315

## Test plan

- `python -m unittest tests.test_release_ceremony.ReleaseRepositoryContractTests.test_manifest_declares_current_methodology_version`
- `python -m unittest tests.test_release_ceremony.ReleaseCeremonyTests`
- `python -m unittest discover -s tests`
