### PR TITLE
feat(schema): add work-unit forge ticket handle contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `groundwork-mechanic` now supplies those parameters from `GROUNDWORK_*` atoms
   while deriving SourceHut endpoints/remotes and GitHub repository identity
   without call-site deployment bindings (closes #362).
+- Work-unit ticket handle contract: `work-unit` artifacts now accept an
+  optional forge-tagged tracker `handle` for GitHub issues and SourceHut
+  tickets, while preserving no-handle non-tracker units and rejecting scoped
+  top-level `work_unit` fields, malformed variants, unknown forge tags, and
+  GitHub URL/number mismatches (closes #368).
 
 ### Changed
 

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -933,6 +933,7 @@ how to know it's done, and whether it's ready to start.
 | title | string | yes | What this work-unit is |
 | description | string | yes | What needs doing |
 | acceptance_criteria | array of strings | yes | Discrete, verifiable conditions for "done" |
+| handle | forge-tagged ticket handle | no | Forge-assigned tracker identity for tracker-backed work-units |
 | scope | array of strings | no | In-scope boundaries for the session frame |
 | out_of_scope | array of strings | no | Explicit nearby exclusions |
 | dependencies | array of work-unit refs | no | Work-units that must be complete before this starts, referenced by `instance_id` |
@@ -941,6 +942,11 @@ Tracker-backed work-units use `instance_id` convention
 `work-unit-<N>-<short-slug>` on first delivery; work-units without tracker
 linkage use `<short-slug>`. Dependency references use those exact
 `instance_id` values.
+
+Tracker-backed work-units may also carry an optional forge-tagged ticket
+`handle`; non-tracker work-units omit it. The body remains unpartitioned and
+does not carry a top-level `work_unit` field. GitHub handles name an issue URL
+and number; SourceHut handles name a tracker ID and ticket number.
 
 ### Traceability Thread
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -26,11 +26,25 @@ a forge-tagged handle. The review disposition is the produced outcome type:
 `change-approved` cannot carry blocking findings, and `change-needs-revision`
 must carry at least one blocking finding.
 
-Change-proposal handle forge tags and mechanic-authored `forge_tag` values
-resolve against the declarative `[[forge_tags]]` registry in `manifest.toml`.
+`work-unit.schema.json` is the planning-to-execution bridge. It remains
+forge-neutral and unpartitioned: tracker-backed units may carry an optional
+forge-tagged ticket `handle`, while non-tracker units omit `handle`, and
+planning-phase work-unit bodies do not carry a top-level `work_unit` field.
+Supported ticket handles are GitHub issue handles
+`{ forge_tag, url, number }` and SourceHut ticket handles
+`{ forge_tag, tracker_id, number }`; Groundwork artifact validation enforces
+registry membership and GitHub URL/number agreement.
+
+Change-proposal and work-unit handle forge tags, plus mechanic-authored
+`forge_tag` values, resolve against the declarative `[[forge_tags]]` registry
+in `manifest.toml`.
 Manifest `[[mechanics]]` entries may declare `forge_tags = [...]` to bind an
 operation handle to forge-specific C-3 mechanics; conformance requires exactly
 one matching `mechanics/**/*.toml` file for each declared operation/tag pair.
+
+Downstream consumers that build against a Groundwork schema contract pin a
+release tag or the merged full commit SHA. They do not pin a branch name or
+pre-merge ref.
 
 `request.schema.json` is different: it is a vendored copy of the canonical
 request contract maintained by `tesserine/commons`. Groundwork keeps the runtime

--- a/schemas/work-unit.schema.json
+++ b/schemas/work-unit.schema.json
@@ -25,6 +25,17 @@
         "type": "string"
       }
     },
