### PR TITLE
feat(github): add GitHub mechanic bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `code-review` skill, manifest-registered required-choice outcome group, and
   typed review disposition routing through `change-approved` /
   `change-needs-revision` (closes #331).
+- GitHub C-3 mechanic library for the reference arc:
+  `deliver-change-proposal`, `apply-approved-change`, and
+  `reflect-disposition` now have forge-tagged mechanics bound from
+  `manifest.toml`, with conformance enforcing exactly one C-3 implementation
+  for each declared operation/tag pair.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ an outcome must use `on_artifact`, while successor triggers must not target a
 disposition-agnostic output of an outcome-bearing protocol through any trigger
 form or composite trigger.
 
+It also validates forge-tagged C-3 mechanic bindings. When a manifest
+`[[mechanics]]` entry declares `forge_tags = [...]`, each tag must resolve to
+`[[forge_tags]]` and exactly one `mechanics/**/*.toml` file whose `name` and
+`forge_tag` match that operation/tag pair.
+
 ## What Groundwork Believes
 
 These are the methodology choices embedded in groundwork's protocols and skills.

--- a/docs/architecture/step-2-reference-arc-design.md
+++ b/docs/architecture/step-2-reference-arc-design.md
@@ -35,10 +35,9 @@ The Step-1 substrate on `main` has these relevant facts:
   `name` values.
 - `schemas/mechanic.schema.json` has `name` and an optional `forge_tag`; it has no
   separate operation field.
-- `tooling.mechanics` validates that a mechanic's `forge_tag` is registered, but
-  it does not select a mechanic for an active forge.
-- `manifest.toml` registers available forge tags (`github`, `sourcehut`), but it
-  does not declare an active forge or operation-to-mechanic bindings.
+- `tooling.mechanics` validates that a mechanic's `forge_tag` is registered.
+- `manifest.toml` registers available forge tags (`github`, `sourcehut`) and
+  operation-to-mechanic bindings through `[[mechanics]].forge_tags`.
 - `change-approved.schema.json` and `change-needs-revision.schema.json` make
   classification structural: approval cannot contain blocking observations, and
   needs-revision must contain at least one blocking observation.
@@ -101,10 +100,11 @@ type cardinality and routes on artifact type.
 C-2 contracts must reference forge-invariant operation names only. They must not
 contain `create-pr`, `pr-merge`, or other forge-specific HOW vocabulary.
 
-The current Step-1 substrate does not yet implement the resolution mechanism
-needed by that decision. Bare mechanic names plus optional `forge_tag` validation
-prove that a mechanic has a registered forge tag; they do not prove that an
-operation reference resolves to exactly one mechanic for an active forge.
+The Step-2 substrate adds the resolution mechanism needed by that decision.
+Bare mechanic names plus optional `forge_tag` validation prove that a mechanic
+has a registered forge tag; manifest-declared `forge_tags` additionally prove
+that an operation reference resolves to exactly one C-3 mechanic for the
+declared forge.
 
 The Step-2 resolution mechanism is:
 
@@ -117,12 +117,10 @@ The Step-2 resolution mechanism is:
 - Validate, for the reference arc, that `github` and `sourcehut` each provide
   implementations for every forge-touching operation they need.
 
-This mechanism is not present on `main`. It should be added as a substrate
-prerequisite before the downstream contracts and mechanics are treated as
-complete. #330 and #332 may author forge-invariant operation references only
-after the conformance runner can validate the operation handles; #333 and #334
-may author forge-tagged mechanics only after the runner can prove their
-operation binding under the selected forge tag.
+#333 introduces this mechanism for GitHub as the first C-3 mechanic library:
+`deliver-change-proposal`, `apply-approved-change`, and
+`reflect-disposition` are bound under `forge_tag = "github"` and conformance
+rejects unknown, missing, or duplicate operation/tag implementations.
 
 ## Downstream Constraints
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -83,6 +83,7 @@ name = "inspect-change-proposals"
 
 [[mechanics]]
 name = "deliver-change-proposal"
+forge_tags = ["github"]
 
 [[mechanics]]
 name = "revise"
@@ -92,9 +93,11 @@ name = "review"
 
 [[mechanics]]
 name = "apply-approved-change"
+forge_tags = ["github"]
 
 [[mechanics]]
 name = "reflect-disposition"
+forge_tags = ["github"]
 
 [[mechanics]]
 name = "close-out"

--- a/mechanics/github/apply-approved-change.toml
+++ b/mechanics/github/apply-approved-change.toml
@@ -1,0 +1,25 @@
+name = "apply-approved-change"
+purpose = "Apply an approved GitHub pull request whose head commit matches the approved change-proposal version."
+forge_tag = "github"
+default_invocation = "gh pr merge {pr_number} --repo {repository} --merge --delete-branch --match-head-commit {commit}"
+examples = [
+  "gh pr merge 344 --repo tesserine/groundwork --merge --delete-branch --match-head-commit 8b519b2cd8782657a7bc3b93b1fac308547c1b0e",
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+
+[[parameters]]
+name = "pr_number"
+purpose = "GitHub pull request number to merge."
+required = true
+
+[[parameters]]
+name = "commit"
+purpose = "Approved proposal head commit SHA that must match the pull request head."
+required = true
+
+[outcome]
+description = "The approved GitHub pull request is merged without applying a different head commit."

--- a/mechanics/github/deliver-change-proposal.toml
+++ b/mechanics/github/deliver-change-proposal.toml
@@ -1,0 +1,36 @@
+name = "deliver-change-proposal"
+purpose = "Deliver a GitHub pull request for review while preserving the forge-neutral change-proposal envelope."
+forge_tag = "github"
+default_invocation = "git push origin {branch} && gh pr create --repo {repository} --base {base} --head {branch} --title {title} --body-file {body_file}"
+examples = [
+  "git push origin issue-343/github-mechanics-dogfood && gh pr create --repo tesserine/groundwork --base main --head issue-343/github-mechanics-dogfood --title 'docs: clarify skill authoring contract boundary' --body-file /tmp/pr-body.md",
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+
+[[parameters]]
+name = "branch"
+purpose = "Feature branch carrying the proposed change."
+required = true
+
+[[parameters]]
+name = "base"
+purpose = "Base branch or revision targeted by the proposal."
+required = true
+
+[[parameters]]
+name = "title"
+purpose = "Pull request title."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing the pull request body."
+required = true
+
+[outcome]
+description = "A GitHub pull request exists and can be recorded as a change-proposal handle."
+artifact_type = "change-proposal"

--- a/mechanics/github/reflect-disposition.toml
+++ b/mechanics/github/reflect-disposition.toml
@@ -1,0 +1,30 @@
+name = "reflect-disposition"
+purpose = "Reflect the acted-on GitHub approval disposition on the pull request and issue surfaces."
+forge_tag = "github"
+default_invocation = "gh pr comment {pr_number} --repo {repository} --body-file {body_file} && gh issue comment {issue_number} --repo {repository} --body-file {body_file} && gh issue close {issue_number} --repo {repository} --reason completed"
+examples = [
+  "gh pr comment 344 --repo tesserine/groundwork --body-file /tmp/disposition.md && gh issue comment 343 --repo tesserine/groundwork --body-file /tmp/disposition.md && gh issue close 343 --repo tesserine/groundwork --reason completed",
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+
+[[parameters]]
+name = "pr_number"
+purpose = "GitHub pull request number where disposition context is recorded."
+required = true
+
+[[parameters]]
+name = "issue_number"
+purpose = "GitHub issue number whose work-unit state is reflected."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing disposition evidence."
+required = true
+
+[outcome]
+description = "GitHub PR and issue state reflect that the approved disposition was acted on."

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -22,6 +22,9 @@ must carry at least one blocking finding.
 
 Change-proposal handle forge tags and mechanic-authored `forge_tag` values
 resolve against the declarative `[[forge_tags]]` registry in `manifest.toml`.
+Manifest `[[mechanics]]` entries may declare `forge_tags = [...]` to bind an
+operation handle to forge-specific C-3 mechanics; conformance requires exactly
+one matching `mechanics/**/*.toml` file for each declared operation/tag pair.
 
 `request.schema.json` is different: it is a vendored copy of the canonical
 request contract maintained by `tesserine/commons`. Groundwork keeps the runtime

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -403,6 +403,86 @@ name = "change-proposal"
         self.assertFalse(mechanic_result.passed)
         self.assertIn("artifact schema `completion-evidence` does not resolve in registry", " ".join(mechanic_result.errors))
 
+    def test_manifest_forge_tagged_mechanic_binding_requires_matching_c3_mechanic(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "manifest.toml"
+            manifest.write_text(
+                """
+[[forge_tags]]
+name = "github"
+
+[[mechanics]]
+name = "deliver-change-proposal"
+forge_tags = ["github"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            results = run_conformance([manifest])
+
+        self.assertEqual(1, len(results))
+        self.assertEqual("C-5 manifest", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn(
+            "mechanic binding `deliver-change-proposal` for forge tag `github` resolves to 0 C-3 mechanics",
+            " ".join(results[0].errors),
+        )
+
+    def test_manifest_forge_tagged_mechanic_binding_rejects_unknown_forge_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "manifest.toml"
+            manifest.write_text(
+                """
+[[mechanics]]
+name = "deliver-change-proposal"
+forge_tags = ["github"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            results = run_conformance([manifest])
+
+        self.assertEqual(1, len(results))
+        self.assertEqual("C-5 manifest", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn("forge tag `github` does not resolve in forge_tags", " ".join(results[0].errors))
+
+    def test_manifest_forge_tagged_mechanic_binding_rejects_duplicate_c3_mechanics(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "manifest.toml"
+            manifest.write_text(
+                """
+[[forge_tags]]
+name = "github"
+
+[[artifact_types]]
+name = "change-proposal"
+
+[[mechanics]]
+name = "deliver-change-proposal"
+forge_tags = ["github"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+            mechanics = root / "mechanics"
+            mechanics.mkdir()
+            mechanic_source = (MECHANIC_FIXTURES / "valid-github.toml").read_text(encoding="utf-8")
+            (mechanics / "one.toml").write_text(mechanic_source, encoding="utf-8")
+            (mechanics / "two.toml").write_text(mechanic_source, encoding="utf-8")
+
+            results = run_conformance([manifest])
+
+        self.assertEqual(1, len(results))
+        self.assertEqual("C-5 manifest", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn(
+            "mechanic binding `deliver-change-proposal` for forge tag `github` resolves to 2 C-3 mechanics",
+            " ".join(results[0].errors),
+        )
+
     def test_malformed_directory_manifest_does_not_abort_sibling_registry_checks(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_reference_arc_topology.py
+++ b/tests/test_reference_arc_topology.py
@@ -30,6 +30,15 @@ def load_fixture(name: str) -> dict:
     return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
 
 
+def mechanics_for_forge(forge_tag: str) -> list[dict]:
+    mechanics = []
+    for path in sorted((ROOT / "mechanics").rglob("*.toml")):
+        mechanic = tomllib.loads(path.read_text(encoding="utf-8"))
+        if mechanic.get("forge_tag") == forge_tag:
+            mechanics.append(mechanic)
+    return mechanics
+
+
 class ReferenceArcTopologyTests(unittest.TestCase):
     def test_manifest_routes_submit_review_land_through_disposition_artifacts(self) -> None:
         artifact_types = {entry["name"] for entry in manifest()["artifact_types"]}
@@ -71,6 +80,19 @@ class ReferenceArcTopologyTests(unittest.TestCase):
         self.assertIn("completion-evidence", land["accepts"])
         self.assertEqual(["completion-record"], land["produces"])
         self.assertEqual({"type": "on_artifact", "name": "change-approved"}, land["trigger"])
+
+    def test_github_reference_arc_mechanics_are_bound_once_in_manifest_and_c3(self) -> None:
+        operations = {
+            "deliver-change-proposal",
+            "apply-approved-change",
+            "reflect-disposition",
+        }
+        manifest_mechanics = {entry["name"]: entry for entry in manifest()["mechanics"]}
+        github_mechanics = mechanics_for_forge("github")
+
+        for operation in operations:
+            self.assertIn("github", manifest_mechanics[operation]["forge_tags"])
+            self.assertEqual(1, sum(1 for mechanic in github_mechanics if mechanic["name"] == operation))
 
     def test_land_approved_proposal_resolution_uses_work_unit_and_version_together(self) -> None:
         v1 = load_fixture("valid-change-proposal-github-issue340-v1.json")

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -221,7 +221,7 @@ def _check_manifest(path: Path) -> ConformanceResult:
             errors=[f"<toml>: {path.name} is invalid TOML: {error}"],
         )
 
-    errors = _manifest_errors(manifest)
+    errors = _manifest_errors(manifest, path.parent)
     return ConformanceResult(
         path=path,
         category=CATEGORY_MANIFEST,
@@ -230,13 +230,16 @@ def _check_manifest(path: Path) -> ConformanceResult:
     )
 
 
-def _manifest_errors(manifest: dict[str, Any]) -> list[tuple[str, str]]:
+def _manifest_errors(manifest: dict[str, Any], root: Path) -> list[tuple[str, str]]:
     errors: list[tuple[str, str]] = []
     artifact_type_entries = _manifest_table_entries(manifest, "artifact_types", "artifact type", errors)
     outcome_type_entries = _manifest_table_entries(manifest, "outcome_types", "outcome type", errors)
     protocol_entries = _manifest_table_entries(manifest, "protocols", "protocol", errors)
+    mechanic_entries = _manifest_table_entries(manifest, "mechanics", "mechanic", errors)
     artifact_types = _named_manifest_entries(artifact_type_entries, "artifact_types", "artifact type", errors)
     outcome_types = _named_manifest_entries(outcome_type_entries, "outcome_types", "outcome type", errors)
+    forge_tag_entries = _manifest_table_entries(manifest, "forge_tags", "forge tag", errors)
+    forge_tags = _named_manifest_entries(forge_tag_entries, "forge_tags", "forge tag", errors)
 
     for outcome_index, outcome_type in outcome_type_entries:
         name = outcome_type.get("name")
@@ -341,7 +344,67 @@ def _manifest_errors(manifest: dict[str, Any]) -> list[tuple[str, str]]:
                 )
             )
 
+    errors.extend(_manifest_mechanic_binding_errors(mechanic_entries, forge_tags, root))
+
     return errors
+
+
+def _manifest_mechanic_binding_errors(
+    mechanic_entries: list[tuple[int, dict[str, Any]]],
+    forge_tags: set[str],
+    root: Path,
+) -> list[tuple[str, str]]:
+    errors: list[tuple[str, str]] = []
+    c3_bindings = _c3_mechanic_bindings(root / "mechanics")
+
+    for mechanic_index, mechanic in mechanic_entries:
+        name = mechanic.get("name")
+        declared_forge_tags = mechanic.get("forge_tags")
+        if declared_forge_tags is None:
+            continue
+        if not isinstance(declared_forge_tags, list):
+            errors.append((f"mechanics/{mechanic_index}/forge_tags", "forge_tags must be an array"))
+            continue
+
+        for forge_tag_index, forge_tag in enumerate(declared_forge_tags):
+            forge_tag_path = f"mechanics/{mechanic_index}/forge_tags/{forge_tag_index}"
+            if not isinstance(forge_tag, str):
+                errors.append((forge_tag_path, "forge_tags member must be a string"))
+                continue
+            if forge_tag not in forge_tags:
+                errors.append((forge_tag_path, f"forge tag `{forge_tag}` does not resolve in forge_tags"))
+                continue
+            if not isinstance(name, str):
+                continue
+
+            match_count = c3_bindings.count((name, forge_tag))
+            if match_count != 1:
+                errors.append(
+                    (
+                        forge_tag_path,
+                        f"mechanic binding `{name}` for forge tag `{forge_tag}` resolves to "
+                        f"{match_count} C-3 mechanics; expected exactly 1",
+                    )
+                )
+
+    return errors
+
+
+def _c3_mechanic_bindings(directory: Path) -> list[tuple[str, str]]:
+    if not directory.exists():
+        return []
+
+    bindings: list[tuple[str, str]] = []
+    for path in directory.rglob("*.toml"):
+        try:
+            mechanic = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError):
+            continue
+        name = mechanic.get("name")
+        forge_tag = mechanic.get("forge_tag")
+        if isinstance(name, str) and isinstance(forge_tag, str):
+            bindings.append((name, forge_tag))
+    return bindings
 
 
 def _named_manifest_entries(


### PR DESCRIPTION
## Summary

- add GitHub C-3 mechanics for deliver-change-proposal, apply-approved-change, and reflect-disposition
- bind the GitHub mechanics from manifest operation rows with exact (name, forge_tag) conformance checks
- document the new binding surface and record the GitHub dogfood proof

## Dogfood evidence

Separate dogfood surface, not PR/issue #333:
- Issue: https://github.com/tesserine/groundwork/issues/343 (closed as completed)
- PR: https://github.com/tesserine/groundwork/pull/344 (merged)
- Evidence record on #333: https://github.com/tesserine/groundwork/issues/333#issuecomment-4594076081
- Approved head: 8b519b2cd8782657a7bc3b93b1fac308547c1b0e
- Merge commit: 8ff7b7080bb78529e9ccbf6c69927fb3f57d654a

## Verification

- python -m tooling.conformance
- python -m unittest discover -s tests

Closes #333
