### PR TITLE
refactor(resolution): rename forge type contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `git am --3way`, and `reflect-disposition` records tracker-ticket state
   under `forge_tag = "sourcehut"`.
 - Runtime forge-operation resolution for C-3 mechanics: `groundwork-mechanic`
-  reads `GROUNDWORK_FORGE` with a `github` default, resolves invariant
+  reads `GROUNDWORK_FORGE_TYPE` with a `github` default, resolves invariant
   operations to exactly one active-forge mechanic, invokes mechanics through
   environment-parameterized shell bodies, installs a runtime resolver bundle
   for interactive sessions, and adds GitHub/SourceHut `close-out` mechanics

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ When `manifest.toml`, `mechanics/`, and the forge-operation resolver are
 present, the installer also projects a managed runtime bundle under
 `~/.groundwork/`. The bundle contains the manifest, mechanic library, resolver
 module, and `bin/groundwork-mechanic`, so installed protocol sessions can
-resolve forge-invariant operations through the active `GROUNDWORK_FORGE`
+resolve forge-invariant operations through the active `GROUNDWORK_FORGE_TYPE`
 configuration without reaching back into the source checkout. Installed
 protocol copies reference the managed resolver path directly, so users do not
 need to add `~/.groundwork/bin` to `PATH`.

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from tooling.forge_operations import (
     ForgeOperationError,
-    active_forge,
+    active_forge_type,
     inspect_invocation,
     render_shell_invocation,
     resolve_operation,
@@ -66,21 +66,48 @@ class ForgeOperationTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-    def test_active_forge_defaults_to_github_when_no_env_or_override_exists(self) -> None:
-        self.assertEqual("github", active_forge({}, None))
+    def test_active_forge_type_defaults_to_github_when_no_env_or_override_exists(self) -> None:
+        self.assertEqual("github", active_forge_type({}, None))
 
-    def test_active_forge_uses_explicit_override_before_environment(self) -> None:
-        self.assertEqual("sourcehut", active_forge({"GROUNDWORK_FORGE": "github"}, "sourcehut"))
+    def test_active_forge_type_uses_explicit_override_before_environment(self) -> None:
+        self.assertEqual("sourcehut", active_forge_type({"GROUNDWORK_FORGE_TYPE": "github"}, "sourcehut"))
+
+    def test_active_forge_type_uses_groundwork_forge_type_environment(self) -> None:
+        self.assertEqual("sourcehut", active_forge_type({"GROUNDWORK_FORGE_TYPE": "sourcehut"}, None))
 
     def test_resolve_operation_returns_exact_active_forge_mechanic(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_methodology(root)
 
-            mechanic = resolve_operation(root, "close-out", forge="sourcehut")
+            mechanic = resolve_operation(root, "close-out", forge_type="sourcehut")
 
         self.assertEqual("close-out", mechanic["name"])
         self.assertEqual("sourcehut", mechanic["forge_tag"])
+
+    def test_cli_resolve_accepts_forge_type_override(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_methodology(root)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "--forge-type",
+                    "sourcehut",
+                    "resolve",
+                    "close-out",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("close-out[sourcehut]\n", result.stdout)
 
     def test_resolve_operation_rejects_duplicate_active_forge_mechanics(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -88,7 +115,7 @@ class ForgeOperationTests(unittest.TestCase):
             self.write_methodology(root, duplicate=True)
 
             with self.assertRaises(ForgeOperationError) as context:
-                resolve_operation(root, "close-out", forge="github")
+                resolve_operation(root, "close-out", forge_type="github")
 
         self.assertIn("close-out", str(context.exception))
         self.assertIn("github", str(context.exception))

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -245,7 +245,7 @@ class GroundworkInstallTests(unittest.TestCase):
         resolved = run(
             [str(resolver), "resolve", "close-out"],
             install.runtime_root(),
-            env={**os.environ, "GROUNDWORK_FORGE": "sourcehut"},
+            env={**os.environ, "GROUNDWORK_FORGE_TYPE": "sourcehut"},
         )
         assert_success(self, resolved)
         self.assertEqual("close-out[sourcehut]\n", resolved.stdout)
@@ -292,7 +292,7 @@ class GroundworkInstallTests(unittest.TestCase):
             resolved = run(
                 argv,
                 install.runtime_root(),
-                env={**os.environ, "GROUNDWORK_FORGE": "sourcehut", "PATH": "/usr/bin:/bin"},
+                env={**os.environ, "GROUNDWORK_FORGE_TYPE": "sourcehut", "PATH": "/usr/bin:/bin"},
             )
             assert_success(self, resolved)
             self.assertEqual("close-out[sourcehut]\n", resolved.stdout)
@@ -329,7 +329,7 @@ class GroundworkInstallTests(unittest.TestCase):
         resolved = run(
             argv,
             install.runtime_root(),
-            env={**os.environ, "GROUNDWORK_FORGE": "sourcehut", "PATH": "/usr/bin:/bin"},
+            env={**os.environ, "GROUNDWORK_FORGE_TYPE": "sourcehut", "PATH": "/usr/bin:/bin"},
         )
         assert_success(self, resolved)
         self.assertEqual("close-out[sourcehut]\n", resolved.stdout)

--- a/tooling/forge_operations.py
+++ b/tooling/forge_operations.py
@@ -15,33 +15,33 @@ class ForgeOperationError(ValueError):
     pass
 
 
-def active_forge(environment: Mapping[str, str], override: str | None) -> str:
+def active_forge_type(environment: Mapping[str, str], override: str | None) -> str:
     if override:
         return override
-    return environment.get("GROUNDWORK_FORGE") or "github"
+    return environment.get("GROUNDWORK_FORGE_TYPE") or "github"
 
 
-def resolve_operation(root: Path | str, operation: str, *, forge: str | None = None) -> dict[str, Any]:
+def resolve_operation(root: Path | str, operation: str, *, forge_type: str | None = None) -> dict[str, Any]:
     root_path = Path(root)
     manifest = _load_toml(root_path / "manifest.toml")
-    selected_forge = active_forge(os.environ, forge)
+    selected_forge_type = active_forge_type(os.environ, forge_type)
     forge_tags = _manifest_names(manifest, "forge_tags")
-    if selected_forge not in forge_tags:
-        raise ForgeOperationError(f"forge `{selected_forge}` does not resolve in forge_tags")
+    if selected_forge_type not in forge_tags:
+        raise ForgeOperationError(f"forge type `{selected_forge_type}` does not resolve in forge_tags")
 
     operation_entry = _manifest_operation(manifest, operation)
-    declared_forges = operation_entry.get("forge_tags")
-    if not isinstance(declared_forges, list) or selected_forge not in declared_forges:
-        raise ForgeOperationError(f"operation `{operation}` is not bound for forge `{selected_forge}`")
+    declared_forge_types = operation_entry.get("forge_tags")
+    if not isinstance(declared_forge_types, list) or selected_forge_type not in declared_forge_types:
+        raise ForgeOperationError(f"operation `{operation}` is not bound for forge type `{selected_forge_type}`")
 
     matches = [
         mechanic
         for mechanic in _load_mechanics(root_path / "mechanics")
-        if mechanic.get("name") == operation and mechanic.get("forge_tag") == selected_forge
+        if mechanic.get("name") == operation and mechanic.get("forge_tag") == selected_forge_type
     ]
     if len(matches) != 1:
         raise ForgeOperationError(
-            f"operation `{operation}` for forge `{selected_forge}` resolves to {len(matches)} mechanics; expected exactly 1"
+            f"operation `{operation}` for forge type `{selected_forge_type}` resolves to {len(matches)} mechanics; expected exactly 1"
         )
     return matches[0]
 
@@ -88,7 +88,7 @@ def run_invocation(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Resolve and invoke Groundwork forge operations.")
     parser.add_argument("--root", default=str(ROOT), help="Groundwork methodology root. Defaults to this checkout.")
-    parser.add_argument("--forge", help="Active forge override. Defaults to GROUNDWORK_FORGE, then github.")
+    parser.add_argument("--forge-type", help="Active forge type override. Defaults to GROUNDWORK_FORGE_TYPE, then github.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     resolve_parser = subparsers.add_parser("resolve", help="Print the resolved mechanic path-equivalent name.")
@@ -110,7 +110,7 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
     try:
-        mechanic = resolve_operation(args.root, args.operation, forge=args.forge)
+        mechanic = resolve_operation(args.root, args.operation, forge_type=args.forge_type)
         if args.command == "resolve":
             print(f"{mechanic['name']}[{mechanic['forge_tag']}]")
             return 0


### PR DESCRIPTION
## Summary

- Renames the Groundwork consumer contract from `GROUNDWORK_FORGE` to `GROUNDWORK_FORGE_TYPE`.
- Renames the resolver helper and standalone override flag to the forge-type vocabulary, including `--forge-type`.
- Updates resolver tests, installed-runtime tests, README, and CHANGELOG while leaving the `forge_tag` matrix unchanged.

## Changes

- Reads the active forge type from `GROUNDWORK_FORGE_TYPE`, defaulting to `github` when absent.
- Updates `groundwork-mechanic` CLI override usage to `--forge-type`.
- Refreshes behavior coverage for environment resolution, explicit override precedence, CLI override handling, and installed resolver bundles.

## Landing Coordination

This PR is paired with tesserine/agentd#143. The two PRs must land together, or no agent sessions should run between merges. A mixed producer/consumer state can silently fall back to `github` because one side would use `GROUNDWORK_FORGE_TYPE` while the other still uses `GROUNDWORK_FORGE`.

## GitHub Issue(s)

Closes #360

Paired with tesserine/agentd#143.

## Test plan

- `python -m unittest discover -s tests`
- `python -m tooling.conformance`
- stale-symbol scan for old standalone `GROUNDWORK_FORGE`, `--forge`, and old resolver API surface