+    "handle": {
+      "description": "Optional forge-specific reference to the tracker ticket backing this work unit.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/github-handle"
+        },
+        {
+          "$ref": "#/$defs/sourcehut-handle"
+        }
+      ]
+    },
     "scope": {
       "type": "array",
       "description": "In-scope boundaries for this work unit.",
@@ -49,6 +60,48 @@
       "items": {
         "type": "string",
         "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+      }
+    }
+  },
+  "$defs": {
+    "github-handle": {
+      "type": "object",
+      "required": ["forge_tag", "url", "number"],
+      "additionalProperties": false,
+      "properties": {
+        "forge_tag": {
+          "const": "github"
+        },
+        "url": {
+          "type": "string",
+          "description": "GitHub issue URL.",
+          "pattern": "^https://github\\.com/[^/]+/[^/]+/issues/[0-9]+$"
+        },
+        "number": {
+          "type": "integer",
+          "description": "GitHub issue number.",
+          "minimum": 1
+        }
+      }
+    },
+    "sourcehut-handle": {
+      "type": "object",
+      "required": ["forge_tag", "tracker_id", "number"],
+      "additionalProperties": false,
+      "properties": {
+        "forge_tag": {
+          "const": "sourcehut"
+        },
+        "tracker_id": {
+          "type": "integer",
+          "description": "SourceHut tracker ID assigned by the deployment.",
+          "minimum": 1
+        },
+        "number": {
+          "type": "integer",
+          "description": "SourceHut ticket number.",
+          "minimum": 1
+        }
       }
     }
   }

--- a/tests/fixtures/artifacts/invalid-work-unit-github-url-number-mismatch.json
+++ b/tests/fixtures/artifacts/invalid-work-unit-github-url-number-mismatch.json
@@ -1,0 +1,12 @@
+{
+  "title": "Reject mismatched GitHub work-unit handle",
+  "description": "GitHub work-unit handle URL and number must agree",
+  "acceptance_criteria": [
+    "GitHub URL and number mismatches are rejected"
+  ],
+  "handle": {
+    "forge_tag": "github",
+    "url": "https://github.com/tesserine/groundwork/issues/367",
+    "number": 368
+  }
+}

--- a/tests/fixtures/artifacts/invalid-work-unit-malformed-handle.json
+++ b/tests/fixtures/artifacts/invalid-work-unit-malformed-handle.json
@@ -1,0 +1,12 @@
+{
+  "title": "Reject malformed work-unit handle",
+  "description": "Work-unit handles must use the declared forge tag variants",
+  "acceptance_criteria": [
+    "Malformed handles are rejected"
+  ],
+  "handle": {
+    "forge_tag": "GitHub",
+    "url": "https://github.com/tesserine/groundwork/issues/368",
+    "number": 368
+  }
+}

--- a/tests/fixtures/artifacts/invalid-work-unit-top-level-work-unit.json
+++ b/tests/fixtures/artifacts/invalid-work-unit-top-level-work-unit.json
@@ -1,0 +1,8 @@
+{
+  "work_unit": "issue-368",
+  "title": "Add work-unit handle contract",
+  "description": "Planning-phase work-unit artifacts must not carry a scoped work_unit field",
+  "acceptance_criteria": [
+    "Top-level work_unit is rejected"
+  ]
+}

--- a/tests/fixtures/artifacts/invalid-work-unit-wrong-handle-variant.json
+++ b/tests/fixtures/artifacts/invalid-work-unit-wrong-handle-variant.json
@@ -1,0 +1,12 @@
+{
+  "title": "Reject wrong work-unit handle variant",
+  "description": "GitHub work-unit handles must not carry SourceHut fields",
+  "acceptance_criteria": [
+    "Wrong forge handle variants are rejected"
+  ],
+  "handle": {
+    "forge_tag": "github",
+    "tracker_id": 4,
+    "number": 368
+  }
+}

--- a/tests/fixtures/artifacts/valid-work-unit-github-handle.json
+++ b/tests/fixtures/artifacts/valid-work-unit-github-handle.json
@@ -1,0 +1,12 @@
+{
+  "title": "Add work-unit handle contract",
+  "description": "Add a schema contract for tracker-backed work-unit handles",
+  "acceptance_criteria": [
+    "GitHub tracker-backed work-units carry a forge-tagged issue handle"
+  ],
+  "handle": {
+    "forge_tag": "github",
+    "url": "https://github.com/tesserine/groundwork/issues/368",
+    "number": 368
+  }
+}

