### PR TITLE
feat(resolution): bind forge operations at runtime

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,33 @@
+name: Conformance
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    name: Methodology conformance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: python -m unittest discover -s tests
+
+      - name: Run conformance
+        run: python -m tooling.conformance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   resolves to the approved commit, and guards tree equality after plain
   `git am --3way`, and `reflect-disposition` records tracker-ticket state
   under `forge_tag = "sourcehut"`.
+- Runtime forge-operation resolution: agents can resolve forge-invariant
+  operation handles through `GROUNDWORK_FORGE` with a `github` default,
+  installed sessions receive a pinned resolver snapshot, conformance enforces
+  complete `operation x forge_tag` bindings and forge-invariant protocol
+  bodies, and `close-out` now has GitHub and SourceHut mechanics for tracker
+  completion.
+- CI conformance gate: pull requests run the real unittest discovery command
+  over `tests/` and the methodology conformance runner.
 
 ### Changed
 
@@ -66,6 +74,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   GraphQL application-layer `errors` payloads returned with HTTP 200, and only
   accept delivery/reflection when the expected mutation `data` fields are
   present.
+- `reflect-disposition` now records acted-on disposition only; tracker
+  closure/resolution is owned by `close-out`, avoiding double-close behavior in
+  land's apply -> reflect -> close-out sequence.
 - SourceHut `deliver-change-proposal` now uploads the mbox artifact against a
   pushed git tag revspec instead of the proposal branch ref, matching
   SourceHut `uploadArtifact` requirements while preserving

--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ It also validates forge-tagged C-3 mechanic bindings. When a manifest
 `[[forge_tags]]` and exactly one `mechanics/**/*.toml` file whose `name` and
 `forge_tag` match that operation/tag pair.
 
+Forge-operation resolution is available to agents through the installed
+`forge-resolution` skill and the source `tooling.forge_resolution` module.
+The active forge is read from `GROUNDWORK_FORGE`, defaulting to `github` when
+the variable is absent; explicit test/standalone overrides may supply a forge
+directly. Resolution maps a forge-invariant operation handle plus active forge
+to exactly one C-3 mechanic. The conformance runner enforces a complete
+operation x forge matrix for forge-tagged operations, rejects ambiguous cells,
+and checks migrated forge-touching protocol bodies for forge-specific leakage.
+
+Mechanic `default_invocation` remains the C-3 shell-string format. The resolver
+renders supplied parameter values as shell-safe literals before invoking the
+existing pipeline, so values with spaces or shell metacharacters cannot split
+or inject additional commands.
+
 ## What Groundwork Believes
 
 These are the methodology choices embedded in groundwork's protocols and skills.

--- a/docs/architecture/step-2-reference-arc-design.md
+++ b/docs/architecture/step-2-reference-arc-design.md
@@ -116,6 +116,10 @@ The Step-2 resolution mechanism is:
 - Reject missing matches and ambiguous matches.
 - Validate, for the reference arc, that `github` and `sourcehut` each provide
   implementations for every forge-touching operation they need.
+- Read the active forge from `GROUNDWORK_FORGE`, defaulting to `github` when
+  absent, with an explicit override only for standalone conformance and tests.
+- Expose resolution where agents run, including installed interactive protocol
+  sessions, through the installed `forge-resolution` skill.
 
 #333 introduced this mechanism for GitHub as the first C-3 mechanic library,
 and #334 extends the same invariant operations to SourceHut:
@@ -123,6 +127,12 @@ and #334 extends the same invariant operations to SourceHut:
 `reflect-disposition` are bound under `forge_tag = "github"` and
 `forge_tag = "sourcehut"`. Conformance rejects unknown, missing, or duplicate
 operation/tag implementations.
+
+`close-out` is also forge-bound for both `github` and `sourcehut`. In land's
+sequence, `reflect-disposition` records that the approved disposition was acted
+on, while `close-out` records completion context and closes or resolves the
+tracker item. This keeps apply -> reflect -> close-out coherent without
+double-closing a work-unit tracker.
 
 SourceHut uses a patch-series handoff instead of a platform merge. Delivery
 stores a durable mbox reference at `change-proposal.handle.mbox` and pushes the

--- a/manifest.toml
+++ b/manifest.toml
@@ -101,6 +101,7 @@ forge_tags = ["github", "sourcehut"]
 
 [[mechanics]]
 name = "close-out"
+forge_tags = ["github", "sourcehut"]
 
 [[mechanics]]
 name = "inspect-worktree"

