### PR TITLE
feat(sourcehut): add SourceHut reference arc mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `reflect-disposition` now have forge-tagged mechanics bound from
   `manifest.toml`, with conformance enforcing exactly one C-3 implementation
   for each declared operation/tag pair.
+- SourceHut C-3 mechanic library for the reference arc: mbox-backed
+  `deliver-change-proposal`, `git am` + SSH-push `apply-approved-change`, and
+  tracker-ticket `reflect-disposition` now bind the same forge-invariant
+  operations under `forge_tag = "sourcehut"` without lists.sr.ht delivery.
 
 ### Changed
 

--- a/docs/architecture/step-2-reference-arc-design.md
+++ b/docs/architecture/step-2-reference-arc-design.md
@@ -117,10 +117,21 @@ The Step-2 resolution mechanism is:
 - Validate, for the reference arc, that `github` and `sourcehut` each provide
   implementations for every forge-touching operation they need.
 
-#333 introduces this mechanism for GitHub as the first C-3 mechanic library:
+#333 introduced this mechanism for GitHub as the first C-3 mechanic library,
+and #334 extends the same invariant operations to SourceHut:
 `deliver-change-proposal`, `apply-approved-change`, and
-`reflect-disposition` are bound under `forge_tag = "github"` and conformance
-rejects unknown, missing, or duplicate operation/tag implementations.
+`reflect-disposition` are bound under `forge_tag = "github"` and
+`forge_tag = "sourcehut"`. Conformance rejects unknown, missing, or duplicate
+operation/tag implementations.
+
+The SourceHut delivery locus is the change-proposal mbox itself. Submit
+produces an mbox, stores it at the artifact-store URI recorded in
+`change-proposal.handle.mbox`, and does not send it to lists.sr.ht. Land reads
+that same mbox handle after resolving the approved proposal by
+`work_unit`/`against_version`, applies it with `git am --3way`, verifies the
+applied and pushed head match the approved commit, and pushes the target ref
+over SSH. Disposition lives in tracker-ticket state; there is no platform merge
+or patchset email.
 
 ## Downstream Constraints
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -83,7 +83,7 @@ name = "inspect-change-proposals"
 
 [[mechanics]]
 name = "deliver-change-proposal"
-forge_tags = ["github"]
+forge_tags = ["github", "sourcehut"]
 
 [[mechanics]]
 name = "revise"
@@ -93,11 +93,11 @@ name = "review"
 
 [[mechanics]]
 name = "apply-approved-change"
-forge_tags = ["github"]
+forge_tags = ["github", "sourcehut"]
 
 [[mechanics]]
 name = "reflect-disposition"
-forge_tags = ["github"]
+forge_tags = ["github", "sourcehut"]
 
 [[mechanics]]
 name = "close-out"

--- a/mechanics/sourcehut/apply-approved-change.toml
+++ b/mechanics/sourcehut/apply-approved-change.toml
@@ -1,0 +1,40 @@
+name = "apply-approved-change"
+purpose = "Apply the mbox handle from the SourceHut change-proposal resolved by work_unit and against_version, verify the applied head is the approved commit, and push the target ref over SSH."
+forge_tag = "sourcehut"
+default_invocation = "git am --3way {mbox_file} && test \"$(git rev-parse HEAD)\" = \"{approved_commit}\" && git push {ssh_remote} HEAD:{target_ref} && test \"$(git ls-remote {ssh_remote} {target_ref} | cut -f1)\" = \"{approved_commit}\""
+examples = [
+  "git am --3way /tmp/issue-316-v2.mbox && test \"$(git rev-parse HEAD)\" = \"7f5a3ce0b626f15e445f4d9fb80663a9a10f4db0\" && git push git@git.sr.ht:~tesserine/groundwork HEAD:refs/heads/dogfood/issue-316-v2 && test \"$(git ls-remote git@git.sr.ht:~tesserine/groundwork refs/heads/dogfood/issue-316-v2 | cut -f1)\" = \"7f5a3ce0b626f15e445f4d9fb80663a9a10f4db0\"",
+]
+
+[[parameters]]
+name = "work_unit"
+purpose = "Work-unit identity used with against_version to resolve the approved change-proposal."
+required = true
+
+[[parameters]]
+name = "against_version"
+purpose = "Approved proposal version from change-approved.against_version."
+required = true
+
+[[parameters]]
+name = "mbox_file"
+purpose = "Local materialization of the artifact-store mbox referenced by the resolved change-proposal handle."
+required = true
+
+[[parameters]]
+name = "approved_commit"
+purpose = "Approved proposal commit that the applied series and pushed ref must match."
+required = true
+
+[[parameters]]
+name = "ssh_remote"
+purpose = "SourceHut Git SSH remote receiving the applied change."
+required = true
+
+[[parameters]]
+name = "target_ref"
+purpose = "Throwaway or release target ref to update on the SourceHut remote."
+required = true
+
+[outcome]
+description = "The resolved SourceHut mbox is applied with git am, the resulting HEAD and pushed ref match the approved commit, and drift is refused before disposition reflection."