--- a/tests/fixtures/artifacts/valid-work-unit-sourcehut-handle.json
+++ b/tests/fixtures/artifacts/valid-work-unit-sourcehut-handle.json
@@ -1,0 +1,12 @@
+{
+  "title": "Add SourceHut work-unit handle contract",
+  "description": "Add a schema contract for SourceHut tracker-backed work-unit handles",
+  "acceptance_criteria": [
+    "SourceHut tracker-backed work-units carry a forge-tagged ticket handle"
+  ],
+  "handle": {
+    "forge_tag": "sourcehut",
+    "tracker_id": 4,
+    "number": 368
+  }
+}

--- a/tests/test_artifact_schemas.py
+++ b/tests/test_artifact_schemas.py
@@ -89,6 +89,52 @@ class ArtifactSchemaTests(unittest.TestCase):
         self.assertIn("handle/forge_tag", context.exception.paths)
         self.assertIn("forge tag `sourcehut` does not resolve in registry", str(context.exception))
 
+    def test_work_unit_schema_accepts_optional_forge_ticket_handles(self) -> None:
+        for name in [
+            "valid-work-unit.json",
+            "valid-work-unit-github-handle.json",
+            "valid-work-unit-sourcehut-handle.json",
+        ]:
+            with self.subTest(fixture=name):
+                artifact = load_artifact("work-unit", self.fixture(name), registry=registry_from_manifest())
+
+                if "handle" in artifact:
+                    self.assertIn(artifact["handle"]["forge_tag"], {"github", "sourcehut"})
+
+    def test_work_unit_schema_rejects_top_level_work_unit_field(self) -> None:
+        with self.assertRaises(ArtifactSchemaError) as context:
+            load_artifact("work-unit", self.fixture("invalid-work-unit-top-level-work-unit.json"))
+
+        self.assertIn("<root>", context.exception.paths)
+
+    def test_work_unit_schema_rejects_wrong_handle_variant_for_tag(self) -> None:
+        with self.assertRaises(ArtifactSchemaError) as context:
+            load_artifact("work-unit", self.fixture("invalid-work-unit-wrong-handle-variant.json"))
+
+        self.assertIn("handle", context.exception.paths)
+
+    def test_work_unit_schema_rejects_malformed_handle(self) -> None:
+        with self.assertRaises(ArtifactSchemaError) as context:
+            load_artifact("work-unit", self.fixture("invalid-work-unit-malformed-handle.json"))
+
+        self.assertIn("handle", context.exception.paths)
+
+    def test_work_unit_schema_rejects_github_url_number_mismatch(self) -> None:
+        with self.assertRaises(ArtifactSchemaError) as context:
+            load_artifact("work-unit", self.fixture("invalid-work-unit-github-url-number-mismatch.json"))
+
+        self.assertIn("handle/url", context.exception.paths)
+        self.assertIn("does not agree with handle number", str(context.exception))
+
+    def test_work_unit_forge_tag_rejects_unknown_registry_value(self) -> None:
+        registry = MechanicRegistry(forge_tags={"github"})
+
+        with self.assertRaises(ArtifactSchemaError) as context:
+            load_artifact("work-unit", self.fixture("valid-work-unit-sourcehut-handle.json"), registry=registry)
+
+        self.assertIn("handle/forge_tag", context.exception.paths)
+        self.assertIn("forge tag `sourcehut` does not resolve in registry", str(context.exception))
+
     def test_change_needs_revision_schema_accepts_structured_findings(self) -> None:
         artifact = load_artifact("change-needs-revision", self.fixture("valid-change-needs-revision.json"))
 

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -83,6 +83,28 @@ name = "successor"
         )
         self.assertTrue(all(result.passed for result in results))
 
