### PR TITLE
feat(mechanics): add early-arc forge ticket operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   tickets, while preserving no-handle non-tracker units and rejecting scoped
   top-level `work_unit` fields, malformed variants, unknown forge tags, and
   GitHub URL/number mismatches (closes #368).
+- Early-arc forge ticket mechanics: `create-ticket`, `read-ticket`,
+  `claim-work-unit`, and `record-progress` now resolve for both GitHub and
+  SourceHut, derive repository/tracker identity from `GROUNDWORK_*`
+  deployment atoms, validate expected API/GraphQL result fields, and expose
+  forge-assigned ticket identities for schema-conforming work-unit handles
+  (closes #369).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- SourceHut `read-ticket` now resolves the active tracker through the live
+  todo GraphQL `user(username: ...) { tracker(name: ...) }` path instead of
+  passing the numeric deployment tracker id to `tracker(rid: ...)`.
 - SourceHut deployment-value resolution now consults each mechanic's declared
   `deployment_value` keys before reading environment atoms, so tracker-only
   operations do not require unrelated repo identity atoms.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ configuration without reaching back into the source checkout. Installed
 protocol copies reference the managed resolver path directly, so users do not
 need to add `~/.groundwork/bin` to `PATH`.
 
+The early-arc tracker operations are forge-invariant at the call site and
+forge-tagged in the mechanic library: `create-ticket`, `read-ticket`,
+`claim-work-unit`, and `record-progress` resolve to either GitHub issue
+mechanics or SourceHut ticket mechanics. Ticket creation emits the
+forge-assigned identity needed for a `work-unit.handle`: GitHub emits
+`forge_tag`, issue `url`, and issue `number`; SourceHut emits `forge_tag`,
+`tracker_id`, and ticket `number`. The mechanics validate the expected API or
+GraphQL result field before accepting a response, so an HTTP- or CLI-successful
+response that contains application errors or omits the expected operation
+result is rejected.
+
 Secret mechanic parameters must be bound from an environment variable rather
 than from `NAME=VALUE` argv bindings. For example, pass
 `--secret-env token=WEFORGE_OPERATOR_PAT` to bind a secret `token` parameter

--- a/manifest.toml
+++ b/manifest.toml
@@ -104,6 +104,22 @@ name = "close-out"
 forge_tags = ["github", "sourcehut"]
 
 [[mechanics]]
+name = "create-ticket"
+forge_tags = ["github", "sourcehut"]
+
+[[mechanics]]
+name = "read-ticket"
+forge_tags = ["github", "sourcehut"]
+
+[[mechanics]]
+name = "claim-work-unit"
+forge_tags = ["github", "sourcehut"]
+
+[[mechanics]]
+name = "record-progress"
+forge_tags = ["github", "sourcehut"]
+
+[[mechanics]]
 name = "inspect-worktree"
 
 [[mechanics]]

--- a/mechanics/github/claim-work-unit.toml
+++ b/mechanics/github/claim-work-unit.toml
@@ -1,0 +1,26 @@
+name = "claim-work-unit"
+purpose = "Claim a GitHub work-unit issue by assigning it in the active repository."
+forge_tag = "github"
+default_invocation = '''response=$(mktemp) && trap 'rm -f "$response"' EXIT && gh api "repos/${repository}/issues/${ticket_number}" --method PATCH -F "assignees[]=${assignee}" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); url=payload.get("html_url"); number=payload.get("number"); sys.exit("GitHub claim-work-unit API response contained errors or omitted html_url/number") if "errors" in payload or not isinstance(url, str) or not url or not isinstance(number, int) else print(json.dumps({"handle":{"forge_tag":"github","url":url,"number":number}}, separators=(",", ":")))' "$response"'''
+examples = [
+  'gh api repos/tesserine/groundwork/issues/369 --method PATCH -F assignees[]=operator',
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+deployment_value = "repository"
+
+[[parameters]]
+name = "ticket_number"
+purpose = "GitHub issue number to claim."
+required = true
+
+[[parameters]]
+name = "assignee"
+purpose = "GitHub login to assign to the issue."
+required = true
+
+[outcome]
+description = "The GitHub issue is assigned and the updated issue identity is returned."

--- a/mechanics/github/create-ticket.toml
+++ b/mechanics/github/create-ticket.toml
@@ -1,0 +1,26 @@
+name = "create-ticket"
+purpose = "Create a GitHub issue in the active repository and emit the forge-tagged work-unit handle identity."
+forge_tag = "github"
+default_invocation = '''response=$(mktemp) && trap 'rm -f "$response"' EXIT && gh api "repos/${repository}/issues" --method POST -f "title=${title}" -F "body=@${body_file}" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); url=payload.get("html_url"); number=payload.get("number"); sys.exit("GitHub create-ticket API response contained errors or omitted html_url/number") if "errors" in payload or not isinstance(url, str) or not url or not isinstance(number, int) else print(json.dumps({"forge_tag":"github","url":url,"number":number}, separators=(",", ":")))' "$response"'''
+examples = [
+  '''gh api repos/tesserine/groundwork/issues --method POST -f title='Add work unit' -F body=@/tmp/work-unit.md''',
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+deployment_value = "repository"
+
+[[parameters]]
+name = "title"
+purpose = "Issue title for the tracker-backed work-unit ticket."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing the issue body."
+required = true
+
+[outcome]
+description = "A GitHub issue exists in the active repository and stdout contains a work-unit handle with forge_tag, url, and number."

--- a/mechanics/github/read-ticket.toml
+++ b/mechanics/github/read-ticket.toml
@@ -1,0 +1,21 @@
+name = "read-ticket"
+purpose = "Read a GitHub issue from the active repository and emit its ticket state with a work-unit handle."
+forge_tag = "github"
+default_invocation = '''response=$(mktemp) && trap 'rm -f "$response"' EXIT && gh api "repos/${repository}/issues/${ticket_number}" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); url=payload.get("html_url"); number=payload.get("number"); title=payload.get("title"); body=payload.get("body"); state=payload.get("state"); sys.exit("GitHub read-ticket API response contained errors or omitted issue fields") if "errors" in payload or not isinstance(url, str) or not url or not isinstance(number, int) or not isinstance(title, str) or not isinstance(state, str) or body is not None and not isinstance(body, str) else print(json.dumps({"handle":{"forge_tag":"github","url":url,"number":number},"title":title,"body":body,"state":state}, separators=(",", ":")))' "$response"'''
+examples = [
+  'gh api repos/tesserine/groundwork/issues/369',
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+deployment_value = "repository"
+
+[[parameters]]
+name = "ticket_number"
+purpose = "GitHub issue number to read."
+required = true
+
+[outcome]
+description = "The GitHub issue state is read from the active repository and returned with a schema-compatible work-unit handle."

--- a/mechanics/github/record-progress.toml
+++ b/mechanics/github/record-progress.toml
@@ -1,0 +1,26 @@
+name = "record-progress"
+purpose = "Record progress on a GitHub work-unit issue in the active repository."
+forge_tag = "github"
+default_invocation = '''response=$(mktemp) && trap 'rm -f "$response"' EXIT && gh api "repos/${repository}/issues/${ticket_number}/comments" --method POST -F "body=@${body_file}" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); url=payload.get("html_url"); comment_id=payload.get("id"); sys.exit("GitHub record-progress API response contained errors or omitted comment id/html_url") if "errors" in payload or not isinstance(url, str) or not url or not isinstance(comment_id, int) else print(json.dumps({"comment_url":url,"id":comment_id}, separators=(",", ":")))' "$response"'''
+examples = [
+  'gh api repos/tesserine/groundwork/issues/369/comments --method POST -F body=@/tmp/progress.md',
+]
+
+[[parameters]]
+name = "repository"
+purpose = "GitHub repository in OWNER/REPO form."
+required = true
+deployment_value = "repository"
+
+[[parameters]]
+name = "ticket_number"
+purpose = "GitHub issue number receiving the progress comment."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing progress text."
+required = true
+
+[outcome]
+description = "A GitHub issue comment records work-unit progress and stdout contains the comment identity."

--- a/mechanics/sourcehut/claim-work-unit.toml
+++ b/mechanics/sourcehut/claim-work-unit.toml
@@ -1,0 +1,38 @@
+name = "claim-work-unit"
+purpose = "Claim a SourceHut work-unit ticket by assigning a user in the active tracker."
+forge_tag = "sourcehut"
+default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; tracker_id=int(sys.argv[1]); ticket_number=int(sys.argv[2]); user_id=int(sys.argv[3]); print(json.dumps({"query":"mutation assignUser($trackerId: Int!, $ticketId: Int!, $userId: Int!) { assignUser(trackerId: $trackerId, ticketId: $ticketId, userId: $userId) { id ticket { id ref subject } } }","variables":{"trackerId":tracker_id,"ticketId":ticket_number,"userId":user_id}}))' "$tracker_id" "$ticket_number" "$assignee_user_id" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker_id=int(sys.argv[2]); data=payload.get("data"); event=data.get("assignUser") if isinstance(data, dict) else None; ticket=event.get("ticket") if isinstance(event, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; sys.exit("SourceHut assignUser GraphQL response contained errors or omitted data.assignUser.ticket.id") if "errors" in payload or not isinstance(number, int) else print(json.dumps({"handle":{"forge_tag":"sourcehut","tracker_id":tracker_id,"number":number}}, separators=(",", ":")))' "$response" "$tracker_id"'''
+examples = [
+  '''curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-claim-ticket.json https://todo.sr.ht/query''',
+]
+
+[[parameters]]
+name = "tracker_id"
+purpose = "todo.sr.ht tracker ID containing work-unit tickets."
+required = true
+deployment_value = "tracker_id"
+
+[[parameters]]
+name = "todo_query_url"
+purpose = "SourceHut todo GraphQL endpoint used for assignUser."
+required = true
+deployment_value = "todo_query_url"
+
+[[parameters]]
+name = "ticket_number"
+purpose = "SourceHut ticket number to claim."
+required = true
+
+[[parameters]]
+name = "assignee_user_id"
+purpose = "SourceHut numeric user ID to assign to the ticket."
+required = true
+
+[[parameters]]
+name = "token"
+purpose = "SourceHut API token supplied at command time only; never hardcoded, written, echoed, or logged."
+required = true
+secret = true
+
+[outcome]
+description = "The SourceHut ticket is assigned and the updated ticket identity is returned."

--- a/mechanics/sourcehut/create-ticket.toml
+++ b/mechanics/sourcehut/create-ticket.toml
@@ -1,0 +1,38 @@
+name = "create-ticket"
+purpose = "Create a SourceHut ticket in the active tracker and emit the forge-tagged work-unit handle identity."
+forge_tag = "sourcehut"
+default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; title=sys.argv[1]; body=open(sys.argv[2], encoding="utf-8").read(); tracker_id=int(sys.argv[3]); print(json.dumps({"query":"mutation submitTicket($trackerId: Int!, $input: SubmitTicketInput!) { submitTicket(trackerId: $trackerId, input: $input) { id ref subject } }","variables":{"trackerId":tracker_id,"input":{"subject":title,"body":body}}}))' "$title" "$body_file" "$tracker_id" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker_id=int(sys.argv[2]); data=payload.get("data"); ticket=data.get("submitTicket") if isinstance(data, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; sys.exit("SourceHut submitTicket GraphQL response contained errors or omitted data.submitTicket.id") if "errors" in payload or not isinstance(number, int) else print(json.dumps({"forge_tag":"sourcehut","tracker_id":tracker_id,"number":number}, separators=(",", ":")))' "$response" "$tracker_id"'''
+examples = [
+  '''curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-create-ticket.json https://todo.sr.ht/query''',
+]
+
+[[parameters]]
+name = "tracker_id"
+purpose = "todo.sr.ht tracker ID containing work-unit tickets."
+required = true
+deployment_value = "tracker_id"
+
+[[parameters]]
+name = "todo_query_url"
+purpose = "SourceHut todo GraphQL endpoint used for submitTicket."
+required = true
+deployment_value = "todo_query_url"
+
+[[parameters]]
+name = "title"
+purpose = "Ticket subject for the tracker-backed work-unit."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing the ticket body."
+required = true
+
+[[parameters]]
+name = "token"
+purpose = "SourceHut API token supplied at command time only; never hardcoded, written, echoed, or logged."
+required = true
+secret = true
+
+[outcome]
+description = "A SourceHut ticket exists in the active tracker and stdout contains a work-unit handle with forge_tag, tracker_id, and number."

--- a/mechanics/sourcehut/read-ticket.toml
+++ b/mechanics/sourcehut/read-ticket.toml
@@ -1,10 +1,22 @@
 name = "read-ticket"
 purpose = "Read a SourceHut ticket from the active tracker and emit its ticket state with a work-unit handle."
 forge_tag = "sourcehut"
-default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; tracker_id=sys.argv[1]; ticket_number=int(sys.argv[2]); print(json.dumps({"query":"query readTicket($trackerId: ID!, $ticketId: Int!) { tracker(rid: $trackerId) { ticket(id: $ticketId) { id ref subject body status resolution } } }","variables":{"trackerId":tracker_id,"ticketId":ticket_number}}))' "$tracker_id" "$ticket_number" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker_id=int(sys.argv[2]); data=payload.get("data"); tracker=data.get("tracker") if isinstance(data, dict) else None; ticket=tracker.get("ticket") if isinstance(tracker, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; subject=ticket.get("subject") if isinstance(ticket, dict) else None; body=ticket.get("body") if isinstance(ticket, dict) else None; status=ticket.get("status") if isinstance(ticket, dict) else None; sys.exit("SourceHut read-ticket GraphQL response contained errors or omitted data.tracker.ticket fields") if "errors" in payload or not isinstance(number, int) or not isinstance(subject, str) or body is not None and not isinstance(body, str) or not isinstance(status, str) else print(json.dumps({"handle":{"forge_tag":"sourcehut","tracker_id":tracker_id,"number":number},"title":subject,"body":body,"state":status}, separators=(",", ":")))' "$response" "$tracker_id"'''
+default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; tracker_owner=sys.argv[1]; tracker_name=sys.argv[2]; ticket_number=int(sys.argv[3]); print(json.dumps({"query":"query readTicket($trackerOwner: String!, $trackerName: String!, $ticketId: Int!) { user(username: $trackerOwner) { tracker(name: $trackerName) { id ticket(id: $ticketId) { id ref subject body status resolution } } } }","variables":{"trackerOwner":tracker_owner,"trackerName":tracker_name,"ticketId":ticket_number}}))' "$tracker_owner" "$tracker_name" "$ticket_number" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker_id=int(sys.argv[2]); data=payload.get("data"); user=data.get("user") if isinstance(data, dict) else None; tracker=user.get("tracker") if isinstance(user, dict) else None; ticket=tracker.get("ticket") if isinstance(tracker, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; subject=ticket.get("subject") if isinstance(ticket, dict) else None; body=ticket.get("body") if isinstance(ticket, dict) else None; status=ticket.get("status") if isinstance(ticket, dict) else None; sys.exit("SourceHut read-ticket GraphQL response contained errors or omitted data.user.tracker.ticket fields") if "errors" in payload or not isinstance(number, int) or not isinstance(subject, str) or body is not None and not isinstance(body, str) or not isinstance(status, str) else print(json.dumps({"handle":{"forge_tag":"sourcehut","tracker_id":tracker_id,"number":number},"title":subject,"body":body,"state":status}, separators=(",", ":")))' "$response" "$tracker_id"'''
 examples = [
   '''curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-read-ticket.json https://todo.sr.ht/query''',
 ]
+
+[[parameters]]
+name = "tracker_owner"
+purpose = "SourceHut tracker owner handle."
+required = true
+deployment_value = "owner"
+
+[[parameters]]
+name = "tracker_name"
+purpose = "SourceHut tracker name."
+required = true
+deployment_value = "name"
 
 [[parameters]]
 name = "tracker_id"

--- a/mechanics/sourcehut/read-ticket.toml
+++ b/mechanics/sourcehut/read-ticket.toml
@@ -1,0 +1,33 @@
+name = "read-ticket"
+purpose = "Read a SourceHut ticket from the active tracker and emit its ticket state with a work-unit handle."
+forge_tag = "sourcehut"
+default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; tracker_id=sys.argv[1]; ticket_number=int(sys.argv[2]); print(json.dumps({"query":"query readTicket($trackerId: ID!, $ticketId: Int!) { tracker(rid: $trackerId) { ticket(id: $ticketId) { id ref subject body status resolution } } }","variables":{"trackerId":tracker_id,"ticketId":ticket_number}}))' "$tracker_id" "$ticket_number" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker_id=int(sys.argv[2]); data=payload.get("data"); tracker=data.get("tracker") if isinstance(data, dict) else None; ticket=tracker.get("ticket") if isinstance(tracker, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; subject=ticket.get("subject") if isinstance(ticket, dict) else None; body=ticket.get("body") if isinstance(ticket, dict) else None; status=ticket.get("status") if isinstance(ticket, dict) else None; sys.exit("SourceHut read-ticket GraphQL response contained errors or omitted data.tracker.ticket fields") if "errors" in payload or not isinstance(number, int) or not isinstance(subject, str) or body is not None and not isinstance(body, str) or not isinstance(status, str) else print(json.dumps({"handle":{"forge_tag":"sourcehut","tracker_id":tracker_id,"number":number},"title":subject,"body":body,"state":status}, separators=(",", ":")))' "$response" "$tracker_id"'''
+examples = [
+  '''curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-read-ticket.json https://todo.sr.ht/query''',
+]
+
+[[parameters]]
+name = "tracker_id"
+purpose = "todo.sr.ht tracker ID containing work-unit tickets."
+required = true
+deployment_value = "tracker_id"
+
+[[parameters]]
+name = "todo_query_url"
+purpose = "SourceHut todo GraphQL endpoint used to read the ticket."
+required = true
+deployment_value = "todo_query_url"
+
+[[parameters]]
+name = "ticket_number"
+purpose = "SourceHut ticket number within the active tracker."
+required = true
+
+[[parameters]]
+name = "token"
+purpose = "SourceHut API token supplied at command time only; never hardcoded, written, echoed, or logged."
+required = true
+secret = true
+
+[outcome]
+description = "The SourceHut ticket state is read from the active tracker and returned with a schema-compatible work-unit handle."

--- a/mechanics/sourcehut/record-progress.toml
+++ b/mechanics/sourcehut/record-progress.toml
@@ -1,0 +1,38 @@
+name = "record-progress"
+purpose = "Record progress on a SourceHut work-unit ticket in the active tracker."
+forge_tag = "sourcehut"
+default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; tracker_id=int(sys.argv[1]); ticket_number=int(sys.argv[2]); body=open(sys.argv[3], encoding="utf-8").read(); print(json.dumps({"query":"mutation submitComment($trackerId: Int!, $ticketId: Int!, $input: SubmitCommentInput!) { submitComment(trackerId: $trackerId, ticketId: $ticketId, input: $input) { id ticket { id ref subject } } }","variables":{"trackerId":tracker_id,"ticketId":ticket_number,"input":{"text":body}}}))' "$tracker_id" "$ticket_number" "$body_file" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); event=data.get("submitComment") if isinstance(data, dict) else None; event_id=event.get("id") if isinstance(event, dict) else None; ticket=event.get("ticket") if isinstance(event, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; sys.exit("SourceHut submitComment GraphQL response contained errors or omitted data.submitComment.id/ticket.id") if "errors" in payload or not isinstance(event_id, int) or not isinstance(number, int) else print(json.dumps({"event_id":event_id,"number":number}, separators=(",", ":")))' "$response"'''
+examples = [
+  '''curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-progress.json https://todo.sr.ht/query''',
+]
+
+[[parameters]]
+name = "tracker_id"
+purpose = "todo.sr.ht tracker ID containing work-unit tickets."
+required = true
+deployment_value = "tracker_id"
+
+[[parameters]]
+name = "todo_query_url"
+purpose = "SourceHut todo GraphQL endpoint used for submitComment."
+required = true
+deployment_value = "todo_query_url"
+
+[[parameters]]
+name = "ticket_number"
+purpose = "SourceHut ticket number receiving the progress comment."
+required = true
+
+[[parameters]]
+name = "body_file"
+purpose = "Path to a file containing progress text."
+required = true
+
+[[parameters]]
+name = "token"
+purpose = "SourceHut API token supplied at command time only; never hardcoded, written, echoed, or logged."
+required = true
+secret = true
+
+[outcome]
+description = "A SourceHut ticket comment records work-unit progress and stdout contains the comment event identity."

--- a/schemas/mechanic.schema.json
+++ b/schemas/mechanic.schema.json
@@ -75,6 +75,8 @@
           "type": "string",
           "enum": [
             "repository",
+            "owner",
+            "name",
             "todo_query_url",
             "git_query_url",
             "ssh_remote",

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -243,6 +243,85 @@ class ForgeOperationTests(unittest.TestCase):
         self.assertNotEqual(0, result.returncode)
         self.assertIn("SourceHut submitTicket GraphQL response", result.stderr)
 
+    def test_sourcehut_read_ticket_reaches_tracker_by_owner_and_name_and_keeps_numeric_handle(self) -> None:
+        mechanic = resolve_operation(ROOT, "read-ticket", forge_type="sourcehut")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            response = root / "response.json"
+            payload = root / "payload.json"
+            self.write_fake_command(
+                bin_dir / "curl",
+                f'''
+for arg in "$@"; do
+  case "$arg" in
+    @*) cp "${{arg#@}}" "{payload}" ;;
+  esac
+done
+cat "{response}"
+''',
+            )
+            response.write_text(
+                '{"data":{"user":{"tracker":{"id":4,"ticket":{"id":369,"ref":"todo/369","subject":"Fix read","body":"Ticket body","status":"reported","resolution":null}}}}}\n',
+                encoding="utf-8",
+            )
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
+                    "GROUNDWORK_FORGE_OWNER": "operator",
+                    "GROUNDWORK_FORGE_NAME": "weforge",
+                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                },
+            ):
+                result = run_invocation(
+                    mechanic,
+                    {"ticket_number": "369", "token": "secret-token"},
+                    cwd=root,
+                )
+            graphql_payload = json.loads(payload.read_text(encoding="utf-8"))
+
+            response.write_text('{"errors":[{"message":"no"}],"data":{"user":{"tracker":{"ticket":null}}}}\n', encoding="utf-8")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
+                    "GROUNDWORK_FORGE_OWNER": "operator",
+                    "GROUNDWORK_FORGE_NAME": "weforge",
+                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                },
+            ):
+                error_result = run_invocation(
+                    mechanic,
+                    {"ticket_number": "369", "token": "secret-token"},
+                    cwd=root,
+                )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            {
+                "handle": {"forge_tag": "sourcehut", "tracker_id": 4, "number": 369},
+                "title": "Fix read",
+                "body": "Ticket body",
+                "state": "reported",
+            },
+            json.loads(result.stdout),
+        )
+        self.assertIn("user(username:", graphql_payload["query"])
+        self.assertIn("tracker(name:", graphql_payload["query"])
+        self.assertNotIn("tracker(rid:", graphql_payload["query"])
+        self.assertEqual(
+            {"trackerOwner": "operator", "trackerName": "weforge", "ticketId": 369},
+            graphql_payload["variables"],
+        )
+        self.assertNotEqual(0, error_result.returncode)
+        self.assertIn("SourceHut read-ticket GraphQL response", error_result.stderr)
+
     def test_early_arc_mechanics_reject_caller_supplied_deployment_identity(self) -> None:
         cases = [
             ("github", "create-ticket", {"repository": "attacker/repo"}),

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -4,8 +4,10 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import tomllib
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from tooling.forge_operations import (
     ForgeOperationError,
@@ -17,6 +19,7 @@ from tooling.forge_operations import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+EARLY_ARC_OPERATIONS = ["create-ticket", "read-ticket", "claim-work-unit", "record-progress"]
 
 
 class ForgeOperationTests(unittest.TestCase):
@@ -120,6 +123,143 @@ class ForgeOperationTests(unittest.TestCase):
         self.assertIn("close-out", str(context.exception))
         self.assertIn("github", str(context.exception))
         self.assertIn("resolves to 2", str(context.exception))
+
+    def test_source_manifest_declares_early_arc_ticket_operations_for_each_forge(self) -> None:
+        manifest = tomllib.loads((ROOT / "manifest.toml").read_text(encoding="utf-8"))
+        mechanics = {entry["name"]: entry for entry in manifest["mechanics"]}
+
+        for operation in EARLY_ARC_OPERATIONS:
+            with self.subTest(operation=operation):
+                self.assertEqual(["github", "sourcehut"], mechanics[operation]["forge_tags"])
+
+    def test_source_tree_resolves_early_arc_ticket_operations_for_each_forge(self) -> None:
+        for operation in EARLY_ARC_OPERATIONS:
+            for forge_type in ["github", "sourcehut"]:
+                with self.subTest(operation=operation, forge_type=forge_type):
+                    mechanic = resolve_operation(ROOT, operation, forge_type=forge_type)
+                    self.assertEqual(operation, mechanic["name"])
+                    self.assertEqual(forge_type, mechanic["forge_tag"])
+
+    def test_github_create_ticket_emits_work_unit_handle_and_rejects_missing_result(self) -> None:
+        mechanic = resolve_operation(ROOT, "create-ticket", forge_type="github")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            response = root / "response.json"
+            args = root / "args.txt"
+            body = root / "body.md"
+            body.write_text("Ticket body\n", encoding="utf-8")
+            self.write_fake_command(bin_dir / "gh", f'printf "%s\\n" "$*" > "{args}"; cat "{response}"')
+            response.write_text('{"html_url":"https://github.com/tesserine/groundwork/issues/381","number":381}\n', encoding="utf-8")
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                    "GROUNDWORK_FORGE_OWNER": "tesserine",
+                    "GROUNDWORK_FORGE_NAME": "groundwork",
+                },
+            ):
+                result = run_invocation(
+                    mechanic,
+                    {"title": "Add ticket", "body_file": str(body)},
+                    cwd=root,
+                )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual(
+                {"forge_tag": "github", "url": "https://github.com/tesserine/groundwork/issues/381", "number": 381},
+                json.loads(result.stdout),
+            )
+            self.assertIn("repos/tesserine/groundwork/issues", args.read_text(encoding="utf-8"))
+
+            response.write_text('{"message":"created but omitted issue identity"}\n', encoding="utf-8")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                    "GROUNDWORK_FORGE_OWNER": "tesserine",
+                    "GROUNDWORK_FORGE_NAME": "groundwork",
+                },
+            ):
+                result = run_invocation(
+                    mechanic,
+                    {"title": "Add ticket", "body_file": str(body)},
+                    cwd=root,
+                )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("GitHub create-ticket API response", result.stderr)
+
+    def test_sourcehut_create_ticket_emits_work_unit_handle_and_rejects_graphql_errors(self) -> None:
+        mechanic = resolve_operation(ROOT, "create-ticket", forge_type="sourcehut")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            response = root / "response.json"
+            args = root / "args.txt"
+            body = root / "body.md"
+            body.write_text("Ticket body\n", encoding="utf-8")
+            self.write_fake_command(bin_dir / "curl", f'printf "%s\\n" "$*" > "{args}"; cat "{response}"')
+            response.write_text('{"data":{"submitTicket":{"id":27,"ref":"todo/27","subject":"Add ticket"}}}\n', encoding="utf-8")
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
+                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                },
+            ):
+                result = run_invocation(
+                    mechanic,
+                    {"title": "Add ticket", "body_file": str(body), "token": "secret-token"},
+                    cwd=root,
+                )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual({"forge_tag": "sourcehut", "tracker_id": 4, "number": 27}, json.loads(result.stdout))
+            self.assertIn("https://todo.weforge.build/query", args.read_text(encoding="utf-8"))
+
+            response.write_text('{"errors":[{"message":"no"}],"data":{"submitTicket":null}}\n', encoding="utf-8")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
+                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                },
+            ):
+                result = run_invocation(
+                    mechanic,
+                    {"title": "Add ticket", "body_file": str(body), "token": "secret-token"},
+                    cwd=root,
+                )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("SourceHut submitTicket GraphQL response", result.stderr)
+
+    def test_early_arc_mechanics_reject_caller_supplied_deployment_identity(self) -> None:
+        cases = [
+            ("github", "create-ticket", {"repository": "attacker/repo"}),
+            ("sourcehut", "create-ticket", {"tracker_id": "99"}),
+            ("sourcehut", "record-progress", {"todo_query_url": "https://attacker.invalid/query"}),
+        ]
+
+        for forge_type, operation, forbidden_values in cases:
+            with self.subTest(forge_type=forge_type, operation=operation):
+                mechanic = resolve_operation(ROOT, operation, forge_type=forge_type)
+                values = self.required_non_deployment_values(operation, forge_type)
+                values.update(forbidden_values)
+
+                with self.assertRaises(ForgeOperationError) as context:
+                    render_shell_invocation(mechanic, values)
+
+                self.assertIn("deployment-resolved parameter(s)", str(context.exception))
 
     def test_inspect_invocation_never_renders_secret_values(self) -> None:
         mechanic = {
@@ -430,6 +570,28 @@ class ForgeOperationTests(unittest.TestCase):
         self.assertNotEqual(0, result.returncode)
         self.assertIn("deployment-resolved parameter(s)", result.stderr)
         self.assertIn("repository", result.stderr)
+
+    def required_non_deployment_values(self, operation: str, forge_type: str) -> dict[str, str]:
+        if operation == "create-ticket":
+            values = {"title": "Title", "body_file": "/tmp/body.md"}
+        elif operation == "read-ticket":
+            values = {"ticket_number": "1"}
+        elif operation == "claim-work-unit":
+            values = {"ticket_number": "1", "assignee": "operator", "assignee_user_id": "7"}
+        elif operation == "record-progress":
+            values = {"ticket_number": "1", "body_file": "/tmp/progress.md"}
+        else:
+            values = {}
+        if forge_type == "github":
+            values.pop("assignee_user_id", None)
+        if forge_type == "sourcehut":
+            values.pop("assignee", None)
+            values["token"] = "secret-token"
+        return values
+
+    def write_fake_command(self, path: Path, body: str) -> None:
+        path.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+        path.chmod(0o755)
 
     def write_secret_probe_methodology(self, root: Path, invocation: str) -> None:
         (root / "manifest.toml").write_text(

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -28,10 +28,14 @@ CATEGORY_UNKNOWN = "unknown"
 
 DIRECT_UNIT_DIRECTORY_NAMES = {"workflow-contracts", "mechanics", "schemas"}
 FORGE_TOUCHING_OPERATIONS = {
-    "deliver-change-proposal",
     "apply-approved-change",
-    "reflect-disposition",
+    "claim-work-unit",
     "close-out",
+    "create-ticket",
+    "deliver-change-proposal",
+    "read-ticket",
+    "record-progress",
+    "reflect-disposition",
 }
 FORGE_LEAKAGE_TOKEN_PATTERNS = {
     "gh": r"(?<![A-Za-z0-9_-])gh(?![A-Za-z0-9_-])",

--- a/tooling/forge_operations.py
+++ b/tooling/forge_operations.py
@@ -228,6 +228,10 @@ def _resolve_deployment_value(
     environment: Mapping[str, str],
 ) -> str:
     if forge_type == "github":
+        if deployment_value == "owner":
+            return _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
+        if deployment_value == "name":
+            return _required_environment(environment, "GROUNDWORK_FORGE_NAME")
         if deployment_value == "repository":
             owner = _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
             name = _required_environment(environment, "GROUNDWORK_FORGE_NAME")
@@ -236,6 +240,10 @@ def _resolve_deployment_value(
             f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
         )
     if forge_type == "sourcehut":
+        if deployment_value == "owner":
+            return _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
+        if deployment_value == "name":
+            return _required_environment(environment, "GROUNDWORK_FORGE_NAME")
         if deployment_value == "repository":
             owner = _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
             name = _required_environment(environment, "GROUNDWORK_FORGE_NAME")

--- a/tooling/forge_operations.py
+++ b/tooling/forge_operations.py
@@ -55,12 +55,13 @@ def inspect_invocation(mechanic: Mapping[str, Any], values: Mapping[str, str]) -
 
 def render_shell_invocation(mechanic: Mapping[str, Any], values: Mapping[str, str]) -> tuple[str, dict[str, str]]:
     parameters = _parameters(mechanic)
-    deployment_values = _deployment_parameter_values(mechanic, os.environ)
-    provided_deployment_values = sorted(set(values) & set(deployment_values))
+    deployment_parameters = _deployment_parameters(mechanic)
+    provided_deployment_values = sorted(set(values) & set(deployment_parameters))
     if provided_deployment_values:
         raise ForgeOperationError(
             f"deployment-resolved parameter(s) must come from GROUNDWORK_*: {', '.join(provided_deployment_values)}"
         )
+    deployment_values = _deployment_parameter_values(mechanic, os.environ)
     resolved_values = {**values, **deployment_values}
     missing = [name for name, parameter in parameters.items() if parameter.get("required") and name not in resolved_values]
     if missing:


### PR DESCRIPTION
## Summary

- Adds forge-tagged early-arc ticket operations for GitHub issues and SourceHut tickets.
- Routes repository/tracker identity through the existing `GROUNDWORK_*` deployment contract instead of caller-provided deployment bindings.
- Validates expected API/GraphQL result fields before accepting ticket creation, reads, claims, or progress records.

## Changes

- Declares `create-ticket`, `read-ticket`, `claim-work-unit`, and `record-progress` in `manifest.toml` for both `github` and `sourcehut`.
- Adds eight C-3 mechanic recipes under `mechanics/github` and `mechanics/sourcehut`.
- Extends forge-operation/conformance tests and rejects caller-supplied deployment parameters before requiring environment atoms.
- Updates README mechanic-facing docs and CHANGELOG entries for the early-arc operation contract.

## GitHub Issue(s)

Closes #369

## Test plan

- `python -m unittest discover -s tests`
- `python -m tooling.conformance`