--- a/mechanics/sourcehut/deliver-change-proposal.toml
+++ b/mechanics/sourcehut/deliver-change-proposal.toml
@@ -1,0 +1,31 @@
+name = "deliver-change-proposal"
+purpose = "Produce the SourceHut change-proposal mbox, store it at the artifact-store URI recorded in handle.mbox, and leave it not sent to lists.sr.ht."
+forge_tag = "sourcehut"
+default_invocation = "git format-patch --stdout {base}..{commit} > {mbox_file} && artifact-store put {mbox_file} {mbox_uri}"
+examples = [
+  "git format-patch --stdout main..7f5a3ce0b626f15e445f4d9fb80663a9a10f4db0 > /tmp/issue-316-v2.mbox && artifact-store put /tmp/issue-316-v2.mbox artifact://change-proposals/issue-316/v2.mbox",
+]
+
+[[parameters]]
+name = "base"
+purpose = "Base branch or revision targeted by the proposal."
+required = true
+
+[[parameters]]
+name = "commit"
+purpose = "Approved proposal commit or stable revision used as the patch-series tip."
+required = true
+
+[[parameters]]
+name = "mbox_file"
+purpose = "Local temporary mbox file produced before artifact-store storage."
+required = true
+
+[[parameters]]
+name = "mbox_uri"
+purpose = "Artifact-store path or URI recorded as the SourceHut change-proposal handle.mbox value."
+required = true
+
+[outcome]
+description = "A single artifact-store mbox carrier exists and the change-proposal handle.mbox points at it; no mailing-list patchset is sent."
+artifact_type = "change-proposal"

--- a/mechanics/sourcehut/reflect-disposition.toml
+++ b/mechanics/sourcehut/reflect-disposition.toml
@@ -1,0 +1,35 @@
+name = "reflect-disposition"
+purpose = "Reflect the acted-on SourceHut approval disposition as tracker-ticket metadata after the approved mbox has been applied and pushed."
+forge_tag = "sourcehut"
+default_invocation = "curl --fail --silent --show-error --header \"Authorization: Bearer {token}\" --header 'Content-Type: application/json' --data @'{comment_payload_file}' https://todo.sr.ht/query && curl --fail --silent --show-error --header \"Authorization: Bearer {token}\" --header 'Content-Type: application/json' --data @'{status_payload_file}' https://todo.sr.ht/query"
+examples = [
+  "curl --fail --silent --show-error --header \"Authorization: Bearer $WEFORGE_OPERATOR_PAT\" --header 'Content-Type: application/json' --data @/tmp/sourcehut-disposition-comment.json https://todo.sr.ht/query && curl --fail --silent --show-error --header \"Authorization: Bearer $WEFORGE_OPERATOR_PAT\" --header 'Content-Type: application/json' --data @/tmp/sourcehut-disposition-resolved.json https://todo.sr.ht/query",
+]
+
+[[parameters]]
+name = "tracker_id"
+purpose = "todo.sr.ht tracker ID containing the work-unit ticket."
+required = true
+
+[[parameters]]
+name = "ticket_id"
+purpose = "todo.sr.ht ticket ID whose status records the disposition."
+required = true
+
+[[parameters]]
+name = "comment_payload_file"
+purpose = "JSON GraphQL payload for submitComment containing mbox, approved version, commit, pushed ref, and apply evidence."
+required = true
+
+[[parameters]]
+name = "status_payload_file"
+purpose = "JSON GraphQL payload for updateTicketStatus setting the ticket to RESOLVED with the chosen resolution."
+required = true
+
+[[parameters]]
+name = "token"
+purpose = "SourceHut API token supplied from WEFORGE_OPERATOR_PAT at command time only; never hardcoded, written, echoed, or logged."
+required = true
+
+[outcome]
+description = "The SourceHut tracker ticket records the acted-on approval evidence and final resolved state; no platform merge or mailing-list patchset is created."

--- a/tests/test_reference_arc_topology.py
+++ b/tests/test_reference_arc_topology.py
@@ -39,6 +39,13 @@ def mechanics_for_forge(forge_tag: str) -> list[dict]:
     return mechanics
 
 