+    def test_artifact_conformance_validates_work_unit_handle_contract(self) -> None:
+        results = run_conformance(
+            [
+                ARTIFACT_FIXTURES / "valid-work-unit-github-handle.json",
+                ARTIFACT_FIXTURES / "valid-work-unit-sourcehut-handle.json",
+                ARTIFACT_FIXTURES / "invalid-work-unit-github-url-number-mismatch.json",
+            ]
+        )
+
+        self.assertEqual(
+            [
+                "C-4 artifact-instance",
+                "C-4 artifact-instance",
+                "C-4 artifact-instance",
+            ],
+            [result.category for result in results],
+        )
+        self.assertTrue(results[0].passed)
+        self.assertTrue(results[1].passed)
+        self.assertFalse(results[2].passed)
+        self.assertIn("handle/url", " ".join(results[2].errors))
+
     def test_invalid_units_return_failures_without_raising(self) -> None:
         results = run_conformance(
             [

--- a/tooling/artifact_schemas.py
+++ b/tooling/artifact_schemas.py
@@ -19,6 +19,9 @@ MANIFEST = ROOT / "manifest.toml"
 DATE_TIME_PATTERN = re.compile(
     r"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})$"
 )
+GITHUB_WORK_UNIT_ISSUE_URL_PATTERN = re.compile(
+    r"^https://github[.]com/[^/]+/[^/]+/issues/([0-9]+)$"
+)
 
 
 class ArtifactSchemaError(ValueError):
@@ -71,6 +74,8 @@ def validate_artifact(
 ) -> None:
     errors: list[tuple[str, str]] = []
     errors.extend(_schema_errors(artifact_type, artifact))
+    if not errors:
+        errors.extend(_artifact_contract_errors(artifact_type, artifact))
     if registry is not None and not errors:
         errors.extend(_registry_errors(artifact_type, artifact, registry))
 
@@ -138,10 +143,24 @@ def _registry_errors(
     artifact: dict[str, Any],
     registry: MechanicRegistry,
 ) -> list[tuple[str, str]]:
-    if artifact_type != "change-proposal":
+    if artifact_type == "change-proposal":
+        forge_tag = artifact["handle"]["forge_tag"]
+    elif artifact_type == "work-unit" and "handle" in artifact:
+        forge_tag = artifact["handle"]["forge_tag"]
+    else:
         return []
 
-    forge_tag = artifact["handle"]["forge_tag"]
     if forge_tag not in registry.forge_tags:
         return [("handle/forge_tag", f"forge tag `{forge_tag}` does not resolve in registry")]
+    return []
+
+
+def _artifact_contract_errors(artifact_type: str, artifact: dict[str, Any]) -> list[tuple[str, str]]:
+    if artifact_type != "work-unit" or artifact.get("handle", {}).get("forge_tag") != "github":
+        return []
+
+    handle = artifact["handle"]
+    match = GITHUB_WORK_UNIT_ISSUE_URL_PATTERN.fullmatch(handle["url"])
+    if match is not None and int(match.group(1)) != handle["number"]:
+        return [("handle/url", "GitHub issue URL number does not agree with handle number")]
     return []


### PR DESCRIPTION
## Summary

- Adds the optional forge-tagged ticket handle contract to `work-unit` artifacts while preserving no-handle non-tracker units.
- Extends Groundwork-owned artifact validation for registered forge tags and GitHub issue URL/number agreement.
- Documents the schema contract and downstream pinning rule for consumers of this layer-0 contract.

## Changes

- Defines GitHub issue and SourceHut ticket handle variants in `schemas/work-unit.schema.json`.
- Adds valid and invalid artifact fixtures plus artifact-schema and conformance tests.
- Updates schema-facing docs, architecture notes, and changelog coverage.

## GitHub Issue(s)

Closes #368
Part of #363

## Test plan

- `python -m unittest discover -s tests`
- `python -m tooling.conformance`
