### PR TITLE
feat(decompose): deliver ticket-backed work-units with handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   deployment atoms, validate expected API/GraphQL result fields, and expose
   forge-assigned ticket identities for schema-conforming work-unit handles
   (closes #369).
+- Ticket-backed decompose delivery: tracker-backed work-units now create the
+  tracker ticket before artifact delivery, use ticket-derived
+  `work-unit-<N>-<short-slug>` instance ids, populate `handle` from the
+  returned forge identity, and preserve unchanged bare-slug/no-handle delivery
+  for non-tracker work-units (closes #370).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,11 +72,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   deployment atoms, validate expected API/GraphQL result fields, and expose
   forge-assigned ticket identities for schema-conforming work-unit handles
   (closes #369).
-- Ticket-backed decompose delivery: tracker-backed work-units now create the
-  tracker ticket before artifact delivery, use ticket-derived
-  `work-unit-<N>-<short-slug>` instance ids, populate `handle` from the
-  returned forge identity, and preserve unchanged bare-slug/no-handle delivery
-  for non-tracker work-units (closes #370).
+- Ticket-backed decompose delivery: new tracker-backed work-units now create
+  the tracker ticket before first artifact delivery, use ticket-derived
+  `work-unit-<N>-<short-slug>` instance ids, populate `handle` exactly once
+  from the returned forge identity, preserve that handle across refinements,
+  and preserve unchanged bare-slug/no-handle delivery for non-tracker
+  work-units (closes #370).
 
 ### Changed
 

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -938,15 +938,18 @@ how to know it's done, and whether it's ready to start.
 | out_of_scope | array of strings | no | Explicit nearby exclusions |
 | dependencies | array of work-unit refs | no | Work-units that must be complete before this starts, referenced by `instance_id` |
 
-Tracker-backed work-units use `instance_id` convention
-`work-unit-<N>-<short-slug>` on first delivery; work-units without tracker
-linkage use `<short-slug>`. Dependency references use those exact
-`instance_id` values.
+Tracker-backed work-units create the forge ticket before first delivery and
+use `instance_id` convention `work-unit-<N>-<short-slug>`, where `<N>` is the
+forge-assigned ticket number. Work-units without tracker linkage use
+`<short-slug>`. Dependency references use those exact `instance_id` values,
+not tracker shorthand.
 
-Tracker-backed work-units may also carry an optional forge-tagged ticket
-`handle`; non-tracker work-units omit it. The body remains unpartitioned and
-does not carry a top-level `work_unit` field. GitHub handles name an issue URL
-and number; SourceHut handles name a tracker ID and ticket number.
+Tracker-backed work-units populate `handle` exactly once from the
+forge-assigned ticket identity returned by `create-ticket`; non-tracker
+work-units omit it. The body remains unpartitioned and does not carry a
+top-level `work_unit` field or forge-specific identity outside `handle`.
+GitHub handles name an issue URL and number; SourceHut handles name a tracker
+ID and ticket number.
 
 ### Traceability Thread
 

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -171,26 +171,31 @@ surfaces. Full runa-native `decompose` — where work-units live as runa
 artifacts with tracker as an optional sync target — is separate future work.
 
 Deliver each `work-unit` artifact by invoking the `work-unit` MCP tool once
-per delivered artifact. The object below is MCP tool input, not artifact body.
-`instance_id` is a tool parameter that names the artifact instance; it is
-extracted before validating artifact content, becomes the workspace filename,
-and must not appear in the artifact body. `work-unit` is a planning-phase
-artifact: the agent supplies the schema fields shown below, and runa does not
-inject `work_unit`. Do not write the workspace JSON file directly.
+per delivered artifact. For tracker-backed work-units, create the tracker
+ticket before invoking the `work-unit` MCP tool so the artifact can use the
+forge-assigned ticket identity. The object below is MCP tool input, not
+artifact body. `instance_id` is a tool parameter that names the artifact
+instance; it is extracted before validating artifact content, becomes the
+workspace filename, and must not appear in the artifact body. `work-unit` is a
+planning-phase artifact: the agent supplies the schema fields shown below, and
+runa does not inject `work_unit`. Work-unit artifact bodies have no top-level
+`work_unit` field and no forge-specific identity outside `handle`. Do not write
+the workspace JSON file directly.
 
-Use a fresh `instance_id` when creating a new
-work-unit. Reuse the existing `instance_id` when refining an already-delivered
-work-unit artifact so artifact identity and inbound dependency references
-remain stable. For a work-unit that exists in the tracker but has not
-previously been delivered through this MCP flow, the first MCP delivery
-uses the reversible tracker-backed convention
-`work-unit-<N>-<short-slug>`, where `<N>` is the tracker identifier. For a
-work-unit with no tracker linkage, first delivery uses `<short-slug>` directly.
-Subsequent updates reuse the `instance_id` established at first delivery. In
-this section, "refining an existing work-unit" means refining an existing
-artifact, not merely refining a tracker item.
+Use a fresh `instance_id` when creating a new work-unit. Reuse the existing
+`instance_id` when refining an already-delivered work-unit artifact so artifact
+identity and inbound dependency references remain stable. A new tracker-backed
+work-unit first calls the active forge's `create-ticket` mechanic. First MCP
+delivery then uses `work-unit-<N>-<short-slug>`, where `<N>` is the
+forge-assigned ticket number, and must populate `handle` exactly once from the
+identity returned by `create-ticket`. Non-tracker work-units omit `handle` and
+first delivery uses `<short-slug>` directly. Subsequent updates reuse the
+`instance_id` established at first delivery. In this section, "refining an
+existing work-unit" means refining an existing artifact, not merely refining a
+tracker item.
 
-For new work-units produced by `create-work-unit` or `decompose-epic`:
+For new tracker-backed work-units produced by `create-work-unit` or
+`decompose-epic`:
 
 ```
 work-unit({
@@ -200,7 +205,27 @@ work-unit({
   acceptance_criteria: ["..."],
   scope: ["decompose delivery", "take framing"],
   out_of_scope: ["submit protocol", "land protocol"],
-  dependencies: ["work-unit-122-artifact-store-cleanup"]
+  dependencies: ["work-unit-122-artifact-store-cleanup"],
+  handle: {
+    forge_tag: "github",
+    url: "<issue URL returned by create-ticket>",
+    number: 123
+  }
+})
+```
+
+For new non-tracker work-units produced by `create-work-unit` or
+`decompose-epic`:
+
+```
+work-unit({
+  instance_id: "pipeline-refactor",
+  title: "<type(scope): what>",
+  description: "<what needs doing and why>",
+  acceptance_criteria: ["..."],
+  scope: ["decompose delivery", "take framing"],
+  out_of_scope: ["submit protocol", "land protocol"],
+  dependencies: ["artifact-store-cleanup"]
 })
 ```
 
@@ -225,13 +250,11 @@ one.
 Runa validates the remaining artifact body fields against the `work-unit`
 schema, persists the artifact under the given `instance_id`, and records it in
 the artifact store.
-The `dependencies` field takes the target work-units' exact `instance_id`
-values, not tracker references such as `#123`. For tracker-backed
-dependencies, first delivery uses the same reversible
-`work-unit-<N>-<short-slug>` convention, so later sessions can recover the
-tracker identifier directly from the artifact identifier without maintaining a
-separate mapping. For non-tracker-backed dependencies, use the dependency's
-bare `<short-slug>` `instance_id`.
+Dependency references must use canonical delivered work-unit `instance_id`
+values, not tracker shorthand such as `#123`, `123`, `work-unit-123`, or
+`issue-123`. For tracker-backed dependencies, first delivery uses the same
+`work-unit-<N>-<short-slug>` convention. For non-tracker-backed dependencies,
+use the dependency's bare `<short-slug>` `instance_id`.
 
 ## Triggers
 

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -171,16 +171,19 @@ surfaces. Full runa-native `decompose` — where work-units live as runa
 artifacts with tracker as an optional sync target — is separate future work.
 
 Deliver each `work-unit` artifact by invoking the `work-unit` MCP tool once
-per delivered artifact. For tracker-backed work-units, create the tracker
-ticket before invoking the `work-unit` MCP tool so the artifact can use the
-forge-assigned ticket identity. The object below is MCP tool input, not
-artifact body. `instance_id` is a tool parameter that names the artifact
-instance; it is extracted before validating artifact content, becomes the
-workspace filename, and must not appear in the artifact body. `work-unit` is a
-planning-phase artifact: the agent supplies the schema fields shown below, and
-runa does not inject `work_unit`. Work-unit artifact bodies have no top-level
-`work_unit` field and no forge-specific identity outside `handle`. Do not write
-the workspace JSON file directly.
+per delivered artifact. For tracker-backed work-units that decompose is newly
+creating, create the tracker ticket before invoking the `work-unit` MCP tool so
+the artifact can use the forge-assigned ticket identity. `create-ticket` is a
+first-delivery-only step: refinement never calls it, and decompose does not
+adopt a pre-existing tracker ticket into a new artifact. If a tracker ticket
+already exists, this delivery path must not create a second ticket for it. The
+object below is MCP tool input, not artifact body. `instance_id` is a tool
+parameter that names the artifact instance; it is extracted before validating
+artifact content, becomes the workspace filename, and must not appear in the
+artifact body. `work-unit` is a planning-phase artifact: the agent supplies the
+schema fields shown below, and runa does not inject `work_unit`. Work-unit
+artifact bodies have no top-level `work_unit` field and no forge-specific
+identity outside `handle`. Do not write the workspace JSON file directly.
 
 Use a fresh `instance_id` when creating a new work-unit. Reuse the existing
 `instance_id` when refining an already-delivered work-unit artifact so artifact
@@ -190,9 +193,12 @@ delivery then uses `work-unit-<N>-<short-slug>`, where `<N>` is the
 forge-assigned ticket number, and must populate `handle` exactly once from the
 identity returned by `create-ticket`. Non-tracker work-units omit `handle` and
 first delivery uses `<short-slug>` directly. Subsequent updates reuse the
-`instance_id` established at first delivery. In this section, "refining an
-existing work-unit" means refining an existing artifact, not merely refining a
-tracker item.
+`instance_id` established at first delivery. If the artifact is tracker-backed,
+subsequent updates also carry the existing `handle` through unchanged from the
+previously delivered artifact body. Do not call `create-ticket`, re-derive
+`handle`, or omit `handle` during refinement; MCP delivery persists the
+submitted body. In this section, "refining an existing work-unit" means
+refining an existing artifact, not merely refining a tracker item.
 
 For new tracker-backed work-units produced by `create-work-unit` or
 `decompose-epic`:
@@ -239,7 +245,12 @@ work-unit({
   acceptance_criteria: ["..."],
   scope: ["decompose delivery", "take framing"],
   out_of_scope: ["submit protocol", "land protocol"],
-  dependencies: ["work-unit-122-artifact-store-cleanup"]
+  dependencies: ["work-unit-122-artifact-store-cleanup"],
+  handle: {
+    forge_tag: "github",
+    url: "<existing issue URL from the delivered artifact handle>",
+    number: 123
+  }
 })
 ```
 

--- a/tests/test_protocol_artifact_delivery_docs.py
+++ b/tests/test_protocol_artifact_delivery_docs.py
@@ -83,6 +83,22 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
                 )
                 self.assertNotIn("validates the payload against", validation_sentence.group(0))
 
+    def test_decompose_delivery_docs_preserve_ticket_backed_work_unit_identity_rules(self) -> None:
+        body = normalized_protocol("decompose")
+
+        for expected in [
+            "create the tracker ticket before invoking the `work-unit` MCP tool",
+            "`work-unit-<N>-<short-slug>`, where `<N>` is the forge-assigned ticket number",
+            "populate `handle` exactly once from the identity returned by `create-ticket`",
+            "Non-tracker work-units omit `handle`",
+            "no top-level `work_unit` field",
+            "no forge-specific identity outside `handle`",
+            "Dependency references must use canonical delivered work-unit `instance_id` values",
+            "not tracker shorthand such as `#123`, `123`, `work-unit-123`, or `issue-123`",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_protocol_artifact_delivery_docs.py
+++ b/tests/test_protocol_artifact_delivery_docs.py
@@ -18,6 +18,10 @@ def normalized_protocol(name: str) -> str:
     return re.sub(r"\s+", " ", text)
 
 
+def protocol_text(name: str) -> str:
+    return (PROTOCOLS_DIR / name / "PROTOCOL.md").read_text(encoding="utf-8")
+
+
 class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
     def test_all_artifact_producing_protocols_explain_mcp_tool_input_boundary(self) -> None:
         producers = [protocol for protocol in manifest_protocols() if protocol["produces"]]
@@ -87,9 +91,15 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
         body = normalized_protocol("decompose")
 
         for expected in [
-            "create the tracker ticket before invoking the `work-unit` MCP tool",
+            "For tracker-backed work-units that decompose is newly creating, create the tracker ticket before invoking the `work-unit` MCP tool",
+            "`create-ticket` is a first-delivery-only step",
+            "refinement never calls it",
+            "decompose does not adopt a pre-existing tracker ticket into a new artifact",
+            "must not create a second ticket",
             "`work-unit-<N>-<short-slug>`, where `<N>` is the forge-assigned ticket number",
             "populate `handle` exactly once from the identity returned by `create-ticket`",
+            "carry the existing `handle` through unchanged",
+            "Do not call `create-ticket`, re-derive `handle`, or omit `handle` during refinement",
             "Non-tracker work-units omit `handle`",
             "no top-level `work_unit` field",
             "no forge-specific identity outside `handle`",
@@ -98,6 +108,27 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
         ]:
             with self.subTest(expected=expected):
                 self.assertIn(expected, body)
+
+    def test_decompose_refine_work_unit_example_carries_existing_handle(self) -> None:
+        body = protocol_text("decompose")
+        match = re.search(
+            r"For refinements produced by `refine-work-unit`:\n\n```(?P<example>.*?)```",
+            body,
+            flags=re.DOTALL,
+        )
+
+        self.assertIsNotNone(match)
+        example = match.group("example")
+
+        for expected in [
+            'instance_id: "<existing-instance-id>"',
+            "handle: {",
+            'forge_tag: "github"',
+            'url: "<existing issue URL from the delivered artifact handle>"',
+            "number: 123",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, example)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Teach `decompose` that tracker-backed work-units create the tracker ticket before artifact delivery.
- Document canonical ticket-derived `work-unit-<N>-<short-slug>` instance ids and exactly-once `handle` population from `create-ticket`.
- Preserve unchanged bare-slug, no-handle delivery for non-tracker work-units.

## Changes

- Updates the decompose delivery contract and examples for tracker-backed and non-tracker work-units.
- Aligns the architecture reference and changelog with the ticket-backed delivery contract.
- Adds protocol-doc coverage for canonical instance-id, handle, body-shape, and dependency-reference rules.

## GitHub Issue(s)

Closes #370

## Test plan

- `python -m unittest tests.test_protocol_artifact_delivery_docs`
- `python -m unittest discover -s tests`
- `python -m tooling.conformance`