+def mechanic_for_forge(forge_tag: str, name: str) -> dict:
+    matches = [mechanic for mechanic in mechanics_for_forge(forge_tag) if mechanic["name"] == name]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one {forge_tag} mechanic named {name}, found {len(matches)}")
+    return matches[0]
+
+
 class ReferenceArcTopologyTests(unittest.TestCase):
     def test_manifest_routes_submit_review_land_through_disposition_artifacts(self) -> None:
         artifact_types = {entry["name"] for entry in manifest()["artifact_types"]}
@@ -81,18 +88,50 @@ class ReferenceArcTopologyTests(unittest.TestCase):
         self.assertEqual(["completion-record"], land["produces"])
         self.assertEqual({"type": "on_artifact", "name": "change-approved"}, land["trigger"])
 
-    def test_github_reference_arc_mechanics_are_bound_once_in_manifest_and_c3(self) -> None:
+    def test_reference_arc_mechanics_are_bound_once_per_forge_in_manifest_and_c3(self) -> None:
         operations = {
             "deliver-change-proposal",
             "apply-approved-change",
             "reflect-disposition",
         }
         manifest_mechanics = {entry["name"]: entry for entry in manifest()["mechanics"]}
-        github_mechanics = mechanics_for_forge("github")
 
-        for operation in operations:
-            self.assertIn("github", manifest_mechanics[operation]["forge_tags"])
-            self.assertEqual(1, sum(1 for mechanic in github_mechanics if mechanic["name"] == operation))
+        for forge_tag in {"github", "sourcehut"}:
+            forge_mechanics = mechanics_for_forge(forge_tag)
+            for operation in operations:
+                self.assertIn(forge_tag, manifest_mechanics[operation]["forge_tags"])
+                self.assertEqual(1, sum(1 for mechanic in forge_mechanics if mechanic["name"] == operation))
+
+    def test_sourcehut_mechanics_use_single_artifact_store_mbox_without_lists(self) -> None:
+        deliver = mechanic_for_forge("sourcehut", "deliver-change-proposal")
+        apply = mechanic_for_forge("sourcehut", "apply-approved-change")
+        combined = " ".join(
+            [
+                deliver["purpose"],
+                deliver["default_invocation"],
+                deliver["outcome"]["description"],
+                apply["purpose"],
+                apply["default_invocation"],
+                apply["outcome"]["description"],
+            ]
+        )
+
+        self.assertIn("artifact-store", deliver["purpose"])
+        self.assertIn("not sent to lists.sr.ht", deliver["purpose"])
+        self.assertIn("mbox", deliver["outcome"]["description"])
+        self.assertIn("artifact://", deliver["examples"][0])
+        self.assertIn("git am --3way", apply["default_invocation"])
+        self.assertIn("git push", apply["default_invocation"])
+        self.assertNotIn("git send-email", combined)
+
+    def test_sourcehut_apply_mechanic_guards_approved_version_against_drift(self) -> None:
+        apply = mechanic_for_forge("sourcehut", "apply-approved-change")
+        invocation = apply["default_invocation"]
+
+        self.assertIn("{approved_commit}", invocation)
+        self.assertIn("git rev-parse HEAD", invocation)
+        self.assertIn("test", invocation)
+        self.assertIn("git push", invocation)
 
     def test_land_approved_proposal_resolution_uses_work_unit_and_version_together(self) -> None:
         v1 = load_fixture("valid-change-proposal-github-issue340-v1.json")


### PR DESCRIPTION
## Summary

- Adds SourceHut-tagged C-3 mechanics for the forge-invariant submit -> review -> land arc.
- Binds SourceHut to the same manifest operation handles as GitHub without changing C-2 contracts.
- Pins the SourceHut delivery locus to one artifact-store mbox carrier, with list-free delivery and an apply drift guard.

## Changes

- Adds `mechanics/sourcehut/` definitions for `deliver-change-proposal`, `apply-approved-change`, and `reflect-disposition`.
- Updates `manifest.toml` so SourceHut resolves `deliver-change-proposal`, `apply-approved-change`, and `reflect-disposition` by `(name, forge_tag)`.
- Extends reference-arc coverage for two-forge mechanic binding, mbox carrier behavior, list-free delivery, and SourceHut approved-commit checks.
- Updates the changelog and Step 2 reference arc design note for the SourceHut mechanics.

## GitHub Issue(s)

Refs #334

## Test plan

- `python -m tooling.conformance`
- `python -m unittest discover -s tests`
- `git diff --check`

## Dogfood status

SourceHut dogfood still needs the separate SSH-capable execution agent: separate tracker ticket, throwaway ref, mbox handle, approved version/commit, am command shape, pushed ref, tracker disposition event, and final resolved state recorded back on #334.