--- a/mechanics/github/close-out.toml
+++ b/mechanics/github/close-out.toml
@@ -1,0 +1,25 @@
+name = "close-out"
+purpose = "Record GitHub work-unit completion context and close the tracker issue."
+forge_tag = "github"
+default_invocation = "gh issue comment {issue_number} --repo {repository} --body-file {body_file} && gh issue close {issue_number} --repo {repository} --reason completed"
+examples = [
+  "gh issue comment 343 --repo tesserine/groundwork --body-file /tmp/completion.md && gh issue close 343 --repo tesserine/groundwork --reason completed",
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+
+[[parameters]]
+name = "issue_number"
+purpose = "GitHub issue number whose work-unit completion is recorded."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing completion context."
+required = true
+
+[outcome]
+description = "The GitHub issue records completion context and is closed as completed."

--- a/mechanics/github/reflect-disposition.toml
+++ b/mechanics/github/reflect-disposition.toml
@@ -1,9 +1,9 @@
 name = "reflect-disposition"
-purpose = "Reflect the acted-on GitHub approval disposition on the pull request and issue surfaces."
+purpose = "Reflect the acted-on GitHub approval disposition on the pull request and issue surfaces without closing the work-unit issue."
 forge_tag = "github"
-default_invocation = "gh pr comment {pr_number} --repo {repository} --body-file {body_file} && gh issue comment {issue_number} --repo {repository} --body-file {body_file} && gh issue close {issue_number} --repo {repository} --reason completed"
+default_invocation = "gh pr comment {pr_number} --repo {repository} --body-file {body_file} && gh issue comment {issue_number} --repo {repository} --body-file {body_file}"
 examples = [
-  "gh pr comment 344 --repo tesserine/groundwork --body-file /tmp/disposition.md && gh issue comment 343 --repo tesserine/groundwork --body-file /tmp/disposition.md && gh issue close 343 --repo tesserine/groundwork --reason completed",
+  "gh pr comment 344 --repo tesserine/groundwork --body-file /tmp/disposition.md && gh issue comment 343 --repo tesserine/groundwork --body-file /tmp/disposition.md",
 ]
 
 [[parameters]]
@@ -27,4 +27,4 @@ purpose = "Path to a file containing disposition evidence."
 required = true
 
 [outcome]
-description = "GitHub PR and issue state reflect that the approved disposition was acted on."
+description = "GitHub PR and issue comments reflect that the approved disposition was acted on; issue closure is left to close-out."

--- a/mechanics/sourcehut/close-out.toml
+++ b/mechanics/sourcehut/close-out.toml
@@ -1,0 +1,40 @@
+name = "close-out"
+purpose = "Record SourceHut work-unit completion context and resolve the tracker ticket as RESOLVED."
+forge_tag = "sourcehut"
+default_invocation = '''comment_response=$(mktemp) && status_response=$(mktemp) && trap 'rm -f "$comment_response" "$status_response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer {token}" --header 'Content-Type: application/json' --data @'{comment_payload_file}' {todo_query_url} > "$comment_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$comment_response" submitComment && curl --fail --silent --show-error --header "Authorization: Bearer {token}" --header 'Content-Type: application/json' --data @'{status_payload_file}' {todo_query_url} > "$status_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$status_response" updateTicketStatus'''
+examples = [
+  '''comment_response=$(mktemp) && status_response=$(mktemp) && trap 'rm -f "$comment_response" "$status_response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-close-out-comment.json https://todo.sr.ht/query > "$comment_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$comment_response" submitComment && curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-close-out-resolved.json https://todo.sr.ht/query > "$status_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$status_response" updateTicketStatus''',
+]
+
+[[parameters]]
+name = "tracker_id"
+purpose = "todo.sr.ht tracker ID containing the work-unit ticket."
+required = true
+
+[[parameters]]
+name = "ticket_id"
+purpose = "todo.sr.ht ticket ID whose status records completion."
+required = true
+
+[[parameters]]
+name = "comment_payload_file"
+purpose = "JSON GraphQL payload for submitComment containing completion context."
+required = true
+
+[[parameters]]
+name = "status_payload_file"
+purpose = "JSON GraphQL payload for updateTicketStatus setting the ticket to RESOLVED."
+required = true
+
+[[parameters]]
+name = "todo_query_url"
+purpose = "SourceHut todo GraphQL endpoint used for submitComment and updateTicketStatus."
+required = true
+
+[[parameters]]
+name = "token"
+purpose = "SourceHut API token supplied from WEFORGE_OPERATOR_PAT at command time only; never hardcoded, written, echoed, or logged."
+required = true
+
+[outcome]
+description = "The SourceHut tracker ticket records completion context and final resolved state; no platform merge or mailing-list patchset is created."

--- a/mechanics/sourcehut/reflect-disposition.toml
+++ b/mechanics/sourcehut/reflect-disposition.toml
@@ -1,9 +1,9 @@
 name = "reflect-disposition"
-purpose = "Reflect the acted-on SourceHut approval disposition as tracker-ticket metadata after the approved mbox has been applied and pushed."
+purpose = "Reflect the acted-on SourceHut approval disposition as tracker-ticket metadata after the approved mbox has been applied and pushed, without resolving the ticket."
 forge_tag = "sourcehut"
-default_invocation = '''comment_response=$(mktemp) && status_response=$(mktemp) && trap 'rm -f "$comment_response" "$status_response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer {token}" --header 'Content-Type: application/json' --data @'{comment_payload_file}' {todo_query_url} > "$comment_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$comment_response" submitComment && curl --fail --silent --show-error --header "Authorization: Bearer {token}" --header 'Content-Type: application/json' --data @'{status_payload_file}' {todo_query_url} > "$status_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$status_response" updateTicketStatus'''
+default_invocation = '''comment_response=$(mktemp) && trap 'rm -f "$comment_response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer {token}" --header 'Content-Type: application/json' --data @'{comment_payload_file}' {todo_query_url} > "$comment_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$comment_response" submitComment'''
 examples = [
-  '''comment_response=$(mktemp) && status_response=$(mktemp) && trap 'rm -f "$comment_response" "$status_response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-disposition-comment.json https://todo.sr.ht/query > "$comment_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$comment_response" submitComment && curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-disposition-resolved.json https://todo.sr.ht/query > "$status_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$status_response" updateTicketStatus''',
+  '''comment_response=$(mktemp) && trap 'rm -f "$comment_response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-disposition-comment.json https://todo.sr.ht/query > "$comment_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$comment_response" submitComment''',
 ]
 
 [[parameters]]
@@ -22,13 +22,8 @@ purpose = "JSON GraphQL payload for submitComment containing mbox, proposal ref,
 required = true
 
 [[parameters]]
-name = "status_payload_file"
-purpose = "JSON GraphQL payload for updateTicketStatus setting the ticket to RESOLVED with the chosen resolution."
-required = true
-
-[[parameters]]
 name = "todo_query_url"
-purpose = "SourceHut todo GraphQL endpoint used for submitComment and updateTicketStatus."
+purpose = "SourceHut todo GraphQL endpoint used for submitComment."
 required = true
 
 [[parameters]]
@@ -37,4 +32,4 @@ purpose = "SourceHut API token supplied from WEFORGE_OPERATOR_PAT at command tim
 required = true
 
 [outcome]
-description = "The SourceHut tracker ticket records the acted-on approval evidence and final resolved state; no platform merge or mailing-list patchset is created."
+description = "The SourceHut tracker ticket records the acted-on approval evidence; final resolved state is left to close-out."

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -48,7 +48,8 @@ order:
 
 1. `apply-approved-change` applies the resolved proposal detail.
 2. `reflect-disposition` records that the approved disposition was acted on.
-3. `close-out` records work-unit completion context.
+3. `close-out` records work-unit completion context and closes or resolves the
+   tracker item.
 
 These operation names remain forge-invariant. Forge-specific mechanics may
 implement them, but the protocol does not prescribe those mechanics.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -25,6 +25,8 @@ resolve against the declarative `[[forge_tags]]` registry in `manifest.toml`.
 Manifest `[[mechanics]]` entries may declare `forge_tags = [...]` to bind an
 operation handle to forge-specific C-3 mechanics; conformance requires exactly
 one matching `mechanics/**/*.toml` file for each declared operation/tag pair.
+Forge-tagged operation rows must cover every registered forge tag, so
+`operation x forge_tag` resolution has no empty supported-forge cells.
 
 `request.schema.json` is different: it is a vendored copy of the canonical
 request contract maintained by `tesserine/commons`. Groundwork keeps the runtime

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -292,7 +292,32 @@ project_entry() {
     mv "$target/PROTOCOL.md" "$target/SKILL.md"
     insert_interactive_adapter "$target/SKILL.md" "$sha"
   fi
+  if [[ "$kind" == "skill" && "$name" == "forge-resolution" ]]; then
+    project_forge_resolution_runtime "$target" "$sha"
+  fi
   write_marker "$target/$MARKER" "$kind" "$name" "$sha"
+}
+
+project_forge_resolution_runtime() {
+  local target="$1"
+  local sha="$2"
+  git -C "$source_path" cat-file -e "$sha:manifest.toml" 2>/dev/null ||
+    die "source has no manifest.toml required by forge-resolution"
+  git -C "$source_path" cat-file -e "$sha:mechanics" 2>/dev/null ||
+    die "source has no mechanics directory required by forge-resolution"
+  git -C "$source_path" cat-file -e "$sha:tooling/forge_resolution.py" 2>/dev/null ||
+    die "source has no tooling/forge_resolution.py required by forge-resolution"
+
+  git -C "$source_path" show "$sha:manifest.toml" > "$target/manifest.toml"
+  mkdir -p "$target/tooling"
+  git -C "$source_path" show "$sha:tooling/forge_resolution.py" > "$target/tooling/forge_resolution.py"
+  if git -C "$source_path" cat-file -e "$sha:tooling/__init__.py" 2>/dev/null; then
+    git -C "$source_path" show "$sha:tooling/__init__.py" > "$target/tooling/__init__.py"
+  else
+    : > "$target/tooling/__init__.py"
+  fi
+  mkdir -p "$target/mechanics"
+  git -C "$source_path" archive --format=tar "$sha:mechanics" | tar -xf - -C "$target/mechanics"
 }
 
 copy_entry() {

--- a/skills/forge-resolution/SKILL.md
+++ b/skills/forge-resolution/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: forge-resolution
+description: >-
+  Resolve forge-invariant operation handles to exactly one active-forge C-3
+  mechanic using GROUNDWORK_FORGE, with shell-safe parameter rendering for
+  existing default_invocation pipelines.
+metadata:
+  version: "1.0.0"
+  updated: "2026-06-02"
+---
+
+# Forge Resolution
+
+Use this skill when a protocol names a forge-invariant operation such as
+`deliver-change-proposal`, `apply-approved-change`, `reflect-disposition`, or
+`close-out`.
+
+Run the installed resolver from this skill directory:
+
+```bash
+python3 -m tooling.forge_resolution close-out
+```
+
+The resolver reads `GROUNDWORK_FORGE`, defaulting to `github` when the variable
+is absent. It resolves the operation against the pinned installed
+`manifest.toml` and `mechanics/` snapshot copied with this skill.
+
+To invoke a mechanic through the existing C-3 shell-string format, pass
+`--invoke` with `--param name=value` arguments. Parameter values are rendered as
+shell-safe literals before the mechanic's `default_invocation` pipeline runs.

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -483,6 +483,124 @@ forge_tags = ["github"]
             " ".join(results[0].errors),
         )
 
+    def test_manifest_forge_tagged_operation_requires_every_supported_forge(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "manifest.toml"
+            manifest.write_text(
+                """
+[[forge_tags]]
+name = "github"
+
+[[forge_tags]]
+name = "sourcehut"
+
+[[mechanics]]
+name = "close-out"
+forge_tags = ["github"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+            (root / "mechanics" / "github").mkdir(parents=True)
+            (root / "mechanics" / "github" / "close-out.toml").write_text(
+                """
+name = "close-out"
+purpose = "Close GitHub work."
+forge_tag = "github"
+default_invocation = "true"
+examples = ["true"]
+
+[outcome]
+description = "Closed."
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            results = run_conformance([manifest])
+
+        self.assertEqual("C-5 manifest", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn("mechanic `close-out` does not declare forge tag `sourcehut`", " ".join(results[0].errors))
+
+    def test_manifest_no_leakage_rejects_forge_specific_body_for_operation_referencing_protocol(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "manifest.toml").write_text(
+                """
+[[artifact_types]]
+name = "completion-record"
+
+[[forge_tags]]
+name = "github"
+
+[[forge_tags]]
+name = "sourcehut"
+
+[[mechanics]]
+name = "close-out"
+forge_tags = ["github", "sourcehut"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+            (root / "skills" / "orient").mkdir(parents=True)
+            (root / "protocols" / "land").mkdir(parents=True)
+            (root / "protocols" / "land" / "PROTOCOL.md").write_text(
+                "# Land\n\nRun `gh issue close 350` after applying the change.\n",
+                encoding="utf-8",
+            )
+            for forge in ["github", "sourcehut"]:
+                (root / "mechanics" / forge).mkdir(parents=True)
+                (root / "mechanics" / forge / "close-out.toml").write_text(
+                    f"""
+name = "close-out"
+purpose = "Close {forge} work."
+forge_tag = "{forge}"
+default_invocation = "true"
+examples = ["true"]
+
+[outcome]
+description = "Closed."
+""".lstrip(),
+                    encoding="utf-8",
+                )
+            contracts = root / "workflow-contracts"
+            contracts.mkdir()
+            (contracts / "land.toml").write_text(
+                """
+name = "land"
+purpose = "Close out approved work."
+session_role = "release gate"
+preconditions = ["approval exists"]
+start_node = "close-out"
+failure_modes = ["close-out fails"]
+corruption_modes = ["forge leakage"]
+
+[[nodes]]
+name = "close-out"
+intent = "Close out the work unit."
+disciplines = ["orient"]
+mechanics = ["close-out"]
+outcomes = ["closed"]
+
+[[edges]]
+from = "close-out"
+to = "completed"
+condition = { type = "always" }
+
+[[terminals]]
+name = "completed"
+outcome = "Closed."
+artifact_produced = "completion-record"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            results = run_conformance([root])
+
+        manifest_result = next(result for result in results if result.path == root / "manifest.toml")
+        self.assertFalse(manifest_result.passed)
+        self.assertIn("forge-specific body leakage", " ".join(manifest_result.errors))
+
     def test_malformed_directory_manifest_does_not_abort_sibling_registry_checks(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_forge_resolution.py
+++ b/tests/test_forge_resolution.py
@@ -1,0 +1,206 @@
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from tooling.forge_resolution import (
+    ForgeResolutionError,
+    active_forge,
+    invoke_mechanic,
+    render_invocation,
+    resolve_operation,
+)
+
+
+class ForgeResolutionTests(unittest.TestCase):
+    def write(self, root: Path, relative: str, contents: str) -> Path:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(contents).lstrip(), encoding="utf-8")
+        return path
+
+    def write_valid_matrix(self, root: Path) -> None:
+        self.write(
+            root,
+            "manifest.toml",
+            """
+            [[forge_tags]]
+            name = "github"
+
+            [[forge_tags]]
+            name = "sourcehut"
+
+            [[mechanics]]
+            name = "deliver-change-proposal"
+            forge_tags = ["github", "sourcehut"]
+            """,
+        )
+        for forge in ["github", "sourcehut"]:
+            self.write(
+                root,
+                f"mechanics/{forge}/deliver-change-proposal.toml",
+                f"""
+                name = "deliver-change-proposal"
+                purpose = "Deliver through {forge}."
+                forge_tag = "{forge}"
+                default_invocation = "printf '%s\\n' {{{forge}_value}}"
+                examples = ["printf '%s\\n' example"]
+
+                [[parameters]]
+                name = "{forge}_value"
+                purpose = "Value to print."
+                required = true
+
+                [outcome]
+                description = "Value printed."
+                """,
+            )
+
+    def test_active_forge_defaults_to_github_when_environment_is_absent(self) -> None:
+        self.assertEqual("github", active_forge(env={}))
+
+    def test_active_forge_reads_groundwork_forge_and_allows_explicit_override(self) -> None:
+        self.assertEqual("sourcehut", active_forge(env={"GROUNDWORK_FORGE": "sourcehut"}))
+        self.assertEqual("github", active_forge(env={"GROUNDWORK_FORGE": "sourcehut"}, override="github"))
+
+    def test_operation_resolves_to_exactly_one_mechanic_for_active_forge(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_valid_matrix(root)
+
+            mechanic = resolve_operation(
+                "deliver-change-proposal",
+                root=root,
+                active_forge_override="sourcehut",
+            )
+
+        self.assertEqual("deliver-change-proposal", mechanic["name"])
+        self.assertEqual("sourcehut", mechanic["forge_tag"])
+
+    def test_resolution_errors_name_operation_and_forge_for_missing_cell(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write(
+                root,
+                "manifest.toml",
+                """
+                [[forge_tags]]
+                name = "github"
+
+                [[forge_tags]]
+                name = "sourcehut"
+
+                [[mechanics]]
+                name = "close-out"
+                forge_tags = ["github", "sourcehut"]
+                """,
+            )
+            self.write(
+                root,
+                "mechanics/github/close-out.toml",
+                """
+                name = "close-out"
+                purpose = "Close GitHub work."
+                forge_tag = "github"
+                default_invocation = "true"
+                examples = ["true"]
+
+                [outcome]
+                description = "Closed."
+                """,
+            )
+
+            with self.assertRaises(ForgeResolutionError) as context:
+                resolve_operation("close-out", root=root, active_forge_override="sourcehut")
+
+        self.assertIn("close-out", str(context.exception))
+        self.assertIn("sourcehut", str(context.exception))
+
+    def test_resolution_errors_name_operation_and_forge_for_duplicate_cell(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write(
+                root,
+                "manifest.toml",
+                """
+                [[forge_tags]]
+                name = "github"
+
+                [[mechanics]]
+                name = "close-out"
+                forge_tags = ["github"]
+                """,
+            )
+            mechanic = """
+                name = "close-out"
+                purpose = "Close GitHub work."
+                forge_tag = "github"
+                default_invocation = "true"
+                examples = ["true"]
+
+                [outcome]
+                description = "Closed."
+                """
+            self.write(root, "mechanics/github/one.toml", mechanic)
+            self.write(root, "mechanics/github/two.toml", mechanic)
+
+            with self.assertRaises(ForgeResolutionError) as context:
+                resolve_operation("close-out", root=root, active_forge_override="github")
+
+        self.assertIn("close-out", str(context.exception))
+        self.assertIn("github", str(context.exception))
+        self.assertIn("2", str(context.exception))
+
+    def test_render_invocation_quotes_unquoted_parameter_values_for_shell_pipeline(self) -> None:
+        rendered = render_invocation(
+            "printf '<%s>\\n' {value} && printf done",
+            {"value": "one two; echo injected $(uname)"},
+        )
+
+        result = subprocess.run(
+            rendered,
+            shell=True,
+            executable="/bin/sh",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("<one two; echo injected $(uname)>\ndone", result.stdout.strip())
+
+    def test_render_invocation_escapes_parameter_values_inside_double_quotes(self) -> None:
+        rendered = render_invocation(
+            'printf "<%s>\\n" "{value}"',
+            {"value": 'one two"; echo injected; printf "'},
+        )
+
+        result = subprocess.run(
+            rendered,
+            shell=True,
+            executable="/bin/sh",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual('<one two"; echo injected; printf ">', result.stdout.strip())
+
+    def test_invoke_mechanic_preserves_existing_shell_pipelines_with_literal_parameters(self) -> None:
+        mechanic = {
+            "name": "deliver-change-proposal",
+            "default_invocation": "printf '<%s>\\n' {value} && printf 'pipeline-ran\\n'",
+        }
+
+        result = invoke_mechanic(
+            mechanic,
+            {"value": "literal value; echo injected"},
+            cwd=Path.cwd(),
+            env=os.environ.copy(),
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("<literal value; echo injected>\npipeline-ran\n", result.stdout)

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -252,6 +252,56 @@ class GroundworkInstallTests(unittest.TestCase):
                 with self.subTest(root=root, protocol=protocol):
                     self.assert_adapter_projected_once(body)
 
+    def test_install_projects_forge_resolution_runtime_snapshot(self) -> None:
+        fixture = self.add_fixture("forge-resolution")
+        fixture.write(
+            "skills/forge-resolution/SKILL.md",
+            """
+            ---
+            name: forge-resolution
+            ---
+            # Forge Resolution
+            """,
+        )
+        fixture.write(
+            "manifest.toml",
+            """
+            [[forge_tags]]
+            name = "github"
+
+            [[mechanics]]
+            name = "close-out"
+            forge_tags = ["github"]
+            """,
+        )
+        fixture.write(
+            "mechanics/github/close-out.toml",
+            """
+            name = "close-out"
+            purpose = "Close GitHub work."
+            forge_tag = "github"
+            default_invocation = "true"
+            examples = ["true"]
+
+            [outcome]
+            description = "Closed."
+            """,
+        )
+        fixture.write("tooling/__init__.py", "")
+        fixture.write("tooling/forge_resolution.py", "SNAPSHOT_SENTINEL = 'installed-runtime'\n")
+        fixture.commit_new_ref("v2")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            target = install.target(root, "forge-resolution")
+            self.assertTrue((target / "manifest.toml").is_file())
+            self.assertTrue((target / "mechanics" / "github" / "close-out.toml").is_file())
+            self.assertTrue((target / "tooling" / "forge_resolution.py").is_file())
+            self.assertIn("installed-runtime", (target / "tooling" / "forge_resolution.py").read_text(encoding="utf-8"))
+
     def test_install_does_not_project_interactive_adapter_into_skill_entries(self) -> None:
         fixture = self.add_fixture("adapter-skills")
         install = InstallRun(self, fixture.root)

--- a/tests/test_reference_arc_topology.py
+++ b/tests/test_reference_arc_topology.py
@@ -128,6 +128,7 @@ class ReferenceArcTopologyTests(unittest.TestCase):
             "deliver-change-proposal",
             "apply-approved-change",
             "reflect-disposition",
+            "close-out",
         }
         manifest_mechanics = {entry["name"]: entry for entry in manifest()["mechanics"]}
 
@@ -285,6 +286,26 @@ class ReferenceArcTopologyTests(unittest.TestCase):
         self.assertIn("{todo_query_url}", invocation)
         self.assertNotIn("https://todo.sr.ht/query", invocation)
 
+    def test_reflect_disposition_records_acted_on_disposition_without_closing_tracker(self) -> None:
+        github_reflect = mechanic_for_forge("github", "reflect-disposition")
+        sourcehut_reflect = mechanic_for_forge("sourcehut", "reflect-disposition")
+
+        self.assertIn("acted-on", github_reflect["purpose"])
+        self.assertIn("acted-on", sourcehut_reflect["purpose"])
+        self.assertNotIn("gh issue close", github_reflect["default_invocation"])
+        self.assertNotIn("updateTicketStatus", sourcehut_reflect["default_invocation"])
+        self.assertNotIn("RESOLVED", sourcehut_reflect["default_invocation"])
+
+    def test_close_out_mechanics_own_tracker_closure_for_each_forge(self) -> None:
+        github_close = mechanic_for_forge("github", "close-out")
+        sourcehut_close = mechanic_for_forge("sourcehut", "close-out")
+
+        self.assertIn("gh issue comment", github_close["default_invocation"])
+        self.assertIn("gh issue close", github_close["default_invocation"])
+        self.assertIn("updateTicketStatus", sourcehut_close["default_invocation"])
+        self.assertIn("RESOLVED", " ".join([sourcehut_close["purpose"], sourcehut_close["default_invocation"], *sourcehut_close["examples"]]))
+        self.assertIn("{todo_query_url}", sourcehut_close["default_invocation"])
+
     def test_sourcehut_deliver_fails_when_upload_artifact_returns_graphql_errors_with_http_success(self) -> None:
         deliver = mechanic_for_forge("sourcehut", "deliver-change-proposal")
 
@@ -382,8 +403,41 @@ printf '%s\\n' '{"data":{"uploadArtifact":{"id":987,"filename":"issue-26-v1.mbox
         )
         self.assertNotIn("https://", result.stdout)
 
-    def test_sourcehut_reflect_fails_when_either_todo_mutation_returns_graphql_errors_with_http_success(self) -> None:
+    def test_sourcehut_reflect_fails_when_comment_mutation_returns_graphql_errors_with_http_success(self) -> None:
         reflect = mechanic_for_forge("sourcehut", "reflect-disposition")
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            comment_payload = root / "comment.json"
+            comment_payload.write_text('{"query":"mutation { submitComment { id } }"}', encoding="utf-8")
+            (bin_dir / "curl").write_text(
+                f"""#!/bin/sh
+case "$*" in
+  *{comment_payload}*) printf '%s\\n' '{{"errors":[{{"message":"comment rejected"}}],"data":{{"submitComment":null}}}}' ;;
+  *) exit 1 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            (bin_dir / "curl").chmod(0o755)
+
+            result = self.run_mechanic_invocation(
+                reflect["default_invocation"],
+                {
+                    "token": "test-token",
+                    "comment_payload_file": str(comment_payload),
+                    "todo_query_url": "https://todo.example.invalid/query",
+                },
+                bin_dir,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("data.submitComment", result.stderr)
+
+    def test_sourcehut_close_out_fails_when_either_todo_mutation_returns_graphql_errors_with_http_success(self) -> None:
+        close_out = mechanic_for_forge("sourcehut", "close-out")
 
         cases = [
             (
@@ -421,7 +475,7 @@ esac
                     (bin_dir / "curl").chmod(0o755)
 
                     result = self.run_mechanic_invocation(
-                        reflect["default_invocation"],
+                        close_out["default_invocation"],
                         {
                             "token": "test-token",
                             "comment_payload_file": str(comment_payload),

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -486,6 +486,14 @@ class ReleaseRepositoryContractTests(unittest.TestCase):
         self.assertIn("paths:", workflow)
         self.assertIn("./scripts/release-check metadata", workflow)
 
+    def test_conformance_workflow_runs_real_test_discovery_and_conformance(self) -> None:
+        workflow = self.read(".github/workflows/conformance.yml")
+
+        self.assertIn("pull_request:", workflow)
+        self.assertIn("python -m unittest discover -s tests", workflow)
+        self.assertIn("python -m tooling.conformance", workflow)
+        self.assertNotIn("python -m unittest\n", workflow)
+
     def test_releasing_documentation_matches_verifier_contract(self) -> None:
         releasing = self.read("RELEASING.md")
 

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,6 +27,15 @@ CATEGORY_MANIFEST = "C-5 manifest"
 CATEGORY_UNKNOWN = "unknown"
 
 DIRECT_UNIT_DIRECTORY_NAMES = {"workflow-contracts", "mechanics", "schemas"}
+FORGE_LEAKAGE_PATTERNS = [
+    (re.compile(r"(?<![A-Za-z0-9_-])gh(?![A-Za-z0-9_-])"), "gh"),
+    (re.compile(r"github"), "github"),
+    (re.compile(r"sourcehut"), "sourcehut"),
+    (re.compile(r"sr[.]ht"), "sr.ht"),
+    (re.compile(r"todo[.]sr[.]ht"), "todo.sr.ht"),
+    (re.compile(r"git[.]sr[.]ht"), "git.sr.ht"),
+    (re.compile(r"lists[.]sr[.]ht"), "lists.sr.ht"),
+]
 
 
 @dataclass(frozen=True)
@@ -345,6 +355,7 @@ def _manifest_errors(manifest: dict[str, Any], root: Path) -> list[tuple[str, st
             )
 
     errors.extend(_manifest_mechanic_binding_errors(mechanic_entries, forge_tags, root))
+    errors.extend(_manifest_forge_leakage_errors(mechanic_entries, root))
 
     return errors
 
@@ -366,6 +377,16 @@ def _manifest_mechanic_binding_errors(
             errors.append((f"mechanics/{mechanic_index}/forge_tags", "forge_tags must be an array"))
             continue
 
+        declared_forge_tag_set = {forge_tag for forge_tag in declared_forge_tags if isinstance(forge_tag, str)}
+        if isinstance(name, str):
+            for forge_tag in sorted(forge_tags - declared_forge_tag_set):
+                errors.append(
+                    (
+                        f"mechanics/{mechanic_index}/forge_tags",
+                        f"mechanic `{name}` does not declare forge tag `{forge_tag}`",
+                    )
+                )
+
         for forge_tag_index, forge_tag in enumerate(declared_forge_tags):
             forge_tag_path = f"mechanics/{mechanic_index}/forge_tags/{forge_tag_index}"
             if not isinstance(forge_tag, str):
@@ -386,6 +407,60 @@ def _manifest_mechanic_binding_errors(
                         f"{match_count} C-3 mechanics; expected exactly 1",
                     )
                 )
+
+    return errors
+
+
+def _manifest_forge_leakage_errors(
+    mechanic_entries: list[tuple[int, dict[str, Any]]],
+    root: Path,
+) -> list[tuple[str, str]]:
+    forge_bound_operations = {
+        entry.get("name")
+        for _index, entry in mechanic_entries
+        if isinstance(entry.get("name"), str) and isinstance(entry.get("forge_tags"), list)
+    }
+    if not forge_bound_operations:
+        return []
+
+    errors: list[tuple[str, str]] = []
+    contracts = root / "workflow-contracts"
+    if not contracts.exists():
+        return errors
+
+    for contract_path in sorted(contracts.rglob("*.toml")):
+        try:
+            contract = tomllib.loads(contract_path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError):
+            continue
+        references_forge_bound_operation = any(
+            mechanic in forge_bound_operations
+            for node in contract.get("nodes", [])
+            if isinstance(node, dict)
+            for mechanic in node.get("mechanics", [])
+            if isinstance(mechanic, str)
+        )
+        if not references_forge_bound_operation:
+            continue
+
+        protocol_name = contract.get("name")
+        if not isinstance(protocol_name, str):
+            protocol_name = contract_path.stem
+        protocol_path = root / "protocols" / protocol_name / "PROTOCOL.md"
+        try:
+            body = protocol_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        normalized = body.lower()
+        for pattern, label in FORGE_LEAKAGE_PATTERNS:
+            if pattern.search(normalized):
+                errors.append(
+                    (
+                        str(protocol_path.relative_to(root)),
+                        f"forge-specific body leakage `{label}` in protocol `{protocol_name}`",
+                    )
+                )
+                break
 
     return errors
 

--- a/tooling/forge_resolution.py
+++ b/tooling/forge_resolution.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Any, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GROUNDWORK_FORGE_ENV = "GROUNDWORK_FORGE"
+DEFAULT_FORGE = "github"
+PLACEHOLDER_RE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_.-]*)\}")
+
+
+class ForgeResolutionError(ValueError):
+    pass
+
+
+def active_forge(
+    *,
+    env: Mapping[str, str] | None = None,
+    override: str | None = None,
+) -> str:
+    if override is not None and override != "":
+        return override
+    environment = os.environ if env is None else env
+    value = environment.get(GROUNDWORK_FORGE_ENV)
+    return value if value else DEFAULT_FORGE
+
+
+def resolve_operation(
+    operation: str,
+    *,
+    root: Path | str = ROOT,
+    active_forge_override: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    root_path = Path(root)
+    manifest = _load_manifest(root_path)
+    forge = active_forge(env=env, override=active_forge_override)
+    forge_tags = _manifest_names(manifest, "forge_tags")
+    if forge not in forge_tags:
+        raise ForgeResolutionError(f"forge `{forge}` is not registered for operation `{operation}`")
+
+    mechanic_entries = [
+        entry
+        for entry in manifest.get("mechanics", [])
+        if isinstance(entry, dict) and entry.get("name") == operation
+    ]
+    if not mechanic_entries:
+        raise ForgeResolutionError(f"operation `{operation}` is not registered for forge `{forge}`")
+
+    declared_tags = mechanic_entries[0].get("forge_tags")
+    if not isinstance(declared_tags, list) or forge not in declared_tags:
+        raise ForgeResolutionError(f"operation `{operation}` has no declared mechanic for forge `{forge}`")
+
+    matches = [
+        mechanic
+        for mechanic in _load_c3_mechanics(root_path / "mechanics")
+        if mechanic.get("name") == operation and mechanic.get("forge_tag") == forge
+    ]
+    if len(matches) != 1:
+        raise ForgeResolutionError(
+            f"operation `{operation}` for forge `{forge}` resolved to {len(matches)} mechanics; expected exactly 1"
+        )
+    return matches[0]
+
+
+def render_invocation(invocation: str, parameters: Mapping[str, object]) -> str:
+    rendered: list[str] = []
+    index = 0
+    quote_state: str | None = None
+
+    while index < len(invocation):
+        character = invocation[index]
+        if character == "'" and quote_state != "double":
+            quote_state = None if quote_state == "single" else "single"
+            rendered.append(character)
+            index += 1
+            continue
+        if character == '"' and quote_state != "single":
+            quote_state = None if quote_state == "double" else "double"
+            rendered.append(character)
+            index += 1
+            continue
+
+        if character == "{":
+            match = PLACEHOLDER_RE.match(invocation, index)
+            if match is not None:
+                name = match.group(1)
+                if name not in parameters:
+                    raise ForgeResolutionError(f"missing parameter `{name}` for mechanic invocation")
+                rendered.append(_quote_parameter(str(parameters[name]), quote_state))
+                index = match.end()
+                continue
+
+        rendered.append(character)
+        index += 1
+
+    return "".join(rendered)
+
+
+def invoke_mechanic(
+    mechanic: Mapping[str, Any],
+    parameters: Mapping[str, object],
+    *,
+    cwd: Path | str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    invocation = mechanic.get("default_invocation")
+    if not isinstance(invocation, str):
+        raise ForgeResolutionError("mechanic has no string default_invocation")
+    command = render_invocation(invocation, parameters)
+    return subprocess.run(
+        command,
+        shell=True,
+        executable="/bin/sh",
+        cwd=cwd,
+        env=None if env is None else dict(env),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Resolve a forge-invariant operation to an active-forge mechanic.")
+    parser.add_argument("operation", help="Forge-invariant operation name.")
+    parser.add_argument("--root", default=str(ROOT), help="Groundwork checkout or installed resolver root.")
+    parser.add_argument("--forge", help=f"Explicit forge override. Defaults to ${GROUNDWORK_FORGE_ENV} or github.")
+    parser.add_argument(
+        "--invoke",
+        action="store_true",
+        help="Render and run the mechanic default_invocation with --param values.",
+    )
+    parser.add_argument(
+        "--param",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="Parameter value supplied to --invoke. May be repeated.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        mechanic = resolve_operation(args.operation, root=args.root, active_forge_override=args.forge)
+        if not args.invoke:
+            print(json.dumps(mechanic, sort_keys=True))
+            return 0
+        result = invoke_mechanic(mechanic, _parse_params(args.param), cwd=args.root)
+    except ForgeResolutionError as error:
+        print(f"forge-resolution: {error}", file=os.sys.stderr)
+        return 1
+
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=os.sys.stderr)
+    return result.returncode
+
+
+def _quote_parameter(value: str, quote_state: str | None) -> str:
+    if quote_state == "single":
+        return value.replace("'", "'\\''")
+    if quote_state == "double":
+        return value.translate(str.maketrans({'"': '\\"', "\\": "\\\\", "$": "\\$", "`": "\\`"}))
+    return shlex.quote(value)
+
+
+def _parse_params(values: list[str]) -> dict[str, str]:
+    parameters: dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            raise ForgeResolutionError(f"parameter `{value}` must be NAME=VALUE")
+        name, parameter_value = value.split("=", 1)
+        if not name:
+            raise ForgeResolutionError("parameter name must not be empty")
+        parameters[name] = parameter_value
+    return parameters
+
+
+def _load_manifest(root: Path) -> dict[str, Any]:
+    try:
+        return tomllib.loads((root / "manifest.toml").read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise ForgeResolutionError(f"manifest.toml not found under {root}") from error
+    except tomllib.TOMLDecodeError as error:
+        raise ForgeResolutionError(f"manifest.toml is invalid TOML: {error}") from error
+
+
+def _manifest_names(manifest: dict[str, Any], key: str) -> set[str]:
+    return {
+        entry["name"]
+        for entry in manifest.get(key, [])
+        if isinstance(entry, dict) and isinstance(entry.get("name"), str)
+    }
+
+
+def _load_c3_mechanics(directory: Path) -> list[dict[str, Any]]:
+    mechanics: list[dict[str, Any]] = []
+    if not directory.exists():
+        return mechanics
+    for path in sorted(directory.rglob("*.toml")):
+        try:
+            mechanics.append(tomllib.loads(path.read_text(encoding="utf-8")))
+        except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError):
+            continue
+    return mechanics
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds runtime forge-operation resolution through `GROUNDWORK_FORGE`, with `github` as the default and explicit override support for tests/standalone use.
- Completes the forge-bound `close-out` matrix for GitHub and SourceHut, while keeping `reflect-disposition` focused on recording acted-on disposition.
- Enforces the operation x forge matrix, installed-session resolver reachability, shell-safe mechanic parameter rendering, and PR-tree conformance CI.

## Changes

- Adds `tooling.forge_resolution` and the installed `forge-resolution` skill, plus installer projection of the pinned resolver runtime, manifest, and mechanics snapshot.
- Adds GitHub and SourceHut `close-out` mechanics and updates land docs/tests so close-out owns tracker closure/resolution.
- Extends C-5 conformance for complete forge-tagged operation rows and forge-specific protocol body leakage checks.
- Adds `.github/workflows/conformance.yml` running real unittest discovery and `python -m tooling.conformance`.

## GitHub Issue(s)

Closes #350

## Test plan

- `python -m unittest discover -s tests` — 172 tests passed
- `python -m tooling.conformance` — 29 passed, 0 failed
- `git diff --check` — clean
