### PR TITLE
feat: phase-2 forge-tag early arc work-unit identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- SourceHut early-arc ticket mechanics now reject HTTP 200 GraphQL responses
+  whose expected operation result is null or absent, instead of treating any
+  `data` object as a successful ticket read/create/comment.
 - SourceHut deployment-value resolution now consults each mechanic's declared
   `deployment_value` keys before reading environment atoms, so tracker-only
   operations do not require unrelated repo identity atoms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `groundwork-mechanic` now supplies those parameters from `GROUNDWORK_*` atoms
   while deriving SourceHut endpoints/remotes and GitHub repository identity
   without call-site deployment bindings (closes #362).
+- Early-arc forge tagging for tracker-backed work-units: `work-unit` artifacts
+  can carry optional GitHub/SourceHut ticket handles, early-arc mechanics are
+  registered for ticket create/read/claim/progress operations, and docs now
+  state the exact `--work-unit` id plus id-to-handle agreement invariant
+  (refs #363).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ design → implement executes through RED-GREEN-REFACTOR → verify gates
 completion with evidence → document ensures accuracy → submit packages the
 change → land merges and closes the loop.
 
+Tracker-backed work-units may carry a forge-tagged ticket `handle`. The
+delivered work-unit artifact id remains the `--work-unit` threading root, and
+runa enforces that the id's ticket number agrees with `handle.number` before
+scoped execution. Non-tracker work-units omit the handle and keep the normal
+forge-neutral threading behavior.
+
 Each protocol produces an artifact that the next protocol requires.
 → [`docs/architecture/connecting-structure.md`](docs/architecture/connecting-structure.md)
 

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -933,6 +933,7 @@ how to know it's done, and whether it's ready to start.
 | title | string | yes | What this work-unit is |
 | description | string | yes | What needs doing |
 | acceptance_criteria | array of strings | yes | Discrete, verifiable conditions for "done" |
+| handle | forge-tagged ticket handle | no | Tracker ticket identity for tracker-backed work-units |
 | scope | array of strings | no | In-scope boundaries for the session frame |
 | out_of_scope | array of strings | no | Explicit nearby exclusions |
 | dependencies | array of work-unit refs | no | Work-units that must be complete before this starts, referenced by `instance_id` |
@@ -940,7 +941,11 @@ how to know it's done, and whether it's ready to start.
 Tracker-backed work-units use `instance_id` convention
 `work-unit-<N>-<short-slug>` on first delivery; work-units without tracker
 linkage use `<short-slug>`. Dependency references use those exact
-`instance_id` values.
+`instance_id` values. For tracker-backed work-units, `handle` carries the
+forge-assigned ticket number: GitHub stores `forge_tag`, issue `url`, and
+`number`; SourceHut stores `forge_tag`, `tracker_id`, and `number`. Runa
+enforces canonical identity by checking that the exact `--work-unit` artifact id
+agrees with `handle.number` and that a ticket has only one delivered root.
 
 ### Traceability Thread
 

--- a/docs/architecture/work-unit-model.md
+++ b/docs/architecture/work-unit-model.md
@@ -50,3 +50,4 @@ Epics with 4+ tasks include a dependency graph in two representations:
 - **Splitting**: when an in-progress work-unit exceeds session size, split remaining work into new work-units and close the original with a pointer.
 - **Merging**: when two work-units converge on the same deliverable, merge into one and close the duplicate with a cross-reference.
 - **Validation after mutation**: after adding, closing, splitting, or merging work-units, verify the graph has no orphaned dependencies or cycles.
+- **Tracker identity agreement**: tracker-backed work-units carry a forge-tagged `handle` whose ticket number is the source of truth. The delivered artifact id must use the same ticket number (`work-unit-<N>-<short-slug>`), and a ticket must not have multiple delivered roots.

--- a/manifest.toml
+++ b/manifest.toml
@@ -86,6 +86,22 @@ name = "deliver-change-proposal"
 forge_tags = ["github", "sourcehut"]
 
 [[mechanics]]
+name = "create-ticket"
+forge_tags = ["github", "sourcehut"]
+
+[[mechanics]]
+name = "read-ticket"
+forge_tags = ["github", "sourcehut"]
+
+[[mechanics]]
+name = "claim-work-unit"
+forge_tags = ["github", "sourcehut"]
+
+[[mechanics]]
+name = "record-progress"
+forge_tags = ["github", "sourcehut"]
+
+[[mechanics]]
 name = "revise"
 
 [[mechanics]]

--- a/mechanics/github/claim-work-unit.toml
+++ b/mechanics/github/claim-work-unit.toml
@@ -1,0 +1,26 @@
+name = "claim-work-unit"
+purpose = "Record a session claim on the GitHub issue backing a work-unit."
+forge_tag = "github"
+default_invocation = 'gh issue comment "$issue_number" --repo "$repository" --body-file "$body_file"'
+examples = [
+  'gh issue comment "$issue_number" --repo "$repository" --body-file "$body_file"',
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+deployment_value = "repository"
+
+[[parameters]]
+name = "issue_number"
+purpose = "GitHub issue number from work-unit.handle.number."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing the claim comment."
+required = true
+
+[outcome]
+description = "The GitHub issue records the active session claim."

--- a/mechanics/github/create-ticket.toml
+++ b/mechanics/github/create-ticket.toml
@@ -1,0 +1,27 @@
+name = "create-ticket"
+purpose = "Create a GitHub issue for a tracker-backed work-unit and return the issue URL."
+forge_tag = "github"
+default_invocation = 'gh issue create --repo "$repository" --title "$title" --body-file "$body_file"'
+examples = [
+  'gh issue create --repo "$repository" --title "$title" --body-file "$body_file"',
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+deployment_value = "repository"
+
+[[parameters]]
+name = "title"
+purpose = "Issue title."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing the issue body."
+required = true
+
+[outcome]
+description = "A GitHub issue exists for the work-unit and its URL can be recorded in work-unit.handle."
+artifact_type = "work-unit"

--- a/mechanics/github/read-ticket.toml
+++ b/mechanics/github/read-ticket.toml
@@ -1,0 +1,21 @@
+name = "read-ticket"
+purpose = "Read a GitHub issue that backs a tracker-linked work-unit."
+forge_tag = "github"
+default_invocation = 'gh issue view "$issue_number" --repo "$repository" --json number,title,body,state,url,comments'
+examples = [
+  'gh issue view "$issue_number" --repo "$repository" --json number,title,body,state,url,comments',
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+deployment_value = "repository"
+
+[[parameters]]
+name = "issue_number"
+purpose = "GitHub issue number from work-unit.handle.number."
+required = true
+
+[outcome]
+description = "The GitHub issue context is available to the session."

--- a/mechanics/github/record-progress.toml
+++ b/mechanics/github/record-progress.toml
@@ -1,0 +1,26 @@
+name = "record-progress"
+purpose = "Record progress on the GitHub issue backing a work-unit."
+forge_tag = "github"
+default_invocation = 'gh issue comment "$issue_number" --repo "$repository" --body-file "$body_file"'
+examples = [
+  'gh issue comment "$issue_number" --repo "$repository" --body-file "$body_file"',
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+deployment_value = "repository"
+
+[[parameters]]
+name = "issue_number"
+purpose = "GitHub issue number from work-unit.handle.number."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing the progress comment."
+required = true
+
+[outcome]
+description = "The GitHub issue records session progress."

--- a/mechanics/sourcehut/claim-work-unit.toml
+++ b/mechanics/sourcehut/claim-work-unit.toml
@@ -1,0 +1,38 @@
+name = "claim-work-unit"
+purpose = "Record a session claim on the SourceHut todo ticket backing a work-unit."
+forge_tag = "sourcehut"
+default_invocation = ''': "$tracker_id" "$ticket_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); sys.exit("SourceHut claim-work-unit GraphQL response contained errors or omitted data") if "errors" in payload or not isinstance(data, dict) else None' "$response"'''
+examples = [
+  ''': "$tracker_id" "$ticket_id" && curl --header "Authorization: Bearer ${token}" --data "@${payload_file}" "$todo_query_url"''',
+]
+
+[[parameters]]
+name = "tracker_id"
+purpose = "todo.sr.ht tracker ID containing the work-unit ticket."
+required = true
+deployment_value = "tracker_id"
+
+[[parameters]]
+name = "ticket_id"
+purpose = "SourceHut ticket number from work-unit.handle.number."
+required = true
+
+[[parameters]]
+name = "payload_file"
+purpose = "JSON GraphQL payload for the claim comment."
+required = true
+
+[[parameters]]
+name = "todo_query_url"
+purpose = "SourceHut todo GraphQL endpoint."
+required = true
+deployment_value = "todo_query_url"
+
+[[parameters]]
+name = "token"
+purpose = "SourceHut API token supplied from WEFORGE_OPERATOR_PAT at command time only; never hardcoded, written, echoed, or logged."
+required = true
+secret = true
+
+[outcome]
+description = "The SourceHut ticket records the active session claim."

--- a/mechanics/sourcehut/claim-work-unit.toml
+++ b/mechanics/sourcehut/claim-work-unit.toml
@@ -1,7 +1,7 @@
 name = "claim-work-unit"
 purpose = "Record a session claim on the SourceHut todo ticket backing a work-unit."
 forge_tag = "sourcehut"
-default_invocation = ''': "$tracker_id" "$ticket_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); sys.exit("SourceHut claim-work-unit GraphQL response contained errors or omitted data") if "errors" in payload or not isinstance(data, dict) else None' "$response"'''
+default_invocation = ''': "$tracker_id" "$ticket_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; expected="submitComment"; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut submitComment GraphQL response contained errors or omitted data.submitComment") if "errors" in payload or not isinstance(value, dict) else print(json.dumps(value))' "$response"'''
 examples = [
   ''': "$tracker_id" "$ticket_id" && curl --header "Authorization: Bearer ${token}" --data "@${payload_file}" "$todo_query_url"''',
 ]

--- a/mechanics/sourcehut/create-ticket.toml
+++ b/mechanics/sourcehut/create-ticket.toml
@@ -1,0 +1,34 @@
+name = "create-ticket"
+purpose = "Create a SourceHut todo ticket for a tracker-backed work-unit and return the tracker response."
+forge_tag = "sourcehut"
+default_invocation = ''': "$tracker_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); sys.exit("SourceHut create-ticket GraphQL response contained errors or omitted data") if "errors" in payload or not isinstance(data, dict) else print(json.dumps(data))' "$response"'''
+examples = [
+  ''': "$tracker_id" && curl --header "Authorization: Bearer ${token}" --data "@${payload_file}" "$todo_query_url"''',
+]
+
+[[parameters]]
+name = "tracker_id"
+purpose = "todo.sr.ht tracker ID containing the work-unit ticket."
+required = true
+deployment_value = "tracker_id"
+
+[[parameters]]
+name = "payload_file"
+purpose = "JSON GraphQL payload for ticket creation."
+required = true
+
+[[parameters]]
+name = "todo_query_url"
+purpose = "SourceHut todo GraphQL endpoint."
+required = true
+deployment_value = "todo_query_url"
+
+[[parameters]]
+name = "token"
+purpose = "SourceHut API token supplied from WEFORGE_OPERATOR_PAT at command time only; never hardcoded, written, echoed, or logged."
+required = true
+secret = true
+
+[outcome]
+description = "A SourceHut ticket exists for the work-unit and its number can be recorded in work-unit.handle."
+artifact_type = "work-unit"

--- a/mechanics/sourcehut/create-ticket.toml
+++ b/mechanics/sourcehut/create-ticket.toml
@@ -1,7 +1,7 @@
 name = "create-ticket"
 purpose = "Create a SourceHut todo ticket for a tracker-backed work-unit and return the tracker response."
 forge_tag = "sourcehut"
-default_invocation = ''': "$tracker_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); sys.exit("SourceHut create-ticket GraphQL response contained errors or omitted data") if "errors" in payload or not isinstance(data, dict) else print(json.dumps(data))' "$response"'''
+default_invocation = ''': "$tracker_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; expected="submitTicket"; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; identity=value.get("id") if isinstance(value, dict) else None; sys.exit("SourceHut submitTicket GraphQL response contained errors or omitted data.submitTicket.id") if "errors" in payload or identity in (None, "") else print(json.dumps(value))' "$response"'''
 examples = [
   ''': "$tracker_id" && curl --header "Authorization: Bearer ${token}" --data "@${payload_file}" "$todo_query_url"''',
 ]

--- a/mechanics/sourcehut/read-ticket.toml
+++ b/mechanics/sourcehut/read-ticket.toml
@@ -1,0 +1,38 @@
+name = "read-ticket"
+purpose = "Read a SourceHut todo ticket that backs a tracker-linked work-unit."
+forge_tag = "sourcehut"
+default_invocation = ''': "$tracker_id" "$ticket_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); sys.exit("SourceHut read-ticket GraphQL response contained errors or omitted data") if "errors" in payload or not isinstance(data, dict) else print(json.dumps(data))' "$response"'''
+examples = [
+  ''': "$tracker_id" "$ticket_id" && curl --header "Authorization: Bearer ${token}" --data "@${payload_file}" "$todo_query_url"''',
+]
+
+[[parameters]]
+name = "tracker_id"
+purpose = "todo.sr.ht tracker ID containing the work-unit ticket."
+required = true
+deployment_value = "tracker_id"
+
+[[parameters]]
+name = "ticket_id"
+purpose = "SourceHut ticket number from work-unit.handle.number."
+required = true
+
+[[parameters]]
+name = "payload_file"
+purpose = "JSON GraphQL payload for ticket lookup."
+required = true
+
+[[parameters]]
+name = "todo_query_url"
+purpose = "SourceHut todo GraphQL endpoint."
+required = true
+deployment_value = "todo_query_url"
+
+[[parameters]]
+name = "token"
+purpose = "SourceHut API token supplied from WEFORGE_OPERATOR_PAT at command time only; never hardcoded, written, echoed, or logged."
+required = true
+secret = true
+
+[outcome]
+description = "The SourceHut ticket context is available to the session."

--- a/mechanics/sourcehut/read-ticket.toml
+++ b/mechanics/sourcehut/read-ticket.toml
@@ -1,7 +1,7 @@
 name = "read-ticket"
 purpose = "Read a SourceHut todo ticket that backs a tracker-linked work-unit."
 forge_tag = "sourcehut"
-default_invocation = ''': "$tracker_id" "$ticket_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); sys.exit("SourceHut read-ticket GraphQL response contained errors or omitted data") if "errors" in payload or not isinstance(data, dict) else print(json.dumps(data))' "$response"'''
+default_invocation = ''': "$tracker_id" "$ticket_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); tracker=data.get("tracker") if isinstance(data, dict) else None; ticket=tracker.get("ticket") if isinstance(tracker, dict) else None; sys.exit("SourceHut read-ticket GraphQL response contained errors or omitted data.tracker.ticket") if "errors" in payload or not isinstance(ticket, dict) else print(json.dumps(ticket))' "$response"'''
 examples = [
   ''': "$tracker_id" "$ticket_id" && curl --header "Authorization: Bearer ${token}" --data "@${payload_file}" "$todo_query_url"''',
 ]

--- a/mechanics/sourcehut/record-progress.toml
+++ b/mechanics/sourcehut/record-progress.toml
@@ -1,0 +1,38 @@
+name = "record-progress"
+purpose = "Record progress on the SourceHut todo ticket backing a work-unit."
+forge_tag = "sourcehut"
+default_invocation = ''': "$tracker_id" "$ticket_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); sys.exit("SourceHut record-progress GraphQL response contained errors or omitted data") if "errors" in payload or not isinstance(data, dict) else None' "$response"'''
+examples = [
+  ''': "$tracker_id" "$ticket_id" && curl --header "Authorization: Bearer ${token}" --data "@${payload_file}" "$todo_query_url"''',
+]
+
+[[parameters]]
+name = "tracker_id"
+purpose = "todo.sr.ht tracker ID containing the work-unit ticket."
+required = true
+deployment_value = "tracker_id"
+
+[[parameters]]
+name = "ticket_id"
+purpose = "SourceHut ticket number from work-unit.handle.number."
+required = true
+
+[[parameters]]
+name = "payload_file"
+purpose = "JSON GraphQL payload for the progress comment."
+required = true
+
+[[parameters]]
+name = "todo_query_url"
+purpose = "SourceHut todo GraphQL endpoint."
+required = true
+deployment_value = "todo_query_url"
+
+[[parameters]]
+name = "token"
+purpose = "SourceHut API token supplied from WEFORGE_OPERATOR_PAT at command time only; never hardcoded, written, echoed, or logged."
+required = true
+secret = true
+
+[outcome]
+description = "The SourceHut ticket records session progress."

--- a/mechanics/sourcehut/record-progress.toml
+++ b/mechanics/sourcehut/record-progress.toml
@@ -1,7 +1,7 @@
 name = "record-progress"
 purpose = "Record progress on the SourceHut todo ticket backing a work-unit."
 forge_tag = "sourcehut"
-default_invocation = ''': "$tracker_id" "$ticket_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); sys.exit("SourceHut record-progress GraphQL response contained errors or omitted data") if "errors" in payload or not isinstance(data, dict) else None' "$response"'''
+default_invocation = ''': "$tracker_id" "$ticket_id" && response=$(mktemp) && trap 'rm -f "$response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; expected="submitComment"; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut submitComment GraphQL response contained errors or omitted data.submitComment") if "errors" in payload or not isinstance(value, dict) else print(json.dumps(value))' "$response"'''
 examples = [
   ''': "$tracker_id" "$ticket_id" && curl --header "Authorization: Bearer ${token}" --data "@${payload_file}" "$todo_query_url"''',
 ]

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -190,6 +190,15 @@ Subsequent updates reuse the `instance_id` established at first delivery. In
 this section, "refining an existing work-unit" means refining an existing
 artifact, not merely refining a tracker item.
 
+When creating a tracker-backed work-unit, use the forge-tagged `create-ticket`
+mechanic for the active forge and populate `handle` from the forge-assigned
+ticket identity. GitHub handles carry `forge_tag`, issue `url`, and `number`.
+SourceHut handles carry `forge_tag`, `tracker_id`, and `number`; the URL
+derives from deployment identity and is not stored. The handle is the source of
+truth for ticket identity, and runa rejects scoped execution when a delivered
+tracker-backed `instance_id` disagrees with `handle.number` or duplicates
+another root for the same ticket.
+
 For new work-units produced by `create-work-unit` or `decompose-epic`:
 
 ```
@@ -200,6 +209,7 @@ work-unit({
   acceptance_criteria: ["..."],
   scope: ["decompose delivery", "take framing"],
   out_of_scope: ["submit protocol", "land protocol"],
+  handle: {"forge_tag": "<forge tag>", "...": "<forge-specific ticket fields>"},
   dependencies: ["work-unit-122-artifact-store-cleanup"]
 })
 ```

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -122,6 +122,13 @@ legitimately spans 2–3 cohesive work-units that share a concern boundary,
 runa activates `take` on each in turn; the session may address them as a
 batch and package them as one PR at `submit`.
 
+For tracker-backed work-units, the artifact's optional `handle` is the source
+of truth for ticket identity. Runa has already checked that the active
+`--work-unit` value is the exact delivered artifact id and that its ticket
+number agrees with `handle.number`; `take` consumes that identity rather than
+reconstructing it from the command line. Use the forge-tagged `read-ticket`
+mechanic to read tracker context for the active handle.
+
 #### Phase 2: Preparation
 
 Set up the repository-local workspace for the selected work.
@@ -143,6 +150,9 @@ Set up the repository-local workspace for the selected work.
    a substrate-failure signal. Missing injected context is not benign absent
    input: `take` does not attempt retrieval through a tracker surface and does
    not proceed in a degraded state.
+4. For tracker-backed work-units, record the session claim through the
+   forge-tagged `claim-work-unit` mechanic against the ticket named by
+   `handle.number`.
 
 #### Phase 3: Claim — produce the session capstone
 
@@ -177,8 +187,8 @@ write files, construct filenames, or supply `work_unit`.
 ### session-close
 
 1. Reach a stable checkpoint (done increment or explicit WIP note).
-2. Update work-unit state and leave a concise progress comment on the active
-   forge tracker record.
+2. Update work-unit state and leave a concise progress comment through the
+   `record-progress` mechanic on the active forge tracker record.
 3. Record decisions, blockers, and the exact next step.
 4. Ensure any follow-up work is represented in the active forge tracker.
 5. Sync workspace and close.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -32,6 +32,13 @@ Manifest `[[mechanics]]` entries may declare `forge_tags = [...]` to bind an
 operation handle to forge-specific C-3 mechanics; conformance requires exactly
 one matching `mechanics/**/*.toml` file for each declared operation/tag pair.
 
+`work-unit.schema.json` also supports an optional forge-tagged ticket `handle`
+for tracker-backed units. The handle records the forge-assigned ticket number:
+GitHub handles store issue URL plus number, while SourceHut handles store
+tracker ID plus ticket number. Runa treats the handle as ticket identity and
+checks that the delivered `work-unit-<N>-<short-slug>` artifact id agrees with
+`handle.number` before scoped execution.
+
 `request.schema.json` is different: it is a vendored copy of the canonical
 request contract maintained by `tesserine/commons`. Groundwork keeps the runtime
 copy here so runtime consumers still read schemas from groundwork, not from

--- a/schemas/work-unit.schema.json
+++ b/schemas/work-unit.schema.json
@@ -25,6 +25,17 @@
         "type": "string"
       }
     },
+    "handle": {
+      "description": "Optional forge-specific ticket reference for tracker-backed work units.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/github-ticket-handle"
+        },
+        {
+          "$ref": "#/$defs/sourcehut-ticket-handle"
+        }
+      ]
+    },
     "scope": {
       "type": "array",
       "description": "In-scope boundaries for this work unit.",
@@ -49,6 +60,48 @@
       "items": {
         "type": "string",
         "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+      }
+    }
+  },
+  "$defs": {
+    "github-ticket-handle": {
+      "type": "object",
+      "required": ["forge_tag", "url", "number"],
+      "additionalProperties": false,
+      "properties": {
+        "forge_tag": {
+          "const": "github"
+        },
+        "url": {
+          "type": "string",
+          "description": "GitHub issue URL.",
+          "pattern": "^https://github\\.com/[^/]+/[^/]+/issues/[0-9]+$"
+        },
+        "number": {
+          "type": "integer",
+          "description": "GitHub issue number.",
+          "minimum": 1
+        }
+      }
+    },
+    "sourcehut-ticket-handle": {
+      "type": "object",
+      "required": ["forge_tag", "tracker_id", "number"],
+      "additionalProperties": false,
+      "properties": {
+        "forge_tag": {
+          "const": "sourcehut"
+        },
+        "tracker_id": {
+          "type": "integer",
+          "description": "SourceHut tracker ID containing the ticket.",
+          "minimum": 1
+        },
+        "number": {
+          "type": "integer",
+          "description": "SourceHut ticket number.",
+          "minimum": 1
+        }
       }
     }
   }

--- a/tests/fixtures/artifacts/invalid-work-unit-wrong-handle-variant.json
+++ b/tests/fixtures/artifacts/invalid-work-unit-wrong-handle-variant.json
@@ -1,0 +1,12 @@
+{
+  "title": "Add ticket-backed work-unit identity",
+  "description": "Reject a handle whose fields do not match its forge tag.",
+  "acceptance_criteria": [
+    "Mismatched handle variants are rejected"
+  ],
+  "handle": {
+    "forge_tag": "github",
+    "tracker_id": 4,
+    "number": 363
+  }
+}

--- a/tests/fixtures/artifacts/valid-work-unit-github-handle.json
+++ b/tests/fixtures/artifacts/valid-work-unit-github-handle.json
@@ -1,0 +1,12 @@
+{
+  "title": "Add ticket-backed work-unit identity",
+  "description": "Add a tracker-backed work-unit handle for a GitHub issue.",
+  "acceptance_criteria": [
+    "Ticket-backed work-units carry the assigned issue number"
+  ],
+  "handle": {
+    "forge_tag": "github",
+    "url": "https://github.com/tesserine/groundwork/issues/363",
+    "number": 363
+  }
+}

--- a/tests/fixtures/artifacts/valid-work-unit-sourcehut-handle.json
+++ b/tests/fixtures/artifacts/valid-work-unit-sourcehut-handle.json
@@ -1,0 +1,12 @@
+{
+  "title": "Add ticket-backed work-unit identity",
+  "description": "Add a tracker-backed work-unit handle for a SourceHut ticket.",
+  "acceptance_criteria": [
+    "Ticket-backed work-units carry the assigned ticket number"
+  ],
+  "handle": {
+    "forge_tag": "sourcehut",
+    "tracker_id": 4,
+    "number": 363
+  }
+}

--- a/tests/test_artifact_schemas.py
+++ b/tests/test_artifact_schemas.py
@@ -89,6 +89,30 @@ class ArtifactSchemaTests(unittest.TestCase):
         self.assertIn("handle/forge_tag", context.exception.paths)
         self.assertIn("forge tag `sourcehut` does not resolve in registry", str(context.exception))
 
+    def test_work_unit_schema_accepts_ticket_handles_and_no_handle(self) -> None:
+        for name in [
+            "valid-work-unit.json",
+            "valid-work-unit-github-handle.json",
+            "valid-work-unit-sourcehut-handle.json",
+        ]:
+            with self.subTest(fixture=name):
+                load_artifact("work-unit", self.fixture(name), registry=registry_from_manifest())
+
+    def test_work_unit_schema_rejects_wrong_ticket_handle_variant(self) -> None:
+        with self.assertRaises(ArtifactSchemaError) as context:
+            load_artifact("work-unit", self.fixture("invalid-work-unit-wrong-handle-variant.json"))
+
+        self.assertIn("handle", context.exception.paths)
+
+    def test_work_unit_forge_tag_rejects_unknown_registry_value(self) -> None:
+        registry = MechanicRegistry(forge_tags={"github"})
+
+        with self.assertRaises(ArtifactSchemaError) as context:
+            load_artifact("work-unit", self.fixture("valid-work-unit-sourcehut-handle.json"), registry=registry)
+
+        self.assertIn("handle/forge_tag", context.exception.paths)
+        self.assertIn("forge tag `sourcehut` does not resolve in registry", str(context.exception))
+
     def test_change_needs_revision_schema_accepts_structured_findings(self) -> None:
         artifact = load_artifact("change-needs-revision", self.fixture("valid-change-needs-revision.json"))
 

--- a/tests/test_reference_arc_topology.py
+++ b/tests/test_reference_arc_topology.py
@@ -135,6 +135,23 @@ class ReferenceArcTopologyTests(unittest.TestCase):
                 self.assertIn(forge_tag, manifest_mechanics[operation]["forge_tags"])
                 self.assertEqual(1, sum(1 for mechanic in forge_mechanics if mechanic["name"] == operation))
 
+    def test_early_arc_mechanics_are_bound_once_per_forge_in_manifest_and_c3(self) -> None:
+        operations = {
+            "create-ticket",
+            "read-ticket",
+            "claim-work-unit",
+            "record-progress",
+        }
+        manifest_mechanics = {entry["name"]: entry for entry in manifest()["mechanics"]}
+
+        for forge_tag in {"github", "sourcehut"}:
+            forge_mechanics = mechanics_for_forge(forge_tag)
+            for operation in operations:
+                with self.subTest(forge_tag=forge_tag, operation=operation):
+                    self.assertIn(operation, manifest_mechanics)
+                    self.assertIn(forge_tag, manifest_mechanics[operation]["forge_tags"])
+                    self.assertEqual(1, sum(1 for mechanic in forge_mechanics if mechanic["name"] == operation))
+
     def test_reference_arc_mechanics_declare_deployment_resolved_parameters(self) -> None:
         expected = {
             ("github", "deliver-change-proposal"): {"repository": "repository"},
@@ -164,6 +181,47 @@ class ReferenceArcTopologyTests(unittest.TestCase):
                 for parameter_name, deployment_value in deployment_values.items():
                     self.assertEqual(deployment_value, parameters[parameter_name].get("deployment_value"))
                     self.assertTrue(parameters[parameter_name]["required"])
+
+    def test_early_arc_mechanics_declare_deployment_resolved_parameters(self) -> None:
+        expected = {
+            ("github", "create-ticket"): {"repository": "repository"},
+            ("github", "read-ticket"): {"repository": "repository"},
+            ("github", "claim-work-unit"): {"repository": "repository"},
+            ("github", "record-progress"): {"repository": "repository"},
+            ("sourcehut", "create-ticket"): {
+                "tracker_id": "tracker_id",
+                "todo_query_url": "todo_query_url",
+            },
+            ("sourcehut", "read-ticket"): {
+                "tracker_id": "tracker_id",
+                "todo_query_url": "todo_query_url",
+            },
+            ("sourcehut", "claim-work-unit"): {
+                "tracker_id": "tracker_id",
+                "todo_query_url": "todo_query_url",
+            },
+            ("sourcehut", "record-progress"): {
+                "tracker_id": "tracker_id",
+                "todo_query_url": "todo_query_url",
+            },
+        }
+
+        for (forge_tag, operation), deployment_values in expected.items():
+            with self.subTest(forge_tag=forge_tag, operation=operation):
+                mechanic = mechanic_for_forge(forge_tag, operation)
+                parameters = {parameter["name"]: parameter for parameter in mechanic["parameters"]}
+                for parameter_name, deployment_value in deployment_values.items():
+                    self.assertEqual(deployment_value, parameters[parameter_name].get("deployment_value"))
+                    self.assertTrue(parameters[parameter_name]["required"])
+
+    def test_sourcehut_early_arc_mechanics_keep_token_secret(self) -> None:
+        for operation in {"create-ticket", "read-ticket", "claim-work-unit", "record-progress"}:
+            with self.subTest(operation=operation):
+                mechanic = mechanic_for_forge("sourcehut", operation)
+                token = {parameter["name"]: parameter for parameter in mechanic["parameters"]}["token"]
+
+                self.assertTrue(token["secret"])
+                self.assertNotIn("WEFORGE_OPERATOR_PAT", mechanic["default_invocation"])
 
     def test_sourcehut_apply_mechanic_uses_proposal_ref_and_tree_equality_not_commit_identity(self) -> None:
         apply = mechanic_for_forge("sourcehut", "apply-approved-change")

--- a/tests/test_reference_arc_topology.py
+++ b/tests/test_reference_arc_topology.py
@@ -79,6 +79,50 @@ class ReferenceArcTopologyTests(unittest.TestCase):
             stderr=subprocess.PIPE,
         )
 
+    def run_sourcehut_early_arc_response(self, operation: str, response_payload: dict) -> subprocess.CompletedProcess:
+        mechanic = mechanic_for_forge("sourcehut", operation)
+        with tempfile.TemporaryDirectory() as directory:
+            temp = Path(directory)
+            bin_dir = temp / "bin"
+            bin_dir.mkdir()
+            curl = bin_dir / "curl"
+            curl.write_text('#!/bin/sh\nprintf "%s\\n" "$GROUNDWORK_TEST_SOURCEHUT_RESPONSE"\n', encoding="utf-8")
+            curl.chmod(0o755)
+            payload_file = temp / "payload.json"
+            payload_file.write_text("{}", encoding="utf-8")
+
+            return self.run_mechanic_invocation(
+                mechanic["default_invocation"],
+                {
+                    "tracker_id": "4",
+                    "ticket_id": "7",
+                    "payload_file": str(payload_file),
+                    "todo_query_url": "https://todo.weforge.build/query",
+                    "token": "test-token",
+                    "GROUNDWORK_TEST_SOURCEHUT_RESPONSE": json.dumps(response_payload),
+                },
+                bin_dir,
+            )
+
+    def sourcehut_early_arc_success_payload(self, operation: str, result: dict) -> dict:
+        if operation == "read-ticket":
+            return {"data": {"tracker": {"ticket": result}}}
+        if operation == "create-ticket":
+            return {"data": {"submitTicket": result}}
+        return {"data": {"submitComment": result}}
+
+    def sourcehut_early_arc_null_payload(self, operation: str) -> dict:
+        if operation == "read-ticket":
+            return {"data": {"tracker": {"ticket": None}}}
+        if operation == "create-ticket":
+            return {"data": {"submitTicket": None}}
+        return {"data": {"submitComment": None}}
+
+    def sourcehut_early_arc_absent_payload(self, operation: str) -> dict:
+        if operation == "read-ticket":
+            return {"data": {"tracker": {}}}
+        return {"data": {}}
+
     def test_manifest_routes_submit_review_land_through_disposition_artifacts(self) -> None:
         artifact_types = {entry["name"] for entry in manifest()["artifact_types"]}
         mechanics = {entry["name"] for entry in manifest()["mechanics"]}
@@ -222,6 +266,46 @@ class ReferenceArcTopologyTests(unittest.TestCase):
 
                 self.assertTrue(token["secret"])
                 self.assertNotIn("WEFORGE_OPERATOR_PAT", mechanic["default_invocation"])
+
+    def test_sourcehut_early_arc_mechanics_reject_null_operation_results(self) -> None:
+        for operation in {"create-ticket", "read-ticket", "claim-work-unit", "record-progress"}:
+            with self.subTest(operation=operation):
+                result = self.run_sourcehut_early_arc_response(
+                    operation,
+                    self.sourcehut_early_arc_null_payload(operation),
+                )
+
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn("omitted data", result.stderr)
+
+    def test_sourcehut_early_arc_mechanics_reject_absent_operation_results(self) -> None:
+        for operation in {"create-ticket", "read-ticket", "claim-work-unit", "record-progress"}:
+            with self.subTest(operation=operation):
+                result = self.run_sourcehut_early_arc_response(
+                    operation,
+                    self.sourcehut_early_arc_absent_payload(operation),
+                )
+
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn("omitted data", result.stderr)
+
+    def test_sourcehut_early_arc_mechanics_emit_well_formed_operation_results(self) -> None:
+        expected = {
+            "create-ticket": {"id": 42, "ref": "~operator/weforge#42"},
+            "read-ticket": {"id": 7, "subject": "ticket"},
+            "claim-work-unit": {"id": 1001},
+            "record-progress": {"id": 1002},
+        }
+
+        for operation, operation_result in expected.items():
+            with self.subTest(operation=operation):
+                result = self.run_sourcehut_early_arc_response(
+                    operation,
+                    self.sourcehut_early_arc_success_payload(operation, operation_result),
+                )
+
+                self.assertEqual(0, result.returncode, result.stderr)
+                self.assertEqual(operation_result, json.loads(result.stdout))
 
     def test_sourcehut_apply_mechanic_uses_proposal_ref_and_tree_equality_not_commit_identity(self) -> None:
         apply = mechanic_for_forge("sourcehut", "apply-approved-change")

--- a/tooling/artifact_schemas.py
+++ b/tooling/artifact_schemas.py
@@ -138,7 +138,9 @@ def _registry_errors(
     artifact: dict[str, Any],
     registry: MechanicRegistry,
 ) -> list[tuple[str, str]]:
-    if artifact_type != "change-proposal":
+    if artifact_type not in {"change-proposal", "work-unit"}:
+        return []
+    if "handle" not in artifact:
         return []
 
     forge_tag = artifact["handle"]["forge_tag"]


### PR DESCRIPTION
## Summary

- Adds the optional tracker-backed `work-unit.handle` schema for GitHub and SourceHut ticket identity.
- Adds early-arc forge mechanics for ticket creation, ticket reads, work-unit claims, and progress comments.
- Documents the exact `--work-unit` artifact-id rule plus the id-to-handle agreement invariant required by the #363 keystone.

## Changes

- Extends `work-unit.schema.json` with a forge-tagged ticket handle union and fixture coverage.
- Registers and tests GitHub/SourceHut `create-ticket`, `read-ticket`, `claim-work-unit`, and `record-progress` mechanics.
- Updates decompose, take, architecture, schema, README, work-unit model, and changelog documentation so the canonical identity rule is discoverable.

## GitHub Issue(s)

Refs #363

## Companion PR

- Runa enforcement PR: https://github.com/tesserine/runa/pull/162

## Test plan

- `python -m tooling.conformance`
- `python -m unittest discover -s tests`
