### PR TITLE
feat(contracts): submit C-2 workflow contract (forge-invariant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `code-review` skill, manifest-registered required-choice outcome group, and
   typed review disposition routing through `change-approved` /
   `change-needs-revision` (closes #331).
+- Submit C-2 workflow contract authoring surface: source `submit` contract,
+  manifest wiring from `patch` to `change-proposal`, revision-path operation
+  registration, and WHAT-layer submit protocol prose that preserves the
+  release metadata invariant while moving forge-specific delivery to C-3
+  mechanics (closes #330).
 
 ### Fixed
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -88,6 +88,9 @@ name = "inspect-change-proposals"
 name = "deliver-change-proposal"
 
 [[mechanics]]
+name = "revise"
+
+[[mechanics]]
 name = "review"
 
 [[mechanics]]
@@ -176,8 +179,8 @@ trigger = { type = "on_artifact", name = "completion-evidence" }
 name = "submit"
 scoped = true
 requires = ["completion-evidence", "documentation-record"]
-accepts = []
-produces = ["patch"]
+accepts = ["change-proposal", "change-needs-revision"]
+produces = ["change-proposal"]
 may_produce = []
 trigger = { type = "on_artifact", name = "documentation-record" }
 

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -1,409 +1,91 @@
 ---
 name: submit
 description: >-
-  Package working changes into a PR: ensure feature branch, analyze and commit
-  changes, push, then create or update a PR linked to GitHub issue(s).
-  The middle phase of the session lifecycle between take and land.
-  Trigger on: 'submit', 'submit pr', 'create pr', 'open pr',
-  'send for review', 'package this up'.
+  Package verified, documented work as a forge-neutral change-proposal
+  artifact. The C-2 contract names invariant delivery operations while C-3
+  mechanics own forge-specific execution.
+metadata:
+  version: "2.0.0"
+  updated: "2026-05-31"
 ---
 
-# Submit — Commit, Push, PR
+# Submit
 
-## Overview
+Submit is the gate between verified implementation work and review. It records
+the current deliverable as a `change-proposal` so reviewers can inspect a
+specific proposal version through a forge-tagged handle.
 
-Protocol for packaging verified, documented changes into a PR and delivering
-the `patch` artifact. Fires when implementation is complete and reviewed
-changes need to cross into the review stage.
+The protocol is not a forge operation. It names the methodology obligation:
+confirm the work has completion evidence and documentation review, choose
+whether the proposal is an initial submission or a revision, invoke the
+forge-invariant delivery operation, and emit the artifact that review consumes.
 
-`submit` means:
-1. Resolve the working context (branch, changes, linked issues)
-2. Ensure a feature branch exists (guard rail if on `main`)
-3. Analyze changes and produce well-formed commits
-4. Resolve whether delivery updates an existing PR or opens a new PR
-5. Push to remote
-6. Create a PR when needed
-7. Deliver the `patch` artifact via the MCP tool
-8. Report the result and suggest next steps
+## Purpose
 
-The session lifecycle is: `take` (initiate session) → implement → `submit`
-(package for review) → review → `land` (merge and close). `submit` is the
-transition from execution to review.
+Submit preserves the boundary between WHAT and HOW. The workflow contract says a
+change proposal must exist for review; it does not prescribe transport,
+review-surface creation, carrier generation, or any other forge-specific
+mechanism. Those details belong to C-3 mechanics selected by forge
+configuration.
 
-Do not stop after creating or updating the PR — the delivery and report steps
-(7 and 8) are part of the protocol. Invoking `submit` IS the operator's
-approval to execute the full sequence.
+The produced proposal carries the common review envelope: work unit, branch,
+commit, base, summary, immutable version, and a forge-tagged handle. Version 1
+represents the initial proposal. Later versions represent revision rounds for
+the same work unit after review asks for changes.
 
----
+## Proposal Paths
 
-## Preconditions
+Submit has two delivery paths:
 
-- Deliverable local work means uncommitted changes OR committed work identified
-  from the branch's tracking and PR state. If the working tree is clean and no
-  deliverable commits exist, there is nothing new to submit. When an open PR
-  exists, report its current state and recommend `land` if appropriate; when no
-  open PR exists, report and stop.
-- Producing the `patch` capstone requires a real PR reference, which in turn
-  requires forge tooling (`gh` authenticated against the remote). Where forge
-  tooling is absent, the protocol can commit and push locally but cannot
-  deliver the `patch` artifact — see step 6 for the failure path.
+- `deliver-change-proposal` creates the first proposal version for a verified,
+  documented change.
+- `revise` creates the next proposal version after a needs-revision outcome.
 
----
+Both paths terminate in the same `change-proposal` artifact type. Proposals are
+not disposition outcomes; review decides disposition later by producing either
+`change-approved` or `change-needs-revision`.
 
-## Procedure
+## Artifact Delivery
 
-### 1. Resolve context
-
-Determine:
-- Current branch name.
-- Whether on `main` or a feature branch.
-- Whether uncommitted changes exist (`git status`).
-- Whether an open PR exists for the current branch (`gh pr list --head <branch>
-  --state open --json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner`)
-  when `gh` is available. PR discovery handles result counts explicitly:
-  0 results means no open PR; 1 result means that PR is the working PR; 2+
-  results means disambiguate by head repository before recording any working
-  PR. To disambiguate multiple results, filter candidates by PR head repository
-  against local remotes using shared GitHub remote matching and each remote's
-  effective push URL. If exactly one PR survives, use it as the working PR. If
-  zero or 2+ candidates survive, stop with Ambiguous PR discovery before fetch,
-  ancestry classification, push, or patch delivery.
-- For the working PR, run `gh repo view --json nameWithOwner,url` in the same
-  repository context as the PR listing, and record that value as the PR base
-  repository identity. For the working PR, record the PR URL as the downstream
-  PR reference, the PR number, the PR head SHA (`headRefOid`) for ancestry
-  classification, the PR head branch (`headRefName`), the PR head repository
-  (`<headRepositoryOwner.login>/<headRepository.name>`) for existing PR push
-  delivery, and the PR base repository for PR-head fetch. Resolve a local remote
-  matching the PR base repository, using that remote's fetch URL, and fetch the
-  PR head into the local object database before post-commit deliverability
-  classification:
-  `git fetch <base-repo-remote> pull/<number>/head`. This is the GitHub PR
-  refspec paired with `gh` discovery. Existing-PR delivery is a single
-  GitHub-shaped commitment across `gh` discovery, the `pull/<number>/head`
-  refspec, and shared GitHub remote matching; adapting the protocol to another
-  forge requires changing all three together. After fetching, verify that
-  `headRefOid` resolves as a commit before any operation consumes it.
-- Shared GitHub remote matching uses one normalization rule for every consumer:
-  accept SSH and HTTPS GitHub URLs, strip `.git`, compare the lowercase
-  `<owner>/<repo>`, and treat non-GitHub URL forms as non-matches. Fetch
-  resolution inspects `git remote get-url <remote>` against the PR base
-  repository; push resolution and PR discovery disambiguation inspect
-  `git remote get-url --push <remote>` against the PR head repository.
-- GitHub issue number(s), resolved in priority order:
-  1. Explicit operator-provided GitHub issue number(s).
-  2. Branch name pattern: `issue-<N>/<slug>` (single) or
-     `issues-<N>-<M>-.../<slug>` (multi).
-  3. None — proceed without GitHub issue linkage.
-
-If GitHub issue number(s) are available and `gh` is installed, fetch issue
-title(s) and body(ies) via `gh issue view` for use in steps 3 and 6.
-
-### 2. Ensure feature branch
-
-If already on a feature branch: record the branch name and continue.
-
-If on `main` (or detached HEAD):
-1. Derive a branch name:
-   - If GitHub issue number(s) known: `issue-<N>/<slug>` (single) or
-     `issues-<N>-<M>/<slug>` (multi), where slug is the GitHub issue title —
-     lowercase, hyphenated, truncated to 40 chars.
-   - If no linked GitHub issue: `feat/<slug>`, `fix/<slug>`, or `chore/<slug>` based on
-     change classification, where slug summarizes the changes.
-2. Create and switch to the branch: `git checkout -b <branch>`.
-
-### 3. Analyze changes and commit
-
-This step is the protocol's core analytical value: understanding changes
-well enough to produce meaningful commit structure, not just staging
-everything at once.
-
-This shared step applies before either PR delivery path. The same commit
-analysis discipline applies whether the deliverable is a new PR or an existing
-PR update.
-
-If the working tree has no uncommitted changes, skip to step 4; committed-work
-deliverability is classified there against the final submission `HEAD`.
-
-**3a. Understand intent.** Examine all uncommitted modifications
-(`git diff`, `git diff --staged`). If GitHub issue context is available,
-cross-reference changes against acceptance criteria.
-
-**3b. Identify logical groups.** Find related changes that belong in the same
-atomic commit. Apply the Complete Feature Rule: implementation, documentation,
-and tests for one feature belong in one commit — never split docs from the code
-they document.
-
-**3c. Plan commits.** Design atomic commits, each serving a single purpose.
-Use conventional commit format: `type(scope): description` where type is
-`feat`, `fix`, `refactor`, `docs`, `test`, or `chore`. If GitHub issue number(s) are
-known, reference them in the commit body (not the title): `Refs #N`. Commit
-messages explain **why**, not just what.
-
-**3d. Execute commits.** Stage and commit each logical group using
-`git add <paths>`. When a single file contains changes for different commits,
-stage it with the dominant change set and note the grouping compromise in the
-commit message — intra-file splitting (`git add -p`) requires interactive input
-and may not be available in agent environments. Verify each commit leaves the
-working tree in a valid state.
-
-If analysis produces no clear grouping (one tangled change), fall back to a
-single commit with a comprehensive message. A single honest commit is better
-than artificial splitting.
-
-### 4. Resolve PR delivery path
-
-After commit analysis has completed, classify current `HEAD` and select exactly
-one delivery path. This classification is post-commit: if step 3 created a
-commit from uncommitted changes, that new commit is part of the `HEAD` being
-classified. Step 4 consumes PR discovery substrate captured in step 1, then
-reads branch substrate that may have changed during step 2 or step 3 from the
-classification-time branch state. Run `git rev-parse HEAD` to capture the
-post-commit `HEAD`. When no open PR exists, determine whether upstream tracking
-exists by running
-`git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` at this point.
-A failing upstream lookup means no upstream exists.
-
-- **Open PR exists:** regardless of whether the branch has upstream tracking,
-  classify current `HEAD` by ancestry. To classify local `HEAD`, run
-  `git rev-parse HEAD` after commit analysis and compare it against the PR head
-  SHA (`headRefOid`) using `git merge-base --is-ancestor` in both directions.
-  The upstream tracking ref plays no role in deliverability when a PR exists;
-  the fetched PR head is the ground truth.
-  - If `HEAD` and `headRefOid` are the same SHA, no committed local work is
-    deliverable and the existing PR state should be reported.
-  - If `HEAD` is an ancestor of `headRefOid`, the local checkout is behind the
-    PR. No committed local work is deliverable; report the existing PR state
-    and stop.
-  - If `headRefOid` is an ancestor of `HEAD`, open PR exists and deliverable
-    local work exists: local commits are deliverable through the existing PR
-    update path, so push to the existing PR branch. This is the normal
-    review-fix path after a PR already exists.
-  - If neither commit is an ancestor of the other, the local branch and PR head
-    have diverged. Report the divergence and stop; do not force-push or rebase
-    automatically.
-- **No open PR and upstream exists:** run `git log main..HEAD` to verify that
-  local commits exist ahead of the base branch. If no commits exist, no
-  committed local work is deliverable; report `clean-branch-no-changes` and
-  stop. If commits exist, the branch is deliverable by opening a new PR. Then
-  inspect commits ahead of the branch's remote tracking ref
-  (`git log @{upstream}..HEAD`). Upstream-ahead commits decide whether a push is
-  needed, not whether PR creation is allowed. If upstream-ahead commits exist,
-  deliver through the new PR path after pushing the branch. If no
-  upstream-ahead commits exist, the already-pushed branch still needs a PR;
-  deliver through the new PR path without pushing again.
-- **No open PR and no upstream:** run `git log main..HEAD` to verify that local
-  commits exist ahead of the base branch. If commits exist, local commits on the
-  feature branch are deliverable under first-push semantics by opening a new PR
-  after pushing the branch. If no commits exist, no committed local work is
-  deliverable; report `clean-branch-no-changes` and stop.
-
-### 5. Push
-
-Use the delivery path from step 4:
-
-- **Existing PR update path:** resolve a local remote whose effective push URL
-  points at the PR head repository recorded in step 1, using shared GitHub
-  remote matching. For each remote, inspect `git remote get-url --push <remote>`.
-  Push the submitted commits to the PR head branch:
-  `git push <head-repo-remote> HEAD:<headRefName>`.
-  Do not push the local branch name to `origin` and assume that it updates the
-  open PR. This push is the delivery action; after it succeeds, report this path
-  as `pushed to existing PR`.
-- **New PR path:** push the feature branch to origin when the delivery
-  classification requires a push. If no upstream is set, run
-  `git push -u origin <branch>`; if upstream exists, run `git push` when
-  upstream-ahead commits exist. If no upstream-ahead commits exist for an
-  upstream-backed branch, open the new PR without a push.
-
-### 6. Create or identify PR
-
-The `patch` capstone requires a real PR reference. Where `gh` is available
-and authenticated against the remote:
-- Existing PR update path: reuse the open PR reference found in step 1.
-- New PR path: create the PR via `gh pr create`.
-
-Where forge tooling is absent, the protocol cannot complete — report what was
-committed and pushed locally, note that no `patch` artifact was delivered, and
-stop. Do not synthesize a PR reference.
-
-**Title** (under 70 chars):
-- Single GitHub issue: use the issue title, condensed if needed. Prefix with
-  conventional commit type if not already present.
-- Multi-GitHub-issue: synthesize a title capturing the combined scope.
-- No linked GitHub issue: derive from commit message(s).
-
-**Body:**
+The capstone is delivery of the `change-proposal` artifact via the
+`change-proposal` MCP tool. The object below is MCP tool input, not artifact
+body. `instance_id` is a tool parameter that names the artifact instance; it is
+extracted before validating artifact content, becomes the workspace filename,
+and must not appear in the artifact body. Runa injects `work_unit` from session
+context; the agent does not supply `work_unit`. Do not write the workspace JSON
+file directly:
 
 ```
-## Summary
-
-[1-3 bullet points: what this PR does and why]
-
-## Changes
-
-[Grouped description derived from commit messages]
-
-## GitHub Issue(s)
-
-Closes #N
-[or "Refs #N" for partial progress]
-
-## Test plan
-
-[How to verify — derived from acceptance criteria if available]
-```
-
-**Shell-safe transport (required):**
-- Build multiline Markdown body content in a file and pass it with
-  `--body-file <path>`.
-- Acceptable file creation patterns:
-  - direct write to a temporary file
-  - single-quoted heredoc redirected to a file (no interpolation)
-- Never pass multiline Markdown bodies inline with double quotes (for example:
-  ``gh pr create --body "...\`cmd\`..."``) because shells can evaluate
-  backticks as command substitution.
-
-Safe examples:
-
-```bash
-# Create
-cat > /tmp/pr-body.md <<'EOF'
-## Summary
-- ...
-EOF
-gh pr create --title "fix(propose): shell-safe PR body handling" --body-file /tmp/pr-body.md
-
-# Edit
-cat > /tmp/pr-body.md <<'EOF'
-## Summary
-- updated after review
-EOF
-gh pr edit <pr-number-or-url> --body-file /tmp/pr-body.md
-```
-
-**Flags:**
-- Do NOT use `--draft` by default. The operator invoked `submit` because the
-  work is ready for review. If the operator explicitly says "draft" or "submit
-  as draft," use `--draft`.
-
-### 7. Deliver `patch`
-
-The capstone is delivery of the `patch` artifact via the `patch` MCP tool.
-`patch` is the complete latest PR state snapshot after submission, with the
-same shape for both a newly opened PR and an updated existing PR. The object
-below is MCP tool input, not artifact body. `instance_id` is a tool parameter
-that names the artifact instance; it is extracted before validating artifact
-content, becomes the workspace filename, and must not appear in the artifact
-body. Runa injects `work_unit` from session context; the agent does not supply
-`work_unit`. Do not write the workspace JSON file directly:
-
-```
-patch({
+change-proposal({
   instance_id: "<slug>",
-  pr_reference: "<PR URL from step 6>",
   branch: "<feature branch name>",
-  commit: "<head commit SHA at submission>"
+  commit: "<head commit or stable revision identifier>",
+  base: "<target base branch or revision>",
+  summary: "<human-readable proposal summary>",
+  version: <review-round version>,
+  handle: { ... forge-tagged handle ... }
 })
 ```
 
-Runa validates the remaining artifact body fields against the patch schema,
-persists the artifact, and records it in the artifact store. Do not emit a
-partial update artifact that assumes the operator already knows the surrounding
-PR context.
-
-### 8. Report
-
-Output:
-- PR URL.
-- Branch name.
-- Commit summary (count and brief subjects).
-- GitHub issue linkage (which GitHub issues are referenced, close vs. ref).
-- `patch` artifact instance_id.
-- Delivery action: "opened new PR" or "pushed to existing PR."
-- Next step: "Get review, then `land` when approved."
-
----
-
-## Failure Policy
-
-- **Forge tooling (`gh`) unavailable or unauthenticated:** The protocol can
-  still commit and push (steps 1–5) but cannot create or identify a PR and
-  therefore cannot deliver the `patch` capstone. Report what was committed and
-  pushed, note the missing forge action, and stop. Do not synthesize a `patch`
-  artifact without a real `pr_reference`. Remote-side failures are covered by
-  the push bullets below.
-- **Branch creation fails** (name collision, unresolvable dirty state): Stop
-  and report. Do not force-create or silently choose an alternate name.
-- **Push rejected** (remote diverged): Stop and report. Do not force-push. Do
-  not rebase automatically. Commits are safely local; the operator decides how
-  to reconcile.
-- **Push network error:** Retry once. If still failing, report.
-- **Ambiguous PR discovery:** Stop before PR head fetch, ancestry
-  classification, push, or patch delivery. Report the candidate PR URLs, the
-  candidate head repositories, the operator's local remotes with their
-  normalized GitHub repository or sanitized non-match status, and that
-  disambiguation requires exactly one local remote pointing at exactly one
-  candidate PR head repository.
-- **No local remote matches the PR base repository:** Stop before PR head fetch
-  and ancestry classification. Report the PR URL, PR base repository, and that
-  no matching local remote was found. Do not run `git merge-base` against an
-  unfetched or unresolvable `headRefOid`.
-- **No local remote matches the PR head repository:** Stop before push. Report
-  the PR URL, PR head repository, and `headRefName`. Do not deliver a `patch`
-  artifact because the PR was not updated.
-- **PR head fetch or resolvability check fails:** Report the recorded PR URL and
-  stop before ancestry classification. Do not run `git merge-base` against an
-  unresolvable `headRefOid`.
-- **`gh pr create` fails:**
-  - Branch already has an open PR: treat as the existing PR update path if
-    deliverable local work was pushed; otherwise report the existing PR URL and
-    stop.
-  - Permissions error: stop and report.
-  - Other: report and stop. The branch is pushed; the operator resolves
-    the cause and directs runa to re-activate `submit`. Manual forge
-    intervention is outside the protocol surface.
-- **PR body corruption from shell interpolation:** If generated content appears
-  corrupted or command output is injected, rebuild the body in a file and
-  repair using `gh pr edit --body-file <path>`. Do not retry with inline
-  double-quoted multiline `--body`.
-- **GitHub issue fetch fails:** Continue without GitHub issue context. Derive PR title/body
-  from commits alone. Warn that GitHub issue linkage is manual.
-
----
+Runa validates the remaining artifact body fields against the change-proposal
+schema, persists the artifact, and records it in the artifact store.
 
 ## Corruption Modes
 
-- `premature-submit`: invoking before verification. Recognition: tests not
-  run, WIP markers in code (TODO, FIXME, incomplete stubs). `submit` is not a
-  verification gate, but it should warn on obvious signs of incomplete work.
-- `empty-submit`: nothing to submit. Recognition: clean tree, no unpushed
-  commits. Report and stop.
-- `split-avoidance`: dumping all changes into one commit to skip analysis.
-  Recognition: single commit touching many unrelated files with a vague
-  message. The analysis phase exists to prevent this.
-- `orphan-pr`: no GitHub issue linkage when GitHub issues are clearly relevant. Recognition:
-  branch name contains a GitHub issue number but the PR body omits it. Detect GitHub issue
-  numbers from branch names automatically.
-- `title-shrug`: uninformative PR title ("Update files", "Changes"). The title
-  is the first thing reviewers see — it must communicate the change's purpose.
-- `submit-as-land`: treating the PR as the end of the workflow. `submit` is
-  the middle of the lifecycle. The report step suggests next actions explicitly.
-- `shell-interpolation-corruption`: passing Markdown via inline double-quoted
-  `--body` causes backtick command substitution or other shell interpolation.
-  Recognition: unexpected command output in PR text, shell errors from tokens in
-  the body, or missing literal Markdown. Remediation: regenerate body via file
-  and use `--body-file`; repair with `gh pr edit --body-file`.
-
----
+- `forge-mechanic-leakage`: embedding forge-specific commands or review-surface
+  vocabulary in the protocol instead of leaving mechanics to the C-3 layer.
+- `unversioned-revision`: replacing the current proposal without advancing the
+  immutable review-round version.
+- `premature-submit`: emitting a proposal without completion evidence and
+  documentation review.
+- `submit-as-review`: treating proposal delivery as approval. Submit only makes
+  the proposal available for review.
 
 ## Cross-References
 
-- `take`: the opening bookend of the session lifecycle — consumes the
-  selected work-unit, prepares the workspace, and produces the `claim`.
-- `land`: the closing bookend — closing ceremony, merge, and work-unit
-  closure after review.
-- `verify`: runs before `submit`; its `completion-evidence` output is
-  a required input (per `manifest.toml`).
-- `document`: runs between `verify` and `submit`; its
-  `documentation-record` output is a required input.
+- `workflow-contracts/submit.toml` defines the C-2 submit flow and its
+  change-proposal terminal.
+- `schemas/change-proposal.schema.json` defines the forge-neutral proposal
+  envelope and forge-tagged handle variants.
+- `docs/architecture/step-2-reference-arc-design.md` explains the
+  artifact-versioned review cycle and the invariant operations used by submit.

--- a/tests/test_submit_protocol.py
+++ b/tests/test_submit_protocol.py
@@ -1,288 +1,79 @@
 from pathlib import Path
 import re
+import tomllib
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "manifest.toml"
+SUBMIT_CONTRACT_PATH = ROOT / "workflow-contracts" / "submit.toml"
 SUBMIT_PROTOCOL_PATH = ROOT / "protocols" / "submit" / "PROTOCOL.md"
 CHANGELOG_PATH = ROOT / "CHANGELOG.md"
 
 
-def normalized_submit_protocol() -> str:
-    return re.sub(r"\s+", " ", SUBMIT_PROTOCOL_PATH.read_text())
+def load_manifest() -> dict:
+    return tomllib.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
 
 
-def normalized_changelog() -> str:
-    return re.sub(r"\s+", " ", CHANGELOG_PATH.read_text())
+def submit_protocol() -> dict:
+    manifest = load_manifest()
+    return next(protocol for protocol in manifest["protocols"] if protocol["name"] == "submit")
 
 
-def normalized_section(start: str, end: str) -> str:
-    protocol = SUBMIT_PROTOCOL_PATH.read_text()
-    section_start = protocol.index(start)
-    section_end = protocol.index(end, section_start)
-    return re.sub(r"\s+", " ", protocol[section_start:section_end])
+def normalized(path: Path) -> str:
+    return re.sub(r"\s+", " ", path.read_text(encoding="utf-8"))
 
 
 class SubmitProtocolTests(unittest.TestCase):
-    def test_existing_pr_with_local_work_is_a_push_path_not_a_stop_path(self) -> None:
-        protocol = normalized_submit_protocol()
+    def test_submit_contract_exists_and_produces_change_proposal(self) -> None:
+        contract = tomllib.loads(SUBMIT_CONTRACT_PATH.read_text(encoding="utf-8"))
 
-        self.assertIn("open PR exists and deliverable local work exists", protocol)
-        self.assertIn("push to the existing PR branch", protocol)
-        self.assertIn("pushed to existing PR", protocol)
+        self.assertEqual("submit", contract["name"])
+        self.assertEqual({"change-proposal"}, {terminal["artifact_produced"] for terminal in contract["terminals"]})
 
-    def test_open_pr_deliverability_uses_pr_head_regardless_of_upstream(self) -> None:
-        protocol = normalized_submit_protocol()
+    def test_submit_contract_uses_only_forge_invariant_delivery_operations(self) -> None:
+        contract = tomllib.loads(SUBMIT_CONTRACT_PATH.read_text(encoding="utf-8"))
+        mechanics = {
+            mechanic
+            for node in contract["nodes"]
+            for mechanic in node["mechanics"]
+        }
+        serialized = normalized(SUBMIT_CONTRACT_PATH)
 
-        self.assertIn("Open PR exists", protocol)
-        self.assertIn("regardless of whether the branch has upstream tracking", protocol)
-        self.assertIn("classify local `HEAD`", protocol)
-        self.assertIn("PR head SHA (`headRefOid`)", protocol)
-        self.assertIn("git merge-base --is-ancestor", protocol)
+        self.assertIn("deliver-change-proposal", mechanics)
+        self.assertIn("revise", mechanics)
+        self.assertNotIn("patch", serialized)
+        for forbidden in ["create-pr", "pr-merge", "github", "sourcehut", "`gh", "gh pr"]:
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, serialized.lower())
 
-    def test_no_open_pr_with_upstream_uses_remote_tracking_ref(self) -> None:
-        protocol = normalized_submit_protocol()
+    def test_manifest_routes_submit_to_change_proposal_not_patch(self) -> None:
+        protocol = submit_protocol()
+        mechanic_names = {mechanic["name"] for mechanic in load_manifest()["mechanics"]}
 
-        self.assertIn("No open PR and upstream exists", protocol)
-        self.assertIn("branch's remote tracking ref", protocol)
-        self.assertIn("git log @{upstream}..HEAD", protocol)
+        self.assertEqual(["completion-evidence", "documentation-record"], protocol["requires"])
+        self.assertEqual(["change-proposal", "change-needs-revision"], protocol["accepts"])
+        self.assertEqual(["change-proposal"], protocol["produces"])
+        self.assertEqual([], protocol["may_produce"])
+        self.assertEqual({"type": "on_artifact", "name": "documentation-record"}, protocol["trigger"])
+        self.assertIn("deliver-change-proposal", mechanic_names)
+        self.assertIn("revise", mechanic_names)
 
-    def test_no_open_pr_with_upstream_already_pushed_still_opens_pr(self) -> None:
-        step_4 = normalized_section("### 4. Resolve PR delivery path", "### 5. Push")
-        step_5 = normalized_section("### 5. Push", "### 6. Create or identify PR")
+    def test_submit_keeps_protocol_doc_for_release_metadata(self) -> None:
+        body = normalized(SUBMIT_PROTOCOL_PATH)
 
-        self.assertIn("No open PR and upstream exists", step_4)
-        self.assertIn("run `git log main..HEAD`", step_4)
-        self.assertIn("already-pushed branch still needs a PR", step_4)
-        self.assertIn("Upstream-ahead commits decide whether a push is needed", step_4)
-        self.assertIn("If no upstream-ahead commits exist", step_4)
-        self.assertIn("open the new PR without a push", step_5)
+        self.assertIn("change-proposal", body)
+        self.assertIn("`change-proposal` MCP tool", body)
+        self.assertIn("MCP tool input, not artifact body", body)
+        self.assertIn("Runa injects `work_unit` from session context", body)
+        self.assertNotIn("`patch` MCP tool", body)
 
-    def test_no_open_pr_without_upstream_uses_first_push_semantics(self) -> None:
-        protocol = normalized_submit_protocol()
+    def test_changelog_records_submit_contract_conversion(self) -> None:
+        changelog = normalized(CHANGELOG_PATH)
 
-        self.assertIn("No open PR and no upstream", protocol)
-        self.assertIn("first-push semantics", protocol)
-
-    def test_existing_pr_context_captures_pr_reference_and_head_sha(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("record the PR URL", protocol)
-        self.assertIn("downstream PR reference", protocol)
-        self.assertIn("PR head SHA", protocol)
-        self.assertIn("headRefOid", protocol)
-
-    def test_existing_pr_context_captures_pr_head_repo_and_ref(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("--json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner", protocol)
-        self.assertIn("PR head branch", protocol)
-        self.assertIn("headRefName", protocol)
-        self.assertIn("PR head repository", protocol)
-        self.assertIn("headRepositoryOwner.login", protocol)
-        self.assertIn("headRepository.name", protocol)
-
-    def test_existing_pr_context_captures_pr_base_repo_from_same_gh_context(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("gh repo view --json nameWithOwner,url", protocol)
-        self.assertIn("same repository context", protocol)
-        self.assertIn("PR base repository", protocol)
-        self.assertIn("base repository identity", protocol)
-
-    def test_step_1_captures_pr_discovery_substrate(self) -> None:
-        step_1 = normalized_section("### 1. Resolve context", "### 2. Ensure feature branch")
-
-        self.assertIn("--json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner", step_1)
-        self.assertIn("gh repo view --json nameWithOwner,url", step_1)
-        self.assertIn("record the PR URL", step_1)
-        self.assertIn("PR number", step_1)
-        self.assertIn("PR head SHA (`headRefOid`)", step_1)
-        self.assertIn("PR head branch (`headRefName`)", step_1)
-        self.assertIn("PR head repository", step_1)
-        self.assertIn("headRepositoryOwner.login", step_1)
-        self.assertIn("headRepository.name", step_1)
-        self.assertIn("PR base repository", step_1)
-        self.assertIn("git fetch <base-repo-remote> pull/<number>/head", step_1)
-        self.assertIn("verify that `headRefOid` resolves", step_1)
-        self.assertIn("post-commit deliverability classification", step_1)
-
-    def test_existing_pr_discovery_fetches_resolvable_pr_head_before_classification(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("--json url,number,headRefOid,headRefName,headRepository,headRepositoryOwner", protocol)
-        self.assertIn("matching the PR base repository", protocol)
-        self.assertIn("git fetch <base-repo-remote> pull/<number>/head", protocol)
-        self.assertIn("GitHub PR refspec", protocol)
-        self.assertIn("verify that `headRefOid` resolves", protocol)
-        self.assertLess(
-            protocol.index("git fetch <base-repo-remote> pull/<number>/head"),
-            protocol.index("git merge-base --is-ancestor"),
-        )
-
-    def test_pr_discovery_handles_zero_one_and_multiple_results(self) -> None:
-        step_1 = normalized_section("### 1. Resolve context", "### 2. Ensure feature branch")
-
-        self.assertIn("PR discovery handles result counts explicitly", step_1)
-        self.assertIn("0 results", step_1)
-        self.assertIn("no open PR", step_1)
-        self.assertIn("1 result", step_1)
-        self.assertIn("working PR", step_1)
-        self.assertIn("2+ results", step_1)
-        self.assertIn("disambiguate by head repository", step_1)
-
-    def test_multiple_pr_discovery_uses_shared_remote_matching_for_head_repo(self) -> None:
-        step_1 = normalized_section("### 1. Resolve context", "### 2. Ensure feature branch")
-
-        self.assertIn("filter candidates by PR head repository", step_1)
-        self.assertIn("local remotes", step_1)
-        self.assertIn("shared GitHub remote matching", step_1)
-        self.assertIn("effective push URL", step_1)
-        self.assertIn("exactly one PR survives", step_1)
-
-    def test_ambiguous_pr_discovery_stops_with_candidate_and_remote_context(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("Ambiguous PR discovery", protocol)
-        self.assertIn("candidate PR URLs", protocol)
-        self.assertIn("candidate head repositories", protocol)
-        self.assertIn("operator's local remotes", protocol)
-        self.assertIn("exactly one local remote", protocol)
-        self.assertIn("exactly one candidate PR head repository", protocol)
-
-    def test_existing_pr_base_remote_failure_stops_before_classification(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("No local remote matches the PR base repository", protocol)
-        self.assertIn("Stop before PR head fetch and ancestry classification", protocol)
-        self.assertIn("PR URL", protocol)
-        self.assertIn("PR base repository", protocol)
-        self.assertIn("matching local remote", protocol)
-
-    def test_existing_pr_head_fetch_failure_stops_with_pr_url(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("PR head fetch or resolvability check fails", protocol)
-        self.assertIn("recorded PR URL", protocol)
-        self.assertIn("stop before ancestry classification", protocol)
-
-    def test_existing_pr_classifies_all_ancestry_states(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("If `HEAD` and `headRefOid` are the same SHA", protocol)
-        self.assertIn("If `HEAD` is an ancestor of `headRefOid`", protocol)
-        self.assertIn("local checkout is behind the PR", protocol)
-        self.assertIn("If `headRefOid` is an ancestor of `HEAD`", protocol)
-        self.assertIn("deliverable through the existing PR update path", protocol)
-        self.assertIn("If neither commit is an ancestor of the other", protocol)
-        self.assertIn("Report the divergence and stop", protocol)
-
-    def test_step_4_classifies_post_commit_deliverability_for_all_paths(self) -> None:
-        step_4 = normalized_section("### 4. Resolve PR delivery path", "### 5. Push")
-
-        self.assertIn("After commit analysis has completed", step_4)
-        self.assertIn("classify current `HEAD`", step_4)
-        self.assertIn("Open PR exists", step_4)
-        self.assertIn("If `HEAD` and `headRefOid` are the same SHA", step_4)
-        self.assertIn("If `HEAD` is an ancestor of `headRefOid`", step_4)
-        self.assertIn("If `headRefOid` is an ancestor of `HEAD`", step_4)
-        self.assertIn("If neither commit is an ancestor of the other", step_4)
-        self.assertIn("No open PR and upstream exists", step_4)
-        self.assertIn("No open PR and no upstream", step_4)
-
-    def test_upstream_tracking_is_determined_at_step_4_classification_time(self) -> None:
-        step_1 = normalized_section("### 1. Resolve context", "### 2. Ensure feature branch")
-        step_4 = normalized_section("### 4. Resolve PR delivery path", "### 5. Push")
-
-        self.assertNotIn("Whether upstream tracking exists", step_1)
-        self.assertIn("determine whether upstream tracking exists", step_4)
-        self.assertIn("classification-time branch state", step_4)
-        self.assertIn("git rev-parse --abbrev-ref --symbolic-full-name @{upstream}", step_4)
-        self.assertIn("A failing upstream lookup means no upstream exists", step_4)
-
-    def test_existing_pr_push_targets_discovered_pr_head_ref(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("Existing PR update path", protocol)
-        self.assertIn("local remote whose effective push URL points at the PR head repository", protocol)
-        self.assertIn("git push <head-repo-remote> HEAD:<headRefName>", protocol)
-        self.assertIn("Do not push the local branch name to `origin`", protocol)
-
-    def test_existing_pr_remote_matching_is_part_of_github_forge_shape(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("GitHub-shaped commitment", protocol)
-        self.assertIn("`gh` discovery", protocol)
-        self.assertIn("`pull/<number>/head`", protocol)
-        self.assertIn("shared GitHub remote matching", protocol)
-        self.assertIn("git remote get-url --push <remote>", protocol)
-        self.assertIn("git remote get-url <remote>", protocol)
-        self.assertIn("SSH and HTTPS GitHub URLs", protocol)
-        self.assertIn("strip `.git`", protocol)
-        self.assertIn("lowercase `<owner>/<repo>`", protocol)
-        self.assertIn("non-GitHub URL forms as non-matches", protocol)
-
-    def test_existing_pr_without_matching_head_remote_stops_before_patch(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("No local remote matches the PR head repository", protocol)
-        self.assertIn("Stop before push", protocol)
-        self.assertIn("PR URL", protocol)
-        self.assertIn("PR head repository", protocol)
-        self.assertIn("headRefName", protocol)
-        self.assertIn("Do not deliver a `patch` artifact", protocol)
-
-    def test_new_pr_path_still_pushes_feature_branch_to_origin(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("New PR path", protocol)
-        self.assertIn("push the feature branch to origin", protocol)
-        self.assertIn("git push -u origin <branch>", protocol)
-        self.assertIn("if upstream exists, run `git push`", protocol)
-
-    def test_no_open_pr_without_upstream_checks_main_ahead_before_first_push(self) -> None:
-        step_4 = normalized_section("### 4. Resolve PR delivery path", "### 5. Push")
-
-        self.assertIn("No open PR and no upstream", step_4)
-        self.assertIn("git log main..HEAD", step_4)
-        self.assertIn("If commits exist", step_4)
-        self.assertIn("first-push semantics", step_4)
-        self.assertIn("If no commits exist", step_4)
-        self.assertIn("clean-branch-no-changes", step_4)
-        self.assertIn("stop", step_4)
-
-    def test_analyze_and_commit_applies_to_both_pr_delivery_paths(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("shared step applies before either PR delivery path", protocol)
-        self.assertIn("new PR or an existing PR update", protocol)
-
-    def test_patch_artifact_is_complete_latest_pr_state_on_both_paths(self) -> None:
-        protocol = normalized_submit_protocol()
-
-        self.assertIn("complete latest PR state snapshot", protocol)
-        self.assertIn(
-            "same shape for both a newly opened PR and an updated existing PR",
-            protocol,
-        )
-
-    def test_changelog_describes_base_fetch_and_first_push_emptiness(self) -> None:
-        changelog = normalized_changelog()
-
-        self.assertIn("matching PR base repository remote", changelog)
-        self.assertIn("first-push", changelog)
-        self.assertIn("git log main..HEAD", changelog)
-        self.assertIn("already-pushed branch still needs a PR", changelog)
-        self.assertIn("clean-branch-no-changes", changelog)
-
-    def test_changelog_describes_classification_time_upstream_and_pr_disambiguation(self) -> None:
-        changelog = normalized_changelog()
-
-        self.assertIn("classification-time branch state", changelog)
-        self.assertIn("upstream tracking", changelog)
-        self.assertIn("multiple open PRs", changelog)
-        self.assertIn("head repository", changelog)
-        self.assertIn("local remote", changelog)
+        self.assertIn("Submit C-2 workflow contract", changelog)
+        self.assertIn("change-proposal", changelog)
+        self.assertIn("closes #330", changelog)
 
 
 if __name__ == "__main__":

--- a/workflow-contracts/submit.toml
+++ b/workflow-contracts/submit.toml
@@ -1,0 +1,60 @@
+name = "submit"
+purpose = "Deliver a verified, documented change as a forge-neutral change proposal for review."
+session_role = "submission gate"
+preconditions = ["completion-evidence and documentation-record artifacts exist"]
+start_node = "resolve-change-proposal-path"
+failure_modes = [
+  "no deliverable change proposal path is available",
+  "proposal delivery cannot produce a valid forge-tagged handle",
+]
+corruption_modes = [
+  "forge-specific delivery vocabulary embedded in the workflow contract",
+  "legacy submission output preserved after change-proposal migration",
+  "revision delivered without advancing the proposal version",
+]
+
+[[nodes]]
+name = "resolve-change-proposal-path"
+intent = "Determine whether this submission creates an initial proposal or revises an existing proposal round."
+disciplines = ["orient", "contract"]
+mechanics = ["read-artifact"]
+outcomes = ["proposal_path is selected and required evidence is identified"]
+
+[[nodes]]
+name = "deliver-change-proposal"
+intent = "Deliver the initial proposal through the selected forge operation."
+disciplines = ["contract"]
+mechanics = ["deliver-change-proposal"]
+outcomes = ["initial change proposal exists with version 1 and a forge-tagged handle"]
+
+[[nodes]]
+name = "revise-change-proposal"
+intent = "Deliver a revised proposal version after a needs-revision outcome."
+disciplines = ["contract"]
+mechanics = ["revise"]
+outcomes = ["revised change proposal exists with an advanced version and a forge-tagged handle"]
+
+[[edges]]
+from = "resolve-change-proposal-path"
+to = "revise-change-proposal"
+condition = { type = "case", field = "proposal_path", equals = "revision" }
+
+[[edges]]
+from = "resolve-change-proposal-path"
+to = "deliver-change-proposal"
+condition = { type = "default", field = "proposal_path" }
+
+[[edges]]
+from = "deliver-change-proposal"
+to = "submitted"
+condition = { type = "always" }
+
+[[edges]]
+from = "revise-change-proposal"
+to = "submitted"
+condition = { type = "always" }
+
+[[terminals]]
+name = "submitted"
+outcome = "A change proposal exists for review."
+artifact_produced = "change-proposal"


### PR DESCRIPTION
## Summary

- Adds the source C-2 `submit` workflow contract producing `change-proposal`.
- Updates `submit` manifest wiring from `patch` to `change-proposal` and registers `revise`.
- Rewrites the submit protocol doc as WHAT-layer prose while preserving the release metadata invariant.

## Changes

- Added `workflow-contracts/submit.toml` with initial and revision proposal paths.
- Updated conformance-facing tests for submit's contract, manifest interface, and retained protocol doc.
- Added a changelog entry for #330.

## GitHub Issue(s)

Closes #330
Refs #318

## Test plan

- `python -m tooling.conformance`
- `python scripts/release-check metadata`
- `python -m unittest discover -s tests`
