### PR TITLE
docs(forge-tagging): document the phase-2 repo seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   from the returned forge identity, preserve that handle across refinements,
   and preserve unchanged bare-slug/no-handle delivery for non-tracker
   work-units (closes #370).
+- Phase-2 forge-tagging seam documentation: README-accessible architecture
+  docs now explain the boundary between Groundwork-owned handle structure,
+  mechanics/decompose handle production, and runa-owned scoped runtime
+  enforcement for exact work-unit ids and active deployment agreement
+  (closes #371).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ directly from their atoms. For GitHub, it derives `repository` as
 `<owner>/<name>`. The atoms are the only deployment facts; composed endpoints
 and remotes are not separate configuration values.
 
+The cross-repo seam for this ticket identity is documented in
+[`docs/architecture/connecting-structure.md`](docs/architecture/connecting-structure.md#phase-2-forge-tagging-seam).
+Groundwork owns the schema-as-contract shape of `work-unit.handle`, the
+mechanics that produce handles from active deployment identity, and the
+decompose delivery rules. runa owns scoped runtime enforcement: exact recorded
+`--work-unit` ids, tracker-handle consistency, duplicate-root rejection, and
+active deployment agreement. Cross-deployment work is composed from separate
+sessions; a handle never overrides the active deployment.
+
 The source checkout must be clean and pinned at a tag or full commit SHA. The
 command refuses branch checkouts because a branch is a moving source. To update
 to a different pinned Groundwork version, check out that ref and run:

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -951,6 +951,42 @@ top-level `work_unit` field or forge-specific identity outside `handle`.
 GitHub handles name an issue URL and number; SourceHut handles name a tracker
 ID and ticket number.
 
+### Phase-2 Forge-Tagging Seam
+
+The `work-unit.handle` field is the schema-as-contract seam between Groundwork
+and runa. Groundwork owns structural validity: the optional handle variants in
+`schemas/work-unit.schema.json`, conformance and artifact tooling, registered
+forge-tag membership, and GitHub `url`/`number` agreement. The released
+Groundwork contract was introduced by [#368](https://github.com/tesserine/groundwork/issues/368)
+and merged by [PR #372](https://github.com/tesserine/groundwork/pull/372);
+downstream consumers pin the release tag that contains that contract or the
+merged full commit SHA, never a branch or pre-merge ref.
+
+Groundwork also owns production of schema-conforming handles. The early-arc
+mechanics from [#369](https://github.com/tesserine/groundwork/issues/369) /
+[PR #373](https://github.com/tesserine/groundwork/pull/373) resolve active
+deployment identity from the `#362` `GROUNDWORK_*` atoms, create/read/claim
+tracker tickets, record progress, and return the forge-assigned identity needed
+for `handle`. The decompose delivery rules from
+[#370](https://github.com/tesserine/groundwork/issues/370) /
+[PR #374](https://github.com/tesserine/groundwork/pull/374) create the tracker
+ticket before first work-unit delivery, use the ticket-derived
+`work-unit-<N>-<short-slug>` instance id, and carry the returned handle exactly
+once. Together, the mechanics and decompose path act on the active `#362`
+deployment identity and produce schema-conforming handles. Those child issues
+carried their own local docs and changelog updates; this section ties their
+repo boundary together.
+
+runa owns runtime enforcement that cannot be expressed by Groundwork's schema.
+The guard in [tesserine/runa#163](https://github.com/tesserine/runa/issues/163)
+merged by [tesserine/runa#164](https://github.com/tesserine/runa/pull/164)
+implements the exact-or-reject `--work-unit` rule for recorded work-unit roots,
+checks instance-id/handle number agreement, rejects duplicate roots for the same
+forge ticket identity, and rejects valid tracker handles whose forge location
+does not match the active `GROUNDWORK_*` deployment. A session has one active
+deployment. Cross-deployment work is represented as separate sessions; runa does
+not switch deployment identity because a handle points somewhere else.
+
 ### Traceability Thread
 
 Acceptance criteria on the work-unit are the high-level "done" statements.


### PR DESCRIPTION
## Summary

- Adds a README-accessible pointer to the phase-2 forge-tagging seam.
- Documents the ownership split between Groundwork's schema/conformance/mechanics/decompose responsibilities and runa's scoped runtime identity guard.
- Records the seam documentation in the changelog.

## Changes

- Adds the architecture seam section for `work-unit.handle`, exact-or-reject `--work-unit`, active deployment agreement, and cross-deployment session composition.
- Cites the landed Groundwork children #368, #369, #370 and the runa guard tesserine/runa#163.
- Confirms the child implementation slices carried their own local docs/changelog updates.

## GitHub Issue(s)

Closes #371
Part of #363

## Test plan

- `python -m unittest discover -s tests`
- `python -m tooling.conformance`
- `git diff --check`
