### PR TITLE
Tracker-identity env contract (GROUNDWORK_* deployment values)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   environment-parameterized shell bodies, installs a runtime resolver bundle
   for interactive sessions, and adds GitHub/SourceHut `close-out` mechanics
   bound in the manifest matrix (closes #350).
+- Tracker-identity environment contract: mechanics can declare
+  deployment-resolved parameters with `deployment_value`, and
+  `groundwork-mechanic` now supplies those parameters from `GROUNDWORK_*` atoms
+  while deriving SourceHut endpoints/remotes and GitHub repository identity
+  without call-site deployment bindings (closes #362).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- SourceHut deployment-value resolution now consults each mechanic's declared
+  `deployment_value` keys before reading environment atoms, so tracker-only
+  operations do not require unrelated repo identity atoms.
 - `take` now halts on missing injected referenced work-unit context instead of
   falling back to a forge-specific tracker lookup, and C-5 conformance now scans
   `take` for forge leakage with the rest of the registered protocol bodies

--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ than from `NAME=VALUE` argv bindings. For example, pass
 from the current process environment without placing the secret value in the
 resolver command line.
 
+Forge deployment identity is also supplied by environment contract, not by
+mechanic call-site bindings. Mechanics mark deployment-resolved parameters with
+`deployment_value`, and `groundwork-mechanic` derives those values from these
+atoms:
+
+| Variable | Holds | Example | Forge-assigned? |
+|---|---|---|---|
+| `GROUNDWORK_FORGE_TYPE` | active forge selector, defaulting to `github` | `sourcehut` | no |
+| `GROUNDWORK_FORGE_ENDPOINT` | deployment host used to derive service hosts | `weforge.build` | no |
+| `GROUNDWORK_FORGE_OWNER` | tracker/repo owner handle | `operator` | no |
+| `GROUNDWORK_FORGE_NAME` | tracker/repo name | `weforge` | no |
+| `GROUNDWORK_FORGE_TRACKER_ID` | tracker integer ID | `4` | yes |
+| `GROUNDWORK_FORGE_REPO_ID` | git repo integer ID | `42` | yes |
+
+For SourceHut, the resolver derives `todo_query_url` as
+`https://todo.<endpoint>/query`, `git_query_url` as
+`https://git.<endpoint>/query`, and `ssh_remote` as
+`git@git.<endpoint>:~<owner>/<name>`, while `tracker_id` and `repo_id` come
+directly from their atoms. For GitHub, it derives `repository` as
+`<owner>/<name>`. The atoms are the only deployment facts; composed endpoints
+and remotes are not separate configuration values.
+
 The source checkout must be clean and pinned at a tag or full commit SHA. The
 command refuses branch checkouts because a branch is a moving source. To update
 to a different pinned Groundwork version, check out that ref and run:

--- a/mechanics/github/apply-approved-change.toml
+++ b/mechanics/github/apply-approved-change.toml
@@ -10,6 +10,7 @@ examples = [
 name = "repository"
 purpose = "GitHub repository in OWNER/REPO form."
 required = true
+deployment_value = "repository"
 
 [[parameters]]
 name = "pr_number"

--- a/mechanics/github/close-out.toml
+++ b/mechanics/github/close-out.toml
@@ -10,6 +10,7 @@ examples = [
 name = "repository"
 purpose = "GitHub repository in OWNER/REPO form."
 required = true
+deployment_value = "repository"
 
 [[parameters]]
 name = "issue_number"

--- a/mechanics/github/deliver-change-proposal.toml
+++ b/mechanics/github/deliver-change-proposal.toml
@@ -10,6 +10,7 @@ examples = [
 name = "repository"
 purpose = "GitHub repository in OWNER/REPO form."
 required = true
+deployment_value = "repository"
 
 [[parameters]]
 name = "branch"

--- a/mechanics/github/reflect-disposition.toml
+++ b/mechanics/github/reflect-disposition.toml
@@ -10,6 +10,7 @@ examples = [
 name = "repository"
 purpose = "GitHub repository in OWNER/REPO form."
 required = true
+deployment_value = "repository"
 
 [[parameters]]
 name = "pr_number"

--- a/mechanics/sourcehut/apply-approved-change.toml
+++ b/mechanics/sourcehut/apply-approved-change.toml
@@ -35,6 +35,7 @@ required = true
 name = "ssh_remote"
 purpose = "SourceHut Git SSH remote used to fetch the proposal ref and push the applied target ref."
 required = true
+deployment_value = "ssh_remote"
 
 [[parameters]]
 name = "target_ref"

--- a/mechanics/sourcehut/close-out.toml
+++ b/mechanics/sourcehut/close-out.toml
@@ -10,6 +10,7 @@ examples = [
 name = "tracker_id"
 purpose = "todo.sr.ht tracker ID containing the work-unit ticket."
 required = true
+deployment_value = "tracker_id"
 
 [[parameters]]
 name = "ticket_id"
@@ -30,6 +31,7 @@ required = true
 name = "todo_query_url"
 purpose = "SourceHut todo GraphQL endpoint used for submitComment and updateTicketStatus."
 required = true
+deployment_value = "todo_query_url"
 
 [[parameters]]
 name = "token"

--- a/mechanics/sourcehut/deliver-change-proposal.toml
+++ b/mechanics/sourcehut/deliver-change-proposal.toml
@@ -25,11 +25,13 @@ required = true
 name = "repo_id"
 purpose = "SourceHut Git repository ID used by uploadArtifact."
 required = true
+deployment_value = "repo_id"
 
 [[parameters]]
 name = "ssh_remote"
 purpose = "SourceHut Git SSH remote receiving the stable proposal ref."
 required = true
+deployment_value = "ssh_remote"
 
 [[parameters]]
 name = "proposal_ref"
@@ -50,6 +52,7 @@ required = true
 name = "git_query_url"
 purpose = "SourceHut Git GraphQL endpoint used for uploadArtifact."
 required = true
+deployment_value = "git_query_url"
 
 [[parameters]]
 name = "token"

--- a/mechanics/sourcehut/reflect-disposition.toml
+++ b/mechanics/sourcehut/reflect-disposition.toml
@@ -10,6 +10,7 @@ examples = [
 name = "tracker_id"
 purpose = "todo.sr.ht tracker ID containing the work-unit ticket."
 required = true
+deployment_value = "tracker_id"
 
 [[parameters]]
 name = "ticket_id"
@@ -30,6 +31,7 @@ required = true
 name = "todo_query_url"
 purpose = "SourceHut todo GraphQL endpoint used for submitComment and updateTicketStatus."
 required = true
+deployment_value = "todo_query_url"
 
 [[parameters]]
 name = "token"

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -13,7 +13,10 @@ ADR-0002. It is validated by `tooling.mechanics`, not declared as a runtime
 artifact type in `manifest.toml`. Mechanic parameters are shell environment
 variable names because invocation data is supplied through the child process
 environment; secret parameters use `secret = true` and must remain values, not
-rendered command text.
+rendered command text. Deployment-resolved parameters use `deployment_value` to
+declare which forge deployment value the resolver supplies from the
+`GROUNDWORK_*` environment contract; the resolver consults this declaration
+rather than inferring parameter categories from names.
 
 `change-proposal.schema.json`, `change-approved.schema.json`, and
 `change-needs-revision.schema.json` are the C-4 artifact schemas for the

--- a/schemas/mechanic.schema.json
+++ b/schemas/mechanic.schema.json
@@ -71,6 +71,17 @@
         "secret": {
           "type": "boolean"
         },
+        "deployment_value": {
+          "type": "string",
+          "enum": [
+            "repository",
+            "todo_query_url",
+            "git_query_url",
+            "ssh_remote",
+            "tracker_id",
+            "repo_id"
+          ]
+        },
         "schema_ref": {
           "type": "string",
           "minLength": 1,

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -239,6 +239,166 @@ class ForgeOperationTests(unittest.TestCase):
         self.assertNotIn(secret, child_argv)
         self.assertEqual(secret, exposed_secret)
 
+    def test_cli_resolves_declared_deployment_value_without_parameter_name_knowledge(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_deployment_probe_methodology(root)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "--forge-type",
+                    "sourcehut",
+                    "run",
+                    "probe",
+                ],
+                env={
+                    **os.environ,
+                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
+                    "GROUNDWORK_FORGE_OWNER": "operator",
+                    "GROUNDWORK_FORGE_NAME": "weforge",
+                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                    "GROUNDWORK_FORGE_REPO_ID": "42",
+                },
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("42\n", result.stdout)
+
+    def test_cli_resolves_sourcehut_deployment_values_from_groundwork_atoms(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_sourcehut_deployment_probe_methodology(root)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "--forge-type",
+                    "sourcehut",
+                    "run",
+                    "probe",
+                ],
+                env={
+                    **os.environ,
+                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
+                    "GROUNDWORK_FORGE_OWNER": "operator",
+                    "GROUNDWORK_FORGE_NAME": "weforge",
+                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                    "GROUNDWORK_FORGE_REPO_ID": "42",
+                },
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            [
+                "https://todo.weforge.build/query",
+                "https://git.weforge.build/query",
+                "git@git.weforge.build:~operator/weforge",
+                "4",
+                "42",
+            ],
+            result.stdout.strip().splitlines(),
+        )
+
+    def test_cli_names_missing_sourcehut_deployment_atom(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_sourcehut_deployment_probe_methodology(root)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "--forge-type",
+                    "sourcehut",
+                    "run",
+                    "probe",
+                ],
+                env={
+                    **os.environ,
+                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
+                    "GROUNDWORK_FORGE_OWNER": "operator",
+                    "GROUNDWORK_FORGE_NAME": "weforge",
+                    "GROUNDWORK_FORGE_REPO_ID": "42",
+                },
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("GROUNDWORK_FORGE_TRACKER_ID", result.stderr)
+
+    def test_cli_resolves_github_repository_from_groundwork_atoms_with_default_forge_type(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_github_deployment_probe_methodology(root)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "run",
+                    "probe",
+                ],
+                env={
+                    **os.environ,
+                    "GROUNDWORK_FORGE_OWNER": "tesserine",
+                    "GROUNDWORK_FORGE_NAME": "groundwork",
+                },
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("tesserine/groundwork\n", result.stdout)
+
+    def test_cli_rejects_caller_supplied_deployment_value(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_github_deployment_probe_methodology(root)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "run",
+                    "probe",
+                    "repository=attacker/repo",
+                ],
+                env={
+                    **os.environ,
+                    "GROUNDWORK_FORGE_OWNER": "tesserine",
+                    "GROUNDWORK_FORGE_NAME": "groundwork",
+                },
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("deployment-resolved parameter(s)", result.stderr)
+        self.assertIn("repository", result.stderr)
+
     def write_secret_probe_methodology(self, root: Path, invocation: str) -> None:
         (root / "manifest.toml").write_text(
             textwrap.dedent(
@@ -268,6 +428,147 @@ class ForgeOperationTests(unittest.TestCase):
                 purpose = "Secret token."
                 required = true
                 secret = true
+
+                [outcome]
+                description = "Printed."
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+
+    def write_deployment_probe_methodology(self, root: Path) -> None:
+        (root / "manifest.toml").write_text(
+            textwrap.dedent(
+                """
+                [[forge_tags]]
+                name = "github"
+
+                [[forge_tags]]
+                name = "sourcehut"
+
+                [[mechanics]]
+                name = "probe"
+                forge_tags = ["sourcehut"]
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+        (root / "mechanics" / "sourcehut").mkdir(parents=True, exist_ok=True)
+        (root / "mechanics" / "sourcehut" / "probe.toml").write_text(
+            textwrap.dedent(
+                """
+                name = "probe"
+                purpose = "Probe deployment-value resolution."
+                forge_tag = "sourcehut"
+                default_invocation = 'printf "%s\\n" "$upload_repo_number"'
+                examples = ['printf "%s\\n" "$upload_repo_number"']
+
+                [[parameters]]
+                name = "upload_repo_number"
+                purpose = "Repo ID under a deliberately non-canonical parameter name."
+                required = true
+                deployment_value = "repo_id"
+
+                [outcome]
+                description = "Printed."
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+
+    def write_sourcehut_deployment_probe_methodology(self, root: Path) -> None:
+        (root / "manifest.toml").write_text(
+            textwrap.dedent(
+                """
+                [[forge_tags]]
+                name = "github"
+
+                [[forge_tags]]
+                name = "sourcehut"
+
+                [[mechanics]]
+                name = "probe"
+                forge_tags = ["sourcehut"]
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+        (root / "mechanics" / "sourcehut").mkdir(parents=True, exist_ok=True)
+        (root / "mechanics" / "sourcehut" / "probe.toml").write_text(
+            textwrap.dedent(
+                """
+                name = "probe"
+                purpose = "Probe SourceHut deployment-value resolution."
+                forge_tag = "sourcehut"
+                default_invocation = 'printf "%s\\n%s\\n%s\\n%s\\n%s\\n" "$todo_url" "$git_url" "$remote" "$tracker" "$repo"'
+                examples = ['printf "%s\\n" "$remote"']
+
+                [[parameters]]
+                name = "todo_url"
+                purpose = "Todo query URL."
+                required = true
+                deployment_value = "todo_query_url"
+
+                [[parameters]]
+                name = "git_url"
+                purpose = "Git query URL."
+                required = true
+                deployment_value = "git_query_url"
+
+                [[parameters]]
+                name = "remote"
+                purpose = "Git SSH remote."
+                required = true
+                deployment_value = "ssh_remote"
+
+                [[parameters]]
+                name = "tracker"
+                purpose = "Tracker ID."
+                required = true
+                deployment_value = "tracker_id"
+
+                [[parameters]]
+                name = "repo"
+                purpose = "Repo ID."
+                required = true
+                deployment_value = "repo_id"
+
+                [outcome]
+                description = "Printed."
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+
+    def write_github_deployment_probe_methodology(self, root: Path) -> None:
+        (root / "manifest.toml").write_text(
+            textwrap.dedent(
+                """
+                [[forge_tags]]
+                name = "github"
+
+                [[mechanics]]
+                name = "probe"
+                forge_tags = ["github"]
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+        (root / "mechanics" / "github").mkdir(parents=True, exist_ok=True)
+        (root / "mechanics" / "github" / "probe.toml").write_text(
+            textwrap.dedent(
+                """
+                name = "probe"
+                purpose = "Probe GitHub deployment-value resolution."
+                forge_tag = "github"
+                default_invocation = 'printf "%s\\n" "$repository"'
+                examples = ['printf "%s\\n" "$repository"']
+
+                [[parameters]]
+                name = "repository"
+                purpose = "GitHub repository."
+                required = true
+                deployment_value = "repository"
 
                 [outcome]
                 description = "Printed."

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -312,6 +312,38 @@ class ForgeOperationTests(unittest.TestCase):
             result.stdout.strip().splitlines(),
         )
 
+    def test_cli_resolves_only_declared_sourcehut_deployment_values(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_sourcehut_tracker_probe_methodology(root)
+            environment = {
+                **os.environ,
+                "GROUNDWORK_FORGE_TYPE": "sourcehut",
+                "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
+                "GROUNDWORK_FORGE_OWNER": "operator",
+                "GROUNDWORK_FORGE_NAME": "weforge",
+                "GROUNDWORK_FORGE_TRACKER_ID": "4",
+            }
+            environment.pop("GROUNDWORK_FORGE_REPO_ID", None)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "run",
+                    "probe",
+                ],
+                env=environment,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(["https://todo.weforge.build/query", "4"], result.stdout.strip().splitlines())
+
     def test_cli_names_missing_sourcehut_deployment_atom(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -532,6 +564,49 @@ class ForgeOperationTests(unittest.TestCase):
                 purpose = "Repo ID."
                 required = true
                 deployment_value = "repo_id"
+
+                [outcome]
+                description = "Printed."
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+
+    def write_sourcehut_tracker_probe_methodology(self, root: Path) -> None:
+        (root / "manifest.toml").write_text(
+            textwrap.dedent(
+                """
+                [[forge_tags]]
+                name = "sourcehut"
+
+                [[mechanics]]
+                name = "probe"
+                forge_tags = ["sourcehut"]
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+        (root / "mechanics" / "sourcehut").mkdir(parents=True, exist_ok=True)
+        (root / "mechanics" / "sourcehut" / "probe.toml").write_text(
+            textwrap.dedent(
+                """
+                name = "probe"
+                purpose = "Probe tracker-only SourceHut deployment-value resolution."
+                forge_tag = "sourcehut"
+                default_invocation = 'printf "%s\\n%s\\n" "$todo_url" "$tracker"'
+                examples = ['printf "%s\\n" "$tracker"']
+
+                [[parameters]]
+                name = "todo_url"
+                purpose = "Todo query URL."
+                required = true
+                deployment_value = "todo_query_url"
+
+                [[parameters]]
+                name = "tracker"
+                purpose = "Tracker ID."
+                required = true
+                deployment_value = "tracker_id"
 
                 [outcome]
                 description = "Printed."

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -49,6 +49,49 @@ class MechanicTests(unittest.TestCase):
 
         validate_mechanic(mechanic)
 
+    def test_schema_accepts_deployment_value_parameter_metadata(self) -> None:
+        mechanic = {
+            "name": "sourcehut-upload",
+            "purpose": "Upload to a configured forge repository.",
+            "default_invocation": 'printf "%s\\n" "$repo_number"',
+            "examples": ['printf "%s\\n" "$repo_number"'],
+            "parameters": [
+                {
+                    "name": "repo_number",
+                    "purpose": "Configured forge repository ID.",
+                    "required": True,
+                    "deployment_value": "repo_id",
+                }
+            ],
+            "outcome": {"description": "Printed."},
+        }
+
+        validate_mechanic(mechanic)
+
+    def test_schema_rejects_secret_deployment_value_parameter_conflict(self) -> None:
+        mechanic = {
+            "name": "sourcehut-upload",
+            "purpose": "Upload to a configured forge repository.",
+            "default_invocation": 'printf "%s\\n" "$repo_number"',
+            "examples": ['printf "%s\\n" "$repo_number"'],
+            "parameters": [
+                {
+                    "name": "repo_number",
+                    "purpose": "Configured forge repository ID.",
+                    "required": True,
+                    "secret": True,
+                    "deployment_value": "repo_id",
+                }
+            ],
+            "outcome": {"description": "Printed."},
+        }
+
+        with self.assertRaises(MechanicError) as context:
+            validate_mechanic(mechanic)
+
+        self.assertIn("parameters/0/deployment_value", context.exception.paths)
+        self.assertIn("must not also be secret", str(context.exception))
+
     def test_invocation_rejects_bare_placeholder_parameters(self) -> None:
         mechanic = {
             "name": "git-push",

--- a/tests/test_reference_arc_topology.py
+++ b/tests/test_reference_arc_topology.py
@@ -135,6 +135,36 @@ class ReferenceArcTopologyTests(unittest.TestCase):
                 self.assertIn(forge_tag, manifest_mechanics[operation]["forge_tags"])
                 self.assertEqual(1, sum(1 for mechanic in forge_mechanics if mechanic["name"] == operation))
 
+    def test_reference_arc_mechanics_declare_deployment_resolved_parameters(self) -> None:
+        expected = {
+            ("github", "deliver-change-proposal"): {"repository": "repository"},
+            ("github", "apply-approved-change"): {"repository": "repository"},
+            ("github", "reflect-disposition"): {"repository": "repository"},
+            ("github", "close-out"): {"repository": "repository"},
+            ("sourcehut", "deliver-change-proposal"): {
+                "repo_id": "repo_id",
+                "ssh_remote": "ssh_remote",
+                "git_query_url": "git_query_url",
+            },
+            ("sourcehut", "apply-approved-change"): {"ssh_remote": "ssh_remote"},
+            ("sourcehut", "reflect-disposition"): {
+                "tracker_id": "tracker_id",
+                "todo_query_url": "todo_query_url",
+            },
+            ("sourcehut", "close-out"): {
+                "tracker_id": "tracker_id",
+                "todo_query_url": "todo_query_url",
+            },
+        }
+
+        for (forge_tag, operation), deployment_values in expected.items():
+            with self.subTest(forge_tag=forge_tag, operation=operation):
+                mechanic = mechanic_for_forge(forge_tag, operation)
+                parameters = {parameter["name"]: parameter for parameter in mechanic["parameters"]}
+                for parameter_name, deployment_value in deployment_values.items():
+                    self.assertEqual(deployment_value, parameters[parameter_name].get("deployment_value"))
+                    self.assertTrue(parameters[parameter_name]["required"])
+
     def test_sourcehut_apply_mechanic_uses_proposal_ref_and_tree_equality_not_commit_identity(self) -> None:
         apply = mechanic_for_forge("sourcehut", "apply-approved-change")
         invocation = apply["default_invocation"]

--- a/tooling/forge_operations.py
+++ b/tooling/forge_operations.py
@@ -55,13 +55,20 @@ def inspect_invocation(mechanic: Mapping[str, Any], values: Mapping[str, str]) -
 
 def render_shell_invocation(mechanic: Mapping[str, Any], values: Mapping[str, str]) -> tuple[str, dict[str, str]]:
     parameters = _parameters(mechanic)
-    missing = [name for name, parameter in parameters.items() if parameter.get("required") and name not in values]
+    deployment_values = _deployment_parameter_values(mechanic, os.environ)
+    provided_deployment_values = sorted(set(values) & set(deployment_values))
+    if provided_deployment_values:
+        raise ForgeOperationError(
+            f"deployment-resolved parameter(s) must come from GROUNDWORK_*: {', '.join(provided_deployment_values)}"
+        )
+    resolved_values = {**values, **deployment_values}
+    missing = [name for name, parameter in parameters.items() if parameter.get("required") and name not in resolved_values]
     if missing:
         raise ForgeOperationError(f"missing required parameter(s): {', '.join(sorted(missing))}")
-    unknown = sorted(set(values) - set(parameters))
+    unknown = sorted(set(resolved_values) - set(parameters))
     if unknown:
         raise ForgeOperationError(f"unknown parameter(s): {', '.join(unknown)}")
-    return _invocation_body(mechanic), {name: str(value) for name, value in values.items()}
+    return _invocation_body(mechanic), {name: str(value) for name, value in resolved_values.items()}
 
 
 def run_invocation(
@@ -176,6 +183,60 @@ def _parameters(mechanic: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
 
 def _secret_parameters(mechanic: Mapping[str, Any]) -> set[str]:
     return {name for name, parameter in _parameters(mechanic).items() if parameter.get("secret") is True}
+
+
+def _deployment_parameters(mechanic: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        name: str(parameter["deployment_value"])
+        for name, parameter in _parameters(mechanic).items()
+        if isinstance(parameter.get("deployment_value"), str)
+    }
+
+
+def _deployment_parameter_values(
+    mechanic: Mapping[str, Any],
+    environment: Mapping[str, str],
+) -> dict[str, str]:
+    deployments = _deployment_parameters(mechanic)
+    if not deployments:
+        return {}
+    forge_type = mechanic.get("forge_tag")
+    if not isinstance(forge_type, str):
+        raise ForgeOperationError("deployment-resolved parameters require mechanic forge_tag")
+    resolved = _resolved_deployment_values(forge_type, environment)
+    values: dict[str, str] = {}
+    for name, deployment_value in deployments.items():
+        if deployment_value not in resolved:
+            raise ForgeOperationError(
+                f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
+            )
+        values[name] = resolved[deployment_value]
+    return values
+
+
+def _resolved_deployment_values(forge_type: str, environment: Mapping[str, str]) -> dict[str, str]:
+    owner = _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
+    name = _required_environment(environment, "GROUNDWORK_FORGE_NAME")
+    if forge_type == "github":
+        return {"repository": f"{owner}/{name}"}
+    if forge_type == "sourcehut":
+        endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
+        return {
+            "repository": f"{owner}/{name}",
+            "todo_query_url": f"https://todo.{endpoint}/query",
+            "git_query_url": f"https://git.{endpoint}/query",
+            "ssh_remote": f"git@git.{endpoint}:~{owner}/{name}",
+            "tracker_id": _required_environment(environment, "GROUNDWORK_FORGE_TRACKER_ID"),
+            "repo_id": _required_environment(environment, "GROUNDWORK_FORGE_REPO_ID"),
+        }
+    raise ForgeOperationError(f"forge type `{forge_type}` does not support deployment identity")
+
+
+def _required_environment(environment: Mapping[str, str], name: str) -> str:
+    value = environment.get(name)
+    if value is None or value == "":
+        raise ForgeOperationError(f"missing required deployment identity atom `{name}`")
+    return value
 
 
 def _invocation_body(mechanic: Mapping[str, Any]) -> str:

--- a/tooling/forge_operations.py
+++ b/tooling/forge_operations.py
@@ -203,32 +203,60 @@ def _deployment_parameter_values(
     forge_type = mechanic.get("forge_tag")
     if not isinstance(forge_type, str):
         raise ForgeOperationError("deployment-resolved parameters require mechanic forge_tag")
-    resolved = _resolved_deployment_values(forge_type, environment)
+    resolved = _resolved_deployment_values(forge_type, set(deployments.values()), environment)
     values: dict[str, str] = {}
     for name, deployment_value in deployments.items():
-        if deployment_value not in resolved:
-            raise ForgeOperationError(
-                f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
-            )
         values[name] = resolved[deployment_value]
     return values
 
 
-def _resolved_deployment_values(forge_type: str, environment: Mapping[str, str]) -> dict[str, str]:
-    owner = _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
-    name = _required_environment(environment, "GROUNDWORK_FORGE_NAME")
+def _resolved_deployment_values(
+    forge_type: str,
+    deployment_values: set[str],
+    environment: Mapping[str, str],
+) -> dict[str, str]:
+    return {
+        deployment_value: _resolve_deployment_value(forge_type, deployment_value, environment)
+        for deployment_value in deployment_values
+    }
+
+
+def _resolve_deployment_value(
+    forge_type: str,
+    deployment_value: str,
+    environment: Mapping[str, str],
+) -> str:
     if forge_type == "github":
-        return {"repository": f"{owner}/{name}"}
+        if deployment_value == "repository":
+            owner = _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
+            name = _required_environment(environment, "GROUNDWORK_FORGE_NAME")
+            return f"{owner}/{name}"
+        raise ForgeOperationError(
+            f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
+        )
     if forge_type == "sourcehut":
-        endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
-        return {
-            "repository": f"{owner}/{name}",
-            "todo_query_url": f"https://todo.{endpoint}/query",
-            "git_query_url": f"https://git.{endpoint}/query",
-            "ssh_remote": f"git@git.{endpoint}:~{owner}/{name}",
-            "tracker_id": _required_environment(environment, "GROUNDWORK_FORGE_TRACKER_ID"),
-            "repo_id": _required_environment(environment, "GROUNDWORK_FORGE_REPO_ID"),
-        }
+        if deployment_value == "repository":
+            owner = _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
+            name = _required_environment(environment, "GROUNDWORK_FORGE_NAME")
+            return f"{owner}/{name}"
+        if deployment_value == "todo_query_url":
+            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
+            return f"https://todo.{endpoint}/query"
+        if deployment_value == "git_query_url":
+            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
+            return f"https://git.{endpoint}/query"
+        if deployment_value == "ssh_remote":
+            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
+            owner = _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
+            name = _required_environment(environment, "GROUNDWORK_FORGE_NAME")
+            return f"git@git.{endpoint}:~{owner}/{name}"
+        if deployment_value == "tracker_id":
+            return _required_environment(environment, "GROUNDWORK_FORGE_TRACKER_ID")
+        if deployment_value == "repo_id":
+            return _required_environment(environment, "GROUNDWORK_FORGE_REPO_ID")
+        raise ForgeOperationError(
+            f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
+        )
     raise ForgeOperationError(f"forge type `{forge_type}` does not support deployment identity")
 
 

--- a/tooling/mechanics.py
+++ b/tooling/mechanics.py
@@ -47,6 +47,8 @@ def validate_mechanic(mechanic: dict[str, Any], registry: MechanicRegistry | Non
     errors: list[tuple[str, str]] = []
     errors.extend(_schema_errors(mechanic))
     if not errors:
+        errors.extend(_parameter_category_errors(mechanic))
+    if not errors:
         errors.extend(_invocation_errors(mechanic))
     if registry is not None and not errors:
         errors.extend(_registry_errors(mechanic, registry))
@@ -67,6 +69,19 @@ def _schema_errors(mechanic: dict[str, Any]) -> list[tuple[str, str]]:
             path = f"{path}/{missing}" if path else missing
         errors.append((path or "<root>", error.message))
 
+    return errors
+
+
+def _parameter_category_errors(mechanic: dict[str, Any]) -> list[tuple[str, str]]:
+    errors: list[tuple[str, str]] = []
+    for parameter_index, parameter in enumerate(mechanic["parameters"]):
+        if parameter.get("secret") is True and "deployment_value" in parameter:
+            errors.append(
+                (
+                    f"parameters/{parameter_index}/deployment_value",
+                    "deployment-resolved parameter must not also be secret",
+                )
+            )
     return errors
 
 


### PR DESCRIPTION
## Summary

- Adds `deployment_value` metadata so mechanics declare which parameters are resolver-supplied.
- Populates declared deployment parameters from `GROUNDWORK_*` atoms for GitHub and SourceHut.
- Documents the environment contract and guards the behavior with resolver, schema, and reference-arc tests.

## Changes

- Extends mechanic schema and validation for deployment-resolved parameters.
- Updates `groundwork-mechanic` invocation rendering to derive deployment identity and reject caller-supplied deployment bindings.
- Marks existing GitHub and SourceHut mechanics with deployment-value declarations.

## GitHub Issue(s)

Closes #362

## Test plan

- `python -m unittest tests.test_forge_operations tests.test_mechanics tests.test_reference_arc_topology tests.test_groundwork_install`
- `python -m unittest discover -s tests -p 'test_*.py'`
- `python -m tooling.conformance`
- `git diff --check`
