### PR TITLE
feat(resolution): bind operations to active forge mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   resolves to the approved commit, and guards tree equality after plain
   `git am --3way`, and `reflect-disposition` records tracker-ticket state
   under `forge_tag = "sourcehut"`.
+- Active forge resolution for forge-touching operations: `GROUNDWORK_FORGE`
+  selects the runtime forge with a `github` default, `python -m
+  tooling.forge_resolution` resolves or invokes the active forge's C-3
+  mechanic, and conformance accepts `--forge` for standalone checks.
+- GitHub and SourceHut `close-out` mechanics now fill the reference arc's final
+  forge matrix cell and record work-unit completion context through the active
+  forge's tracker surface.
 
 ### Changed
 
@@ -92,6 +99,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   registry-loaded mechanics whose `forge_tag` is not declared in
   `manifest.toml`; generic runtime mechanics remain forge-neutral by omitting
   `forge_tag` (closes #322).
+- C-5 manifest conformance now enforces full supported-forge matrix
+  declarations for forge-tagged operations and scans migrated protocol targets
+  for forge-specific leakage by inclusion rule.
 - Interactive install now projects the artifact delivery adapter into every
   protocol entry without depending on protocol prose formatting, so wrapped MCP
   delivery text cannot omit the adapter from installed protocol skills.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,25 @@ It also validates forge-tagged C-3 mechanic bindings. When a manifest
 `[[forge_tags]]` and exactly one `mechanics/**/*.toml` file whose `name` and
 `forge_tag` match that operation/tag pair.
 
+Forge-touching operations resolve through the active forge. Groundwork reads the
+active forge from `GROUNDWORK_FORGE`; when the variable is absent, the default is
+`github`. Standalone conformance and tests can supply or override that value:
+
+```bash
+python -m tooling.conformance --forge sourcehut
+```
+
+An executing agent resolves the operation before invoking forge mechanics:
+
+```bash
+python -m tooling.forge_resolution resolve close-out
+```
+
+The resolver returns the active forge's C-3 mechanic and exits non-zero if the
+operation and forge resolve to zero or multiple mechanics. The same entrypoint
+can execute a resolved mechanic with `invoke` and `name=value` parameters for
+runtime tests or scripted agent flows.
+
 ## What Groundwork Believes
 
 These are the methodology choices embedded in groundwork's protocols and skills.

--- a/manifest.toml
+++ b/manifest.toml
@@ -101,6 +101,7 @@ forge_tags = ["github", "sourcehut"]
 
 [[mechanics]]
 name = "close-out"
+forge_tags = ["github", "sourcehut"]
 
 [[mechanics]]
 name = "inspect-worktree"

--- a/mechanics/github/close-out.toml
+++ b/mechanics/github/close-out.toml
@@ -1,0 +1,25 @@
+name = "close-out"
+purpose = "Record GitHub work-unit completion context on the tracker issue."
+forge_tag = "github"
+default_invocation = "gh issue comment {issue_number} --repo {repository} --body-file {body_file} && gh issue close {issue_number} --repo {repository} --reason completed"
+examples = [
+  "gh issue comment 350 --repo tesserine/groundwork --body-file /tmp/completion.md && gh issue close 350 --repo tesserine/groundwork --reason completed",
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+
+[[parameters]]
+name = "issue_number"
+purpose = "GitHub issue number whose work-unit completion context is recorded."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing completion context."
+required = true
+
+[outcome]
+description = "The GitHub issue records completion context and is closed as completed."

--- a/mechanics/sourcehut/close-out.toml
+++ b/mechanics/sourcehut/close-out.toml
@@ -1,0 +1,40 @@
+name = "close-out"
+purpose = "Record SourceHut work-unit completion context on the tracker ticket."
+forge_tag = "sourcehut"
+default_invocation = '''comment_response=$(mktemp) && status_response=$(mktemp) && trap 'rm -f "$comment_response" "$status_response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer {token}" --header 'Content-Type: application/json' --data @'{comment_payload_file}' {todo_query_url} > "$comment_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$comment_response" submitComment && curl --fail --silent --show-error --header "Authorization: Bearer {token}" --header 'Content-Type: application/json' --data @'{status_payload_file}' {todo_query_url} > "$status_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$status_response" updateTicketStatus'''
+examples = [
+  '''comment_response=$(mktemp) && status_response=$(mktemp) && trap 'rm -f "$comment_response" "$status_response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-close-out-comment.json https://todo.sr.ht/query > "$comment_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$comment_response" submitComment && curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-close-out-resolved.json https://todo.sr.ht/query > "$status_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$status_response" updateTicketStatus''',
+]
+
+[[parameters]]
+name = "tracker_id"
+purpose = "todo.sr.ht tracker ID containing the work-unit ticket."
+required = true
+
+[[parameters]]
+name = "ticket_id"
+purpose = "todo.sr.ht ticket ID whose completion context is recorded."
+required = true
+
+[[parameters]]
+name = "comment_payload_file"
+purpose = "JSON GraphQL payload for submitComment containing completion context."
+required = true
+
+[[parameters]]
+name = "status_payload_file"
+purpose = "JSON GraphQL payload for updateTicketStatus setting the ticket to RESOLVED with the chosen resolution."
+required = true
+
+[[parameters]]
+name = "todo_query_url"
+purpose = "SourceHut todo GraphQL endpoint used for submitComment and updateTicketStatus."
+required = true
+
+[[parameters]]
+name = "token"
+purpose = "SourceHut API token supplied from WEFORGE_OPERATOR_PAT at command time only; never hardcoded, written, echoed, or logged."
+required = true
+
+[outcome]
+description = "The SourceHut tracker ticket records completion context and final resolved state."

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -50,6 +50,19 @@ order:
 2. `reflect-disposition` records that the approved disposition was acted on.
 3. `close-out` records work-unit completion context.
 
+Before invoking each forge-touching operation, resolve it through the
+methodology resolver:
+
+```
+python -m tooling.forge_resolution resolve apply-approved-change
+python -m tooling.forge_resolution resolve reflect-disposition
+python -m tooling.forge_resolution resolve close-out
+```
+
+The resolver reads the active forge from `GROUNDWORK_FORGE` and returns the
+forge-specific C-3 mechanic to execute. If resolution does not yield exactly one
+mechanic for the operation and active forge, stop before that operation.
+
 These operation names remain forge-invariant. Forge-specific mechanics may
 implement them, but the protocol does not prescribe those mechanics.
 

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -41,6 +41,17 @@ Revision delivery uses the invariant `revise` operation and then delivers the
 new proposal version. Both paths end in the same capstone: a
 `change-proposal` artifact.
 
+Before invoking a forge-touching operation, resolve it through the methodology
+resolver:
+
+```
+python -m tooling.forge_resolution resolve deliver-change-proposal
+```
+
+The resolver reads the active forge from `GROUNDWORK_FORGE` and returns the
+forge-specific C-3 mechanic to execute. If resolution does not yield exactly one
+mechanic, stop without producing a `change-proposal`.
+
 The protocol must not encode forge-specific delivery language. The artifact's
 `handle` carries the forge-tagged reference needed by downstream review and
 apply mechanics while the protocol remains at the WHAT layer.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -25,6 +25,8 @@ resolve against the declarative `[[forge_tags]]` registry in `manifest.toml`.
 Manifest `[[mechanics]]` entries may declare `forge_tags = [...]` to bind an
 operation handle to forge-specific C-3 mechanics; conformance requires exactly
 one matching `mechanics/**/*.toml` file for each declared operation/tag pair.
+Forge-tagged operations must declare every supported `[[forge_tags]]` entry so
+the active-forge resolver can halt loudly on missing or ambiguous matrix cells.
 
 `request.schema.json` is different: it is a vendored copy of the canonical
 request contract maintained by `tesserine/commons`. Groundwork keeps the runtime

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -26,6 +26,25 @@ class ConformanceTests(unittest.TestCase):
 
             return run_conformance([manifest])
 
+    def write_mechanic(self, root: Path, forge_tag: str, name: str) -> Path:
+        mechanic = root / "mechanics" / forge_tag / f"{name}.toml"
+        mechanic.parent.mkdir(parents=True, exist_ok=True)
+        mechanic.write_text(
+            f"""
+name = "{name}"
+purpose = "{forge_tag} {name}"
+forge_tag = "{forge_tag}"
+default_invocation = "printf {forge_tag}-{name}"
+examples = ["printf {forge_tag}-{name}"]
+parameters = []
+
+[outcome]
+description = "{name} completed"
+""".lstrip(),
+            encoding="utf-8",
+        )
+        return mechanic
+
     def review_outcome_manifest(self, successor_trigger: str) -> str:
         return f"""
 name = "review-methodology"
@@ -482,6 +501,93 @@ forge_tags = ["github"]
             "mechanic binding `deliver-change-proposal` for forge tag `github` resolves to 2 C-3 mechanics",
             " ".join(results[0].errors),
         )
+
+    def test_cli_accepts_forge_override_for_standalone_conformance(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "manifest.toml").write_text(
+                """
+[[forge_tags]]
+name = "github"
+
+[[forge_tags]]
+name = "sourcehut"
+
+[[mechanics]]
+name = "deliver-change-proposal"
+forge_tags = ["github", "sourcehut"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+            self.write_mechanic(root, "github", "deliver-change-proposal")
+            self.write_mechanic(root, "sourcehut", "deliver-change-proposal")
+
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                exit_code = main(["--forge", "sourcehut", str(root)])
+
+        self.assertEqual(0, exit_code)
+        self.assertIn("PASS C-5 manifest", stdout.getvalue())
+
+    def test_manifest_forge_matrix_requires_each_supported_forge_for_forge_touching_operations(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "manifest.toml"
+            manifest.write_text(
+                """
+[[forge_tags]]
+name = "github"
+
+[[forge_tags]]
+name = "sourcehut"
+
+[[mechanics]]
+name = "deliver-change-proposal"
+forge_tags = ["github"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+            self.write_mechanic(root, "github", "deliver-change-proposal")
+
+            results = run_conformance([manifest])
+
+        self.assertEqual("C-5 manifest", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn("operation `deliver-change-proposal` does not declare supported forge `sourcehut`", " ".join(results[0].errors))
+
+    def test_no_forge_leakage_scans_migrated_protocol_targets_by_extensible_rule(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "manifest.toml").write_text(
+                """
+[[artifact_types]]
+name = "completion-evidence"
+
+[[mechanics]]
+name = "read-artifact"
+
+[[protocols]]
+name = "land"
+""".lstrip(),
+                encoding="utf-8",
+            )
+            (root / "skills" / "orient").mkdir(parents=True)
+            contracts = root / "workflow-contracts"
+            contracts.mkdir()
+            (contracts / "land.toml").write_text(
+                (WORKFLOW_FIXTURES / "valid-linear.toml").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            protocol = root / "protocols" / "land" / "PROTOCOL.md"
+            protocol.parent.mkdir(parents=True)
+            protocol.write_text("Land closes the issue with `gh issue close`.\n", encoding="utf-8")
+
+            results = run_conformance([root])
+
+        manifest_result = next(result for result in results if result.path == root / "manifest.toml")
+        self.assertFalse(manifest_result.passed)
+        self.assertIn("protocols/land/PROTOCOL.md", " ".join(manifest_result.errors))
+        self.assertIn("forge-specific vocabulary", " ".join(manifest_result.errors))
 
     def test_malformed_directory_manifest_does_not_abort_sibling_registry_checks(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_forge_resolution.py
+++ b/tests/test_forge_resolution.py
@@ -1,0 +1,179 @@
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class ForgeResolutionTests(unittest.TestCase):
+    def test_active_forge_defaults_to_github_when_env_is_absent(self) -> None:
+        from tooling.forge_resolution import active_forge
+
+        self.assertEqual("github", active_forge(environ={}))
+
+    def test_active_forge_reads_groundwork_forge_and_allows_explicit_override(self) -> None:
+        from tooling.forge_resolution import active_forge
+
+        self.assertEqual("sourcehut", active_forge(environ={"GROUNDWORK_FORGE": "sourcehut"}))
+        self.assertEqual("github", active_forge("github", environ={"GROUNDWORK_FORGE": "sourcehut"}))
+
+    def test_resolves_active_forge_mechanic_from_manifest_matrix(self) -> None:
+        from tooling.forge_resolution import resolve_mechanic
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "mechanics" / "github").mkdir(parents=True)
+            (root / "mechanics" / "sourcehut").mkdir(parents=True)
+            (root / "manifest.toml").write_text(
+                """
+[[forge_tags]]
+name = "github"
+
+[[forge_tags]]
+name = "sourcehut"
+
+[[mechanics]]
+name = "deliver-change-proposal"
+forge_tags = ["github", "sourcehut"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+            (root / "mechanics" / "github" / "deliver-change-proposal.toml").write_text(
+                """
+name = "deliver-change-proposal"
+purpose = "github delivery"
+forge_tag = "github"
+default_invocation = "printf github"
+examples = ["printf github"]
+
+[outcome]
+description = "delivered"
+""".lstrip(),
+                encoding="utf-8",
+            )
+            (root / "mechanics" / "sourcehut" / "deliver-change-proposal.toml").write_text(
+                """
+name = "deliver-change-proposal"
+purpose = "sourcehut delivery"
+forge_tag = "sourcehut"
+default_invocation = "printf sourcehut"
+examples = ["printf sourcehut"]
+
+[outcome]
+description = "delivered"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            resolved = resolve_mechanic(
+                "deliver-change-proposal",
+                root=root,
+                environ={"GROUNDWORK_FORGE": "sourcehut"},
+            )
+
+        self.assertEqual("sourcehut", resolved.forge_tag)
+        self.assertEqual("printf sourcehut", resolved.mechanic["default_invocation"])
+        self.assertEqual(Path("mechanics/sourcehut/deliver-change-proposal.toml"), resolved.path.relative_to(root))
+
+    def test_resolution_halts_with_operation_and_forge_when_match_count_is_not_one(self) -> None:
+        from tooling.forge_resolution import ForgeResolutionError, resolve_mechanic
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "mechanics").mkdir()
+            (root / "manifest.toml").write_text(
+                """
+[[forge_tags]]
+name = "github"
+
+[[mechanics]]
+name = "close-out"
+forge_tags = ["github"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ForgeResolutionError) as context:
+                resolve_mechanic("close-out", root=root, environ={"GROUNDWORK_FORGE": "github"})
+
+        self.assertIn("close-out", str(context.exception))
+        self.assertIn("github", str(context.exception))
+        self.assertIn("expected exactly 1", str(context.exception))
+
+    def test_cli_resolution_error_exits_nonzero_and_names_operation_and_forge(self) -> None:
+        from tooling.forge_resolution import main
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "mechanics").mkdir()
+            (root / "manifest.toml").write_text(
+                """
+[[forge_tags]]
+name = "github"
+
+[[mechanics]]
+name = "close-out"
+forge_tags = ["github"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                exit_code = main(["resolve", "close-out", "--root", str(root)])
+
+        self.assertEqual(1, exit_code)
+        self.assertIn("close-out", stdout.getvalue())
+        self.assertIn("github", stdout.getvalue())
+
+    def test_invokes_resolved_mechanic_for_each_active_forge(self) -> None:
+        from tooling.forge_resolution import invoke_operation
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "mechanics" / "github").mkdir(parents=True)
+            (root / "mechanics" / "sourcehut").mkdir(parents=True)
+            (root / "manifest.toml").write_text(
+                """
+[[forge_tags]]
+name = "github"
+
+[[forge_tags]]
+name = "sourcehut"
+
+[[mechanics]]
+name = "close-out"
+forge_tags = ["github", "sourcehut"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+            for forge_tag in ("github", "sourcehut"):
+                (root / "mechanics" / forge_tag / "close-out.toml").write_text(
+                    f"""
+name = "close-out"
+purpose = "{forge_tag} close-out"
+forge_tag = "{forge_tag}"
+default_invocation = "printf {forge_tag} > {{marker}}"
+examples = ["printf {forge_tag} > /tmp/marker"]
+
+[outcome]
+description = "closed"
+""".lstrip(),
+                    encoding="utf-8",
+                )
+
+            for forge_tag in ("github", "sourcehut"):
+                with self.subTest(forge_tag=forge_tag):
+                    marker = root / f"{forge_tag}.txt"
+                    result = invoke_operation(
+                        "close-out",
+                        {"marker": str(marker)},
+                        root=root,
+                        environ={"GROUNDWORK_FORGE": forge_tag},
+                    )
+
+                    self.assertEqual(0, result.returncode, result.stderr)
+                    self.assertEqual(forge_tag, marker.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reference_arc_topology.py
+++ b/tests/test_reference_arc_topology.py
@@ -128,6 +128,7 @@ class ReferenceArcTopologyTests(unittest.TestCase):
             "deliver-change-proposal",
             "apply-approved-change",
             "reflect-disposition",
+            "close-out",
         }
         manifest_mechanics = {entry["name"]: entry for entry in manifest()["mechanics"]}
 
@@ -136,6 +137,19 @@ class ReferenceArcTopologyTests(unittest.TestCase):
             for operation in operations:
                 self.assertIn(forge_tag, manifest_mechanics[operation]["forge_tags"])
                 self.assertEqual(1, sum(1 for mechanic in forge_mechanics if mechanic["name"] == operation))
+
+    def test_sourcehut_close_out_mechanic_uses_checked_tracker_graphql(self) -> None:
+        close_out = mechanic_for_forge("sourcehut", "close-out")
+        invocation = close_out["default_invocation"]
+        parameters = {parameter["name"] for parameter in close_out["parameters"]}
+
+        self.assertIn("{todo_query_url}", invocation)
+        self.assertIn("submitComment", invocation)
+        self.assertIn("updateTicketStatus", invocation)
+        self.assertIn("expected=sys.argv[2]", invocation)
+        self.assertIn("data.%s", invocation)
+        self.assertIn("token", parameters)
+        self.assertIn("completion context", close_out["purpose"])
 
     def test_sourcehut_apply_mechanic_uses_proposal_ref_and_tree_equality_not_commit_identity(self) -> None:
         apply = mechanic_for_forge("sourcehut", "apply-approved-change")

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -255,6 +255,47 @@ name = "change-proposal"
 
         self.assertEqual("submit-smoke", contract["name"])
 
+    def test_registry_from_manifest_carries_active_forge_resolved_mechanics(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for forge_tag in ("github", "sourcehut"):
+                mechanic = root / "mechanics" / forge_tag / "deliver-change-proposal.toml"
+                mechanic.parent.mkdir(parents=True, exist_ok=True)
+                mechanic.write_text(
+                    f"""
+name = "deliver-change-proposal"
+purpose = "{forge_tag} delivery"
+forge_tag = "{forge_tag}"
+default_invocation = "printf {forge_tag}"
+examples = ["printf {forge_tag}"]
+parameters = []
+
+[outcome]
+description = "delivered"
+""".lstrip(),
+                    encoding="utf-8",
+                )
+            manifest = root / "manifest.toml"
+            manifest.write_text(
+                """
+[[forge_tags]]
+name = "github"
+
+[[forge_tags]]
+name = "sourcehut"
+
+[[mechanics]]
+name = "deliver-change-proposal"
+forge_tags = ["github", "sourcehut"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            registry = workflow_registry_from_manifest(manifest, root=root, forge="sourcehut")
+
+        self.assertEqual("sourcehut", registry.active_forge)
+        self.assertEqual("printf sourcehut", registry.resolved_mechanics["deliver-change-proposal"]["default_invocation"])
+
     def test_validate_workflow_contract_accepts_already_loaded_toml_data(self) -> None:
         contract = load_workflow_contract(self.fixture("valid-linear.toml"))
 

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -11,6 +12,7 @@ from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError
 
 from tooling.artifact_schemas import ArtifactSchemaError, load_artifact, registry_from_manifest
+from tooling.forge_resolution import active_forge
 from tooling.mechanics import MechanicError, load_mechanic
 from tooling.workflow_contracts import WorkflowContractError, load_workflow_contract, workflow_registry_from_manifest
 
@@ -24,6 +26,20 @@ CATEGORY_ARTIFACT = "C-4 artifact-instance"
 CATEGORY_SCHEMA = "C-4 schema-definition"
 CATEGORY_MANIFEST = "C-5 manifest"
 CATEGORY_UNKNOWN = "unknown"
+_FORGE_LEAKAGE_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\bgh\b",
+        r"github\.com",
+        r"git\.sr\.ht",
+        r"todo\.sr\.ht",
+        r"\bgithub\b",
+        r"\bsourcehut\b",
+        r"\bcreate-pr\b",
+        r"\bpr-merge\b",
+        r"\bpull request\b",
+    )
+]
 
 DIRECT_UNIT_DIRECTORY_NAMES = {"workflow-contracts", "mechanics", "schemas"}
 
@@ -56,18 +72,19 @@ def discover_units(root: Path | str = ROOT) -> list[Path]:
     return units
 
 
-def run_conformance(paths: Iterable[Path | str] | None = None) -> list[ConformanceResult]:
+def run_conformance(paths: Iterable[Path | str] | None = None, *, forge: str | None = None) -> list[ConformanceResult]:
     units = discover_units() if paths is None else _expand_paths(paths)
-    return [_check_unit(path) for path in units]
+    return [_check_unit(path, forge=forge) for path in units]
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run Groundwork Step-1 conformance checks.")
+    parser.add_argument("--forge", help="Override GROUNDWORK_FORGE for standalone conformance and testing.")
     parser.add_argument("paths", nargs="*", help="Files or directories to check. Defaults to source-tree units.")
     args = parser.parse_args(argv)
 
     paths = args.paths if args.paths else None
-    results = run_conformance(paths)
+    results = run_conformance(paths, forge=args.forge)
     for result in results:
         status = "PASS" if result.passed else "FAIL"
         print(f"{status} {result.category} {result.path}")
@@ -105,7 +122,7 @@ def _discover_direct_unit_directory(path: Path) -> list[Path]:
     return sorted(path.rglob("*.toml"))
 
 
-def _check_unit(path: Path) -> ConformanceResult:
+def _check_unit(path: Path, *, forge: str | None = None) -> ConformanceResult:
     category = _classify(path)
     try:
         if category == CATEGORY_WORKFLOW:
@@ -117,7 +134,7 @@ def _check_unit(path: Path) -> ConformanceResult:
         if category == CATEGORY_ARTIFACT:
             return _check_artifact_instance(path)
         if category == CATEGORY_MANIFEST:
-            return _check_manifest(path)
+            return _check_manifest(path, forge=forge)
     except (OSError, UnicodeDecodeError) as error:
         return ConformanceResult(
             path=path,
@@ -210,7 +227,7 @@ def _check_schema_definition(path: Path) -> ConformanceResult:
     return ConformanceResult(path=path, category=CATEGORY_SCHEMA, passed=True, errors=[])
 
 
-def _check_manifest(path: Path) -> ConformanceResult:
+def _check_manifest(path: Path, *, forge: str | None = None) -> ConformanceResult:
     try:
         manifest = tomllib.loads(path.read_text(encoding="utf-8"))
     except tomllib.TOMLDecodeError as error:
@@ -221,7 +238,7 @@ def _check_manifest(path: Path) -> ConformanceResult:
             errors=[f"<toml>: {path.name} is invalid TOML: {error}"],
         )
 
-    errors = _manifest_errors(manifest, path.parent)
+    errors = _manifest_errors(manifest, path.parent, forge=forge)
     return ConformanceResult(
         path=path,
         category=CATEGORY_MANIFEST,
@@ -230,7 +247,7 @@ def _check_manifest(path: Path) -> ConformanceResult:
     )
 
 
-def _manifest_errors(manifest: dict[str, Any], root: Path) -> list[tuple[str, str]]:
+def _manifest_errors(manifest: dict[str, Any], root: Path, *, forge: str | None = None) -> list[tuple[str, str]]:
     errors: list[tuple[str, str]] = []
     artifact_type_entries = _manifest_table_entries(manifest, "artifact_types", "artifact type", errors)
     outcome_type_entries = _manifest_table_entries(manifest, "outcome_types", "outcome type", errors)
@@ -240,6 +257,9 @@ def _manifest_errors(manifest: dict[str, Any], root: Path) -> list[tuple[str, st
     outcome_types = _named_manifest_entries(outcome_type_entries, "outcome_types", "outcome type", errors)
     forge_tag_entries = _manifest_table_entries(manifest, "forge_tags", "forge tag", errors)
     forge_tags = _named_manifest_entries(forge_tag_entries, "forge_tags", "forge tag", errors)
+    selected_forge = active_forge(forge)
+    if forge_tags and selected_forge not in forge_tags:
+        errors.append(("forge_tags", f"active forge `{selected_forge}` does not resolve in forge_tags"))
 
     for outcome_index, outcome_type in outcome_type_entries:
         name = outcome_type.get("name")
@@ -345,6 +365,7 @@ def _manifest_errors(manifest: dict[str, Any], root: Path) -> list[tuple[str, st
             )
 
     errors.extend(_manifest_mechanic_binding_errors(mechanic_entries, forge_tags, root))
+    errors.extend(_manifest_no_forge_leakage_errors(protocol_entries, root))
 
     return errors
 
@@ -366,13 +387,27 @@ def _manifest_mechanic_binding_errors(
             errors.append((f"mechanics/{mechanic_index}/forge_tags", "forge_tags must be an array"))
             continue
 
+        if isinstance(name, str):
+            for required_forge_tag in sorted(forge_tags):
+                if required_forge_tag not in declared_forge_tags:
+                    errors.append(
+                        (
+                            f"mechanics/{mechanic_index}/forge_tags",
+                            f"operation `{name}` does not declare supported forge `{required_forge_tag}`",
+                        )
+                    )
         for forge_tag_index, forge_tag in enumerate(declared_forge_tags):
             forge_tag_path = f"mechanics/{mechanic_index}/forge_tags/{forge_tag_index}"
             if not isinstance(forge_tag, str):
                 errors.append((forge_tag_path, "forge_tags member must be a string"))
                 continue
             if forge_tag not in forge_tags:
-                errors.append((forge_tag_path, f"forge tag `{forge_tag}` does not resolve in forge_tags"))
+                errors.append(
+                    (
+                        forge_tag_path,
+                        f"forge tag `{forge_tag}` does not resolve in forge_tags",
+                    )
+                )
                 continue
             if not isinstance(name, str):
                 continue
@@ -387,6 +422,44 @@ def _manifest_mechanic_binding_errors(
                     )
                 )
 
+    return errors
+
+
+def _manifest_no_forge_leakage_errors(
+    protocol_entries: list[tuple[int, dict[str, Any]]],
+    root: Path,
+) -> list[tuple[str, str]]:
+    errors: list[tuple[str, str]] = []
+    registered_protocols = {
+        protocol.get("name")
+        for _protocol_index, protocol in protocol_entries
+        if isinstance(protocol.get("name"), str)
+    }
+    workflow_contracts = root / "workflow-contracts"
+    protocol_bodies = root / "protocols"
+    for protocol_name in sorted(registered_protocols):
+        if not (workflow_contracts / f"{protocol_name}.toml").exists():
+            continue
+        for path in (
+            workflow_contracts / f"{protocol_name}.toml",
+            protocol_bodies / protocol_name / "PROTOCOL.md",
+        ):
+            if not path.exists():
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as error:
+                errors.append((str(path.relative_to(root)), f"cannot read migrated protocol target: {error}"))
+                continue
+            for pattern in _FORGE_LEAKAGE_PATTERNS:
+                if pattern.search(text):
+                    errors.append(
+                        (
+                            str(path.relative_to(root)),
+                            f"migrated protocol target contains forge-specific vocabulary `{pattern.pattern}`",
+                        )
+                    )
+                    break
     return errors
 
 

--- a/tooling/forge_resolution.py
+++ b/tooling/forge_resolution.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FORGE = "github"
+FORGE_ENV = "GROUNDWORK_FORGE"
+
+
+class ForgeResolutionError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ResolvedMechanic:
+    operation: str
+    forge_tag: str
+    path: Path
+    mechanic: dict[str, Any]
+
+
+def active_forge(
+    explicit_forge: str | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    environment = os.environ if environ is None else environ
+    return explicit_forge or environment.get(FORGE_ENV) or DEFAULT_FORGE
+
+
+def resolve_mechanic(
+    operation: str,
+    *,
+    forge: str | None = None,
+    root: Path | str = ROOT,
+    environ: Mapping[str, str] | None = None,
+) -> ResolvedMechanic:
+    root_path = Path(root)
+    manifest = _load_manifest(root_path)
+    forge_tag = active_forge(forge, environ=environ)
+    registered_forges = _registered_forges(manifest)
+    if forge_tag not in registered_forges:
+        raise ForgeResolutionError(f"active forge `{forge_tag}` does not resolve in forge_tags")
+
+    declared_forges = _declared_operation_forges(manifest, operation)
+    matches = _c3_matches(root_path, operation, forge_tag) if forge_tag in declared_forges else []
+    if len(matches) != 1:
+        raise ForgeResolutionError(
+            f"operation `{operation}` for forge `{forge_tag}` resolves to "
+            f"{len(matches)} C-3 mechanics; expected exactly 1"
+        )
+
+    path, mechanic = matches[0]
+    return ResolvedMechanic(operation=operation, forge_tag=forge_tag, path=path, mechanic=mechanic)
+
+
+def invoke_operation(
+    operation: str,
+    parameters: Mapping[str, str],
+    *,
+    forge: str | None = None,
+    root: Path | str = ROOT,
+    environ: Mapping[str, str] | None = None,
+    cwd: Path | str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    resolved = resolve_mechanic(operation, forge=forge, root=root, environ=environ)
+    command = resolved.mechanic["default_invocation"]
+    for name, value in parameters.items():
+        command = command.replace(f"{{{name}}}", value)
+
+    environment = os.environ.copy()
+    if environ is not None:
+        environment.update(environ)
+    return subprocess.run(
+        command,
+        shell=True,
+        executable="/bin/sh",
+        cwd=cwd,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _load_manifest(root: Path) -> dict[str, Any]:
+    try:
+        return tomllib.loads((root / "manifest.toml").read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as error:
+        raise ForgeResolutionError(f"manifest.toml is invalid TOML: {error}") from error
+    except OSError as error:
+        raise ForgeResolutionError(f"cannot read manifest.toml: {error}") from error
+
+
+def _registered_forges(manifest: dict[str, Any]) -> set[str]:
+    return {
+        entry["name"]
+        for entry in manifest.get("forge_tags", [])
+        if isinstance(entry, dict) and isinstance(entry.get("name"), str)
+    }
+
+
+def _declared_operation_forges(manifest: dict[str, Any], operation: str) -> set[str]:
+    declared: set[str] = set()
+    for entry in manifest.get("mechanics", []):
+        if not isinstance(entry, dict) or entry.get("name") != operation:
+            continue
+        forge_tags = entry.get("forge_tags")
+        if isinstance(forge_tags, list):
+            declared.update(forge_tag for forge_tag in forge_tags if isinstance(forge_tag, str))
+    return declared
+
+
+def _c3_matches(root: Path, operation: str, forge_tag: str) -> list[tuple[Path, dict[str, Any]]]:
+    mechanics = root / "mechanics"
+    if not mechanics.exists():
+        return []
+
+    matches: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted(mechanics.rglob("*.toml")):
+        try:
+            mechanic = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError):
+            continue
+        if mechanic.get("name") == operation and mechanic.get("forge_tag") == forge_tag:
+            matches.append((path, mechanic))
+    return matches
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Resolve Groundwork forge-specific mechanics.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    resolve_parser = subparsers.add_parser("resolve", help="Resolve an operation to the active forge mechanic.")
+    resolve_parser.add_argument("operation", help="Forge-invariant operation name.")
+    resolve_parser.add_argument("--forge", help="Override GROUNDWORK_FORGE for standalone tests/conformance.")
+    resolve_parser.add_argument("--root", default=str(ROOT), help="Methodology root. Defaults to this checkout.")
+    invoke_parser = subparsers.add_parser("invoke", help="Resolve and invoke the active forge mechanic.")
+    invoke_parser.add_argument("operation", help="Forge-invariant operation name.")
+    invoke_parser.add_argument("parameters", nargs="*", help="Mechanic parameters as name=value replacements.")
+    invoke_parser.add_argument("--forge", help="Override GROUNDWORK_FORGE for standalone tests/conformance.")
+    invoke_parser.add_argument("--root", default=str(ROOT), help="Methodology root. Defaults to this checkout.")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "invoke":
+            result = invoke_operation(
+                args.operation,
+                _parse_parameter_arguments(args.parameters),
+                forge=args.forge,
+                root=Path(args.root),
+            )
+            if result.stdout:
+                print(result.stdout, end="")
+            if result.stderr:
+                print(result.stderr, end="")
+            return result.returncode
+
+        resolved = resolve_mechanic(args.operation, forge=args.forge, root=Path(args.root))
+    except ForgeResolutionError as error:
+        print(error)
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "operation": resolved.operation,
+                "forge_tag": resolved.forge_tag,
+                "path": str(resolved.path),
+                "mechanic": resolved.mechanic,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _parse_parameter_arguments(arguments: list[str]) -> dict[str, str]:
+    parameters: dict[str, str] = {}
+    for argument in arguments:
+        if "=" not in argument:
+            raise ForgeResolutionError(f"parameter `{argument}` must use name=value form")
+        name, value = argument.split("=", 1)
+        parameters[name] = value
+    return parameters
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tooling/workflow_contracts.py
+++ b/tooling/workflow_contracts.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
+from tooling.forge_resolution import ForgeResolutionError, active_forge, resolve_mechanic
+
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = ROOT / "manifest.toml"
@@ -31,11 +33,14 @@ class WorkflowRegistry:
     artifact_schemas: set[str] = field(default_factory=set)
     outcome_types: set[str] = field(default_factory=set)
     required_output_choices: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    active_forge: str = "github"
+    resolved_mechanics: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 def workflow_registry_from_manifest(
     path: Path | str = MANIFEST,
     root: Path | str | None = None,
+    forge: str | None = None,
 ) -> WorkflowRegistry:
     manifest_path = Path(path)
     root_path = Path(root) if root is not None else manifest_path.parent
@@ -74,6 +79,7 @@ def workflow_registry_from_manifest(
         if isinstance(entry, dict) and isinstance(entry.get("name"), str)
     }
     mechanic_names.update(_mechanic_names_from_directory(root_path / "mechanics"))
+    selected_forge = active_forge(forge)
 
     return WorkflowRegistry(
         disciplines=_directory_names(root_path / "skills") | _directory_names(root_path / "protocols"),
@@ -81,6 +87,8 @@ def workflow_registry_from_manifest(
         artifact_schemas=artifact_types,
         outcome_types=outcome_types,
         required_output_choices=required_output_choices,
+        active_forge=selected_forge,
+        resolved_mechanics=_resolved_mechanics(manifest, root_path, selected_forge),
     )
 
 
@@ -129,6 +137,21 @@ def _mechanic_names_from_directory(directory: Path) -> set[str]:
         if isinstance(name, str):
             names.add(name)
     return names
+
+
+def _resolved_mechanics(manifest: dict[str, Any], root: Path, selected_forge: str) -> dict[str, dict[str, Any]]:
+    resolved: dict[str, dict[str, Any]] = {}
+    for entry in manifest.get("mechanics", []):
+        if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+            continue
+        forge_tags = entry.get("forge_tags")
+        if not isinstance(forge_tags, list) or selected_forge not in forge_tags:
+            continue
+        try:
+            resolved[entry["name"]] = resolve_mechanic(entry["name"], forge=selected_forge, root=root).mechanic
+        except ForgeResolutionError:
+            continue
+    return resolved
 
 
 def _schema_errors(contract: dict[str, Any]) -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary

- Adds a methodology-layer active forge resolver that reads `GROUNDWORK_FORGE`, defaults to `github`, and can resolve or invoke the active forge's C-3 mechanic.
- Extends conformance with `--forge`, full supported-forge matrix checks, and migrated protocol no-leakage scanning.
- Adds GitHub and SourceHut `close-out` mechanics so the reference arc's final forge-touching operation is bound on both supported forges.

## Changes

- Introduces `tooling.forge_resolution` with runtime `resolve` and `invoke` entrypoints plus operation/forge-specific failure messages.
- Threads active-forge resolved mechanics into workflow registries and conformance.
- Documents the runtime resolver convention in submit/land protocols, README, schema notes, and CHANGELOG.

## GitHub Issue(s)

Closes #350
Closes #351
Closes #352

## Test plan

- `python -m unittest discover -s tests`
- `python -m tooling.conformance`
- `python -m tooling.conformance --forge github`
- `python -m tooling.conformance --forge sourcehut`
