### PR TITLE
fix(take): remove gh issue view forge-leakage from the protocol body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `take` now halts on missing injected referenced work-unit context instead of
+  falling back to a forge-specific tracker lookup, and C-5 conformance now scans
+  `take` for forge leakage with the rest of the registered protocol bodies
+  (closes #353).
 - SourceHut `deliver-change-proposal` and `reflect-disposition` now fail on
   GraphQL application-layer `errors` payloads returned with HTTP 200, and only
   accept delivery/reflection when the expected mutation `data` fields are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Mechanic invocation validation now rejects bare `{parameter}` placeholders
   outside shell quoting, malformed shell, unexpanded declared parameters,
   incomplete forge-operation matrices, and registered protocol bodies that leak
-  forge-specific command tokens outside the temporary #353 `take` exception.
+  forge-specific command tokens.
 - Interactive install now projects the artifact delivery adapter into every
   protocol entry without depending on protocol prose formatting, so wrapped MCP
   delivery text cannot omit the adapter from installed protocol skills.

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -88,8 +88,8 @@ references. Without it, runa cannot thread related artifacts together.
 
 The take artifact is a threading mechanism: work-unit identifier plus
 enough orientation for downstream protocols. Not a context dump — the
-the GitHub issue itself carries the full context, and the work-unit graph is the right
-place for that.
+forge tracker record carries the full context, and the work-unit graph is the
+right place for that.
 
 ## Input Edge Principle
 

--- a/docs/architecture/work-unit-model.md
+++ b/docs/architecture/work-unit-model.md
@@ -11,13 +11,13 @@ The work-unit graph is the persistence layer across sessions. Agent sessions end
 
 ## State Source Rule
 
-State is determined by reading GitHub issue content, not forge metadata (labels, columns). A work-unit's state is what its issue body and comments say it is.
+State is determined by reading the forge tracker record content, not forge metadata (labels, columns). A work-unit's state is what its record body and comments say it is.
 
 ## Work-Unit Working States
 
 | State       | Meaning                                      | Enters when                        | Exits when                          |
 |-------------|----------------------------------------------|------------------------------------|-------------------------------------|
-| draft       | Intent captured, not yet agent-executable     | GitHub issue created without full criteria | Criteria, scope, and size filled in |
+| draft       | Intent captured, not yet agent-executable     | Tracker record created without full criteria | Criteria, scope, and size filled in |
 | ready       | Agent-executable and unblocked                | All fields complete, deps closed   | Session claims it                   |
 | in-progress | Active session is working on it               | Session declares goal against it   | Session closes or blocks            |
 | blocked     | Waiting on one or more open dependencies      | Dependency discovered or reopened  | All blocking work-units closed      |

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -177,9 +177,10 @@ write files, construct filenames, or supply `work_unit`.
 ### session-close
 
 1. Reach a stable checkpoint (done increment or explicit WIP note).
-2. Update work-unit state and leave a concise progress comment on the GitHub issue.
+2. Update work-unit state and leave a concise progress comment on the active
+   forge tracker record.
 3. Record decisions, blockers, and the exact next step.
-4. Ensure any follow-up work is represented as GitHub issue(s).
+4. Ensure any follow-up work is represented in the active forge tracker.
 5. Sync workspace and close.
 
 ## Key Terms

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -137,10 +137,12 @@ Set up the repository-local workspace for the selected work.
    Slug is the work-unit title — lowercase, hyphenated, truncated to 40
    chars. The `issue-` prefix on linked branch names is a repository-local
    naming convention; `<N>` encodes the work-unit's tracker identifier.
-3. Resolve referenced work-units. Runa injects the active work-unit; when
-   it references other work-units as dependencies or context, prefer runa's
-   injected context. Where runa does not carry a referenced work-unit, fall
-   back to the tracker surface (`gh issue view`) if available.
+3. Resolve referenced work-units from injected session context. Runa injects
+   the active work-unit and any referenced work-units needed as dependencies or
+   context. If a referenced work-unit is missing from injected input, halt with
+   a substrate-failure signal. Missing injected context is not benign absent
+   input: `take` does not attempt retrieval through a tracker surface and does
+   not proceed in a degraded state.
 
 #### Phase 3: Claim — produce the session capstone
 
@@ -198,10 +200,10 @@ Brief definitions for self-contained use. See
 
 ## Operating Principles
 
-- **GitHub issue tracker is the source of truth.** Planning state lives in forge
-  issues, not local task trackers or agent memory. Sessions end; the graph
-  doesn't. GitHub issue status and comments reflect actual implementation state —
-  inaccurate state is planning debt.
+- **Forge tracker is the source of truth.** Planning state lives in work-unit
+  records in the active forge, not local task trackers or agent memory.
+  Sessions end; the graph doesn't. Forge tracker state and comments reflect
+  actual implementation state — inaccurate state is planning debt.
 - **Direction over prediction.** Capture starting direction at session open.
   Goals sharpen through implementation — rigid upfront done conditions are
   premature precision. The closing handoff matters more than the opening
@@ -226,7 +228,7 @@ Brief definitions for self-contained use. See
 - `recency-drift`: picking last-touched work instead of highest leverage.
 - `scope-creep`: crossing concern boundaries mid-session.
 - `blocker-bypass`: beginning blocked work anyway.
-- `state-lag`: GitHub issue tracker not reflecting real implementation state.
+- `state-lag`: forge tracker state not reflecting real implementation state.
 - `open-loop-close`: ending session without a concrete next step.
 - `skip-preparation`: jumping from selection to implementation without setting
   up a feature branch — loses workspace isolation and makes `submit` harder.

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -528,6 +528,27 @@ name = "survey"
         self.assertFalse(results[0].passed)
         self.assertIn("protocol `survey` leaks forge-specific token `gh`", " ".join(results[0].errors))
 
+    def test_manifest_forge_leakage_scan_covers_take_protocol(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "manifest.toml"
+            manifest.write_text(
+                """
+[[protocols]]
+name = "take"
+""".lstrip(),
+                encoding="utf-8",
+            )
+            protocol = root / "protocols" / "take"
+            protocol.mkdir(parents=True)
+            (protocol / "PROTOCOL.md").write_text("Fallback: run `gh issue view 353`.\n", encoding="utf-8")
+
+            results = run_conformance([manifest])
+
+        self.assertEqual("C-5 manifest", results[0].category)
+        self.assertFalse(results[0].passed)
+        self.assertIn("protocol `take` leaks forge-specific token `gh`", " ".join(results[0].errors))
+
     def test_malformed_directory_manifest_does_not_abort_sibling_registry_checks(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -39,7 +39,6 @@ FORGE_LEAKAGE_TOKEN_PATTERNS = {
     "git.sr.ht": r"git[.]sr[.]ht",
     "todo.sr.ht": r"todo[.]sr[.]ht",
 }
-TEMPORARY_FORGE_LEAKAGE_EXEMPTIONS = {"take"}
 
 
 @dataclass(frozen=True)
@@ -406,8 +405,6 @@ def _manifest_protocol_leakage_errors(
     for protocol_index, protocol in protocol_entries:
         name = protocol.get("name")
         if not isinstance(name, str):
-            continue
-        if name in TEMPORARY_FORGE_LEAKAGE_EXEMPTIONS:
             continue
         protocol_body = root / "protocols" / name / "PROTOCOL.md"
         if not protocol_body.exists():


### PR DESCRIPTION
## Summary

- Removes the forge-specific tracker lookup fallback from `take`.
- Makes missing injected referenced work-unit context a substrate-failure halt instead of degraded execution.
- Re-enables C-5 forge-leakage scanning for registered `take` protocol bodies.

## Changes

- Updates `protocols/take/PROTOCOL.md` to resolve referenced work-units only from runa-injected session context.
- Removes the temporary conformance exemption for `take`.
- Adds a regression test proving `take` protocol leaks are caught.
- Records the user-visible methodology fix in `CHANGELOG.md`.

## GitHub Issue(s)

Closes #353

## Test plan

- `python -m unittest tests.test_conformance`
- `python -m tooling.conformance`
- `git diff --check`
