### PR TITLE
Tracker-identity env contract (GROUNDWORK_* deployment values)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   environment-parameterized shell bodies, installs a runtime resolver bundle
   for interactive sessions, and adds GitHub/SourceHut `close-out` mechanics
   bound in the manifest matrix (closes #350).
+- `GROUNDWORK_*` deployment-identity contract documenting the atom variables a
+  forge session binds for deployment endpoint, owner/name, tracker ID, repo ID,
+  and active forge selection, with README discovery and the #363 composition
+  boundary (closes #362).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ configuration without reaching back into the source checkout. Installed
 protocol copies reference the managed resolver path directly, so users do not
 need to add `~/.groundwork/bin` to `PATH`.
 
+GROUNDWORK_* deployment identity is the atom set a forge session binds into
+that runtime surface: `GROUNDWORK_FORGE_TYPE`, `GROUNDWORK_FORGE_ENDPOINT`,
+`GROUNDWORK_FORGE_OWNER`, `GROUNDWORK_FORGE_NAME`,
+`GROUNDWORK_FORGE_TRACKER_ID`, and `GROUNDWORK_FORGE_REPO_ID`. See
+[`docs/architecture/forge-deployment-identity.md`](docs/architecture/forge-deployment-identity.md)
+for the contract and the boundary between atom binding and mechanic-parameter
+composition.
+
 Secret mechanic parameters must be bound from an environment variable rather
 than from `NAME=VALUE` argv bindings. For example, pass
 `--secret-env token=WEFORGE_OPERATOR_PAT` to bind a secret `token` parameter

--- a/docs/architecture/forge-deployment-identity.md
+++ b/docs/architecture/forge-deployment-identity.md
@@ -1,0 +1,56 @@
+# Forge Deployment Identity
+
+## Audience and Purpose
+
+This note is for interactive agents, runa-served agents, and operators binding
+Groundwork forge mechanics. It defines the `GROUNDWORK_*` deployment identity
+contract: the environment variables that identify the active forge deployment
+and the repository/tracker targets used by forge-tagged mechanics.
+
+The contract is an atom set, not a bundle of ready-made endpoint strings. Each
+variable stores one fact. Consumers derive composed values from those facts at
+the point of use so there is no second stored copy to keep synchronized.
+
+## Contract
+
+| Variable | Holds | Example | Forge-assigned? |
+|---|---|---|---|
+| `GROUNDWORK_FORGE_TYPE` | Forge selector used to choose the active forge-tagged mechanic. | `github` | No; this is configuration. |
+| `GROUNDWORK_FORGE_ENDPOINT` | Deployment host; service subdomains derive from it where the forge topology uses them. | `weforge.build` | No; this is configuration. |
+| `GROUNDWORK_FORGE_OWNER` | Tracker and repository owner handle. | `operator` | No; this is configuration. |
+| `GROUNDWORK_FORGE_NAME` | Tracker and repository name. | `weforge` | No; this is configuration. |
+| `GROUNDWORK_FORGE_TRACKER_ID` | Tracker integer ID for mechanics whose forge API requires an integer tracker identifier. | `4` | Yes; non-derivable and assigned by the forge. |
+| `GROUNDWORK_FORGE_REPO_ID` | Git repository integer ID for mechanics whose forge API requires an integer repository identifier. | `<repo Int>` | Yes; non-derivable and assigned by the forge. |
+
+`GROUNDWORK_FORGE_TYPE` already has runtime behavior in the forge-operation
+resolver: when no explicit override or environment value is present, the active
+forge type defaults to `github`. The other variables are deployment identity
+atoms supplied by the session environment or by runa session construction.
+
+The two integer IDs are explicit because they are forge-assigned and
+non-derivable. Do not infer them from owner, name, endpoint, or URL shape.
+
+## Derivation Boundary
+
+Issue #362 owns this atom contract only. It does not change mechanics and does
+not define the resolver logic that composes mechanic parameters.
+
+Issue #363 owns composition from atoms to mechanic parameters. For SourceHut,
+that follow-on work inherits these formulas:
+
+```text
+todo_query_url = https://todo.${GROUNDWORK_FORGE_ENDPOINT}/query
+git_query_url = https://git.${GROUNDWORK_FORGE_ENDPOINT}/query
+ssh_remote = git@git.${GROUNDWORK_FORGE_ENDPOINT}:~${GROUNDWORK_FORGE_OWNER}/${GROUNDWORK_FORGE_NAME}
+```
+
+GitHub composition differs because GitHub does not use the same per-service
+subdomain topology; that is #363 scope, not this contract.
+
+## Binding Modes
+
+Interactive sessions set these variables in the repo or session environment.
+Autonomous sessions receive them from runa at session construction. In both
+modes, consumers read the same atom names and derive composed values from those
+atoms instead of re-deriving forge access from memory or hardcoding deployment
+endpoints.

--- a/tests/test_forge_deployment_identity_docs.py
+++ b/tests/test_forge_deployment_identity_docs.py
@@ -1,0 +1,53 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+CONTRACT_DOC = ROOT / "docs" / "architecture" / "forge-deployment-identity.md"
+
+
+class ForgeDeploymentIdentityDocsTests(unittest.TestCase):
+    def test_readme_links_to_groundwork_deployment_identity_contract(self) -> None:
+        readme = README.read_text(encoding="utf-8")
+
+        self.assertIn("GROUNDWORK_* deployment identity", readme)
+        self.assertIn("docs/architecture/forge-deployment-identity.md", readme)
+
+    def test_deployment_identity_contract_documents_all_atoms(self) -> None:
+        body = CONTRACT_DOC.read_text(encoding="utf-8")
+
+        for variable in [
+            "GROUNDWORK_FORGE_TYPE",
+            "GROUNDWORK_FORGE_ENDPOINT",
+            "GROUNDWORK_FORGE_OWNER",
+            "GROUNDWORK_FORGE_NAME",
+            "GROUNDWORK_FORGE_TRACKER_ID",
+            "GROUNDWORK_FORGE_REPO_ID",
+        ]:
+            with self.subTest(variable=variable):
+                self.assertIn(variable, body)
+
+        self.assertIn("Forge-assigned?", body)
+        self.assertIn("non-derivable", body)
+        self.assertIn("github", body)
+        self.assertIn("weforge.build", body)
+        self.assertIn("operator", body)
+        self.assertIn("weforge", body)
+        self.assertIn("4", body)
+        self.assertIn("<repo Int>", body)
+
+    def test_deployment_identity_contract_assigns_composition_to_issue_363(self) -> None:
+        body = CONTRACT_DOC.read_text(encoding="utf-8")
+
+        self.assertIn("#363", body)
+        self.assertIn("todo_query_url = https://todo.${GROUNDWORK_FORGE_ENDPOINT}/query", body)
+        self.assertIn("git_query_url = https://git.${GROUNDWORK_FORGE_ENDPOINT}/query", body)
+        self.assertIn(
+            "ssh_remote = git@git.${GROUNDWORK_FORGE_ENDPOINT}:~${GROUNDWORK_FORGE_OWNER}/${GROUNDWORK_FORGE_NAME}",
+            body,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Documents the `GROUNDWORK_*` deployment-identity atom contract for forge sessions.
- Makes the contract discoverable from the README runtime/forge section.
- Captures the #363-owned SourceHut derivation formulas while keeping mechanics untouched.

## Changes

- Added `docs/architecture/forge-deployment-identity.md` with variable semantics, examples, and forge-assigned status.
- Updated README discovery text and CHANGELOG coverage for the new contract.
- Added regression coverage for the README link, atom table, and #363 derivation boundary.

## GitHub Issue(s)

Closes #362

## Test plan

- `python -m tooling.conformance`
- `python -m unittest discover -s tests`
- `git diff --exit-code -- mechanics`
- `git diff --check HEAD~1..HEAD`
