### PR TITLE
Add --from-branch opt-in to install the current branch HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,19 @@ removing entries that no longer exist upstream. `scripts/groundwork-install
 status` reports the recorded install state, and `scripts/groundwork-install
 uninstall` removes only entries the command created.
 
+Methodology authors who develop Groundwork itself and want their working branch
+reflected in the live discovery surface can pass `--from-branch` to install or
+sync the current branch HEAD instead of a detached pinned ref:
+
+```bash
+scripts/groundwork-install sync --from-branch
+```
+
+The checkout must still be clean — `--from-branch` relaxes only the pinned-ref
+requirement, not the clean-checkout requirement, so the recorded `source-sha`
+always identifies a real commit. Because a branch is a moving source, this is an
+opt-in for development; the default still requires a pinned tag or commit SHA.
+
 Ownership is tracked in both a per-entry marker file and an XDG state file at
 `${XDG_STATE_HOME:-~/.local/state}/groundwork-install/interactive-install.tsv`.
 Pre-existing entries, including unofficial symlinks with the same names, are

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -8,10 +8,13 @@ INTERACTIVE_ADAPTER_PATH="scripts/interactive-artifact-delivery-adapter.md"
 
 usage() {
   cat <<'EOF'
-usage: groundwork-install [install|sync|status|uninstall] [--source PATH] [--home PATH] [--state-dir PATH]
+usage: groundwork-install [install|sync|status|uninstall] [--source PATH] [--home PATH] [--state-dir PATH] [--from-branch]
 
 Installs this pinned Groundwork checkout into Claude Code and Codex skill
 discovery directories. The default subcommand is install.
+
+--from-branch installs the current branch HEAD instead of requiring a detached
+pinned tag or commit. The source checkout must still be clean.
 EOF
 }
 
@@ -41,6 +44,7 @@ mode="install"
 source_path="."
 home_path="${HOME:-}"
 state_dir=""
+allow_branch=0
 
 if [[ "${1:-}" == "install" || "${1:-}" == "sync" || "${1:-}" == "status" || "${1:-}" == "uninstall" ]]; then
   mode="$1"
@@ -63,6 +67,10 @@ while [[ "$#" -gt 0 ]]; do
       [[ "$#" -ge 2 ]] || die "--state-dir requires a path"
       state_dir="$2"
       shift 2
+      ;;
+    --from-branch)
+      allow_branch=1
+      shift
       ;;
     -h|--help)
       usage
@@ -99,8 +107,8 @@ validate_source() {
   [[ -d "$source_path/skills" ]] || die "source has no skills directory"
   [[ -d "$source_path/protocols" ]] || die "source has no protocols directory"
   [[ -z "$(git -C "$source_path" status --porcelain)" ]] || die "source checkout is dirty; install from a pinned clean checkout"
-  if git -C "$source_path" symbolic-ref -q --short HEAD >/dev/null; then
-    die "source must be a pinned checkout at a tag or full commit SHA, not a branch"
+  if [[ "$allow_branch" -ne 1 ]] && git -C "$source_path" symbolic-ref -q --short HEAD >/dev/null; then
+    die "source must be a pinned checkout at a tag or full commit SHA, not a branch (pass --from-branch to install the current branch HEAD)"
   fi
   git -C "$source_path" cat-file -e "$(source_sha):$INTERACTIVE_ADAPTER_PATH" 2>/dev/null ||
     die "source has no interactive artifact delivery adapter at $INTERACTIVE_ADAPTER_PATH"

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -82,6 +82,8 @@ class MethodologyFixture:
         run(["git", "init", "-q"], self.root, check=True)
         run(["git", "config", "user.name", "installer test"], self.root, check=True)
         run(["git", "config", "user.email", "installer-test@example.invalid"], self.root, check=True)
+        run(["git", "config", "commit.gpgsign", "false"], self.root, check=True)
+        run(["git", "config", "tag.gpgsign", "false"], self.root, check=True)
         run(["git", "checkout", "-q", "-b", "main"], self.root, check=True)
         run(["git", "add", "."], self.root, check=True)
         run(["git", "commit", "-q", "-m", "test: seed methodology"], self.root, check=True)
@@ -695,6 +697,53 @@ class GroundworkInstallTests(unittest.TestCase):
         install = InstallRun(self, fixture.root)
 
         result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "dirty")
+
+    def test_install_from_branch_installs_committed_branch_head(self) -> None:
+        fixture = self.add_fixture("from-branch")
+        fixture.checkout_branch()
+        expected_sha = run(["git", "rev-parse", "HEAD"], fixture.root, check=True).stdout.strip()
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install", "--from-branch")
+
+        assert_success(self, result)
+        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
+        recorded = {
+            line.split("\t")[3]
+            for line in install.state_file().read_text(encoding="utf-8").splitlines()
+        }
+        self.assertEqual(recorded, {expected_sha})
+
+    def test_sync_from_branch_converges_to_the_moving_branch_head(self) -> None:
+        fixture = self.add_fixture("sync-from-branch")
+        fixture.checkout_branch()
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install", "--from-branch"))
+
+        fixture.write("skills/added/SKILL.md", "---\nname: added\n---\n# Added\n")
+        run(["git", "add", "."], fixture.root, check=True)
+        run(["git", "commit", "-q", "-m", "test: advance branch"], fixture.root, check=True)
+        advanced_sha = run(["git", "rev-parse", "HEAD"], fixture.root, check=True).stdout.strip()
+
+        result = install.run_installer("sync", "--from-branch")
+
+        assert_success(self, result)
+        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit", "added"})
+        recorded = {
+            line.split("\t")[3]
+            for line in install.state_file().read_text(encoding="utf-8").splitlines()
+        }
+        self.assertEqual(recorded, {advanced_sha})
+
+    def test_from_branch_does_not_bypass_dirty_source_checkouts(self) -> None:
+        fixture = self.add_fixture("from-branch-dirty")
+        fixture.checkout_branch()
+        fixture.write("skills/orient/SKILL.md", "# changed\n")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install", "--from-branch")
 
         assert_failure_contains(self, result, "dirty")
 


### PR DESCRIPTION
## What

Adds a `--from-branch` opt-in flag to `scripts/groundwork-install` so authors developing Groundwork itself can install/sync the **current branch HEAD** instead of being forced to detach to a pinned tag or commit SHA first.

```bash
scripts/groundwork-install sync --from-branch
```

## Why

The installer required a detached pinned ref and refused branch checkouts ("a branch is a moving source"). For day-to-day development of Groundwork, that meant detaching to a SHA before every install/sync just to see your working branch reflected in the live skill-discovery surface.

## Design

- **Opt-in, not the new default.** The branch refusal in `validate_source` is now gated on the flag. Without `--from-branch`, the installer still refuses branches, so the pinned-ref reproducibility guarantee is unchanged for all existing callers.
- **Committed HEAD only.** `--from-branch` relaxes *only* the pinned-ref requirement. The clean-checkout requirement still holds, projection is still `git archive HEAD`, and the recorded `source-sha` in every marker and the state file remains an honest identity of the installed bytes. `sync` reconciles the moving branch tip the same way it reconciles a new pinned ref.

## Tests

New coverage in `tests/test_groundwork_install.py`:
- `--from-branch` installs the committed branch HEAD and records its SHA
- `sync --from-branch` converges to the advancing branch tip
- `--from-branch` still rejects a dirty checkout
- the existing `test_install_rejects_branch_checkouts` is unchanged, confirming the default still refuses branches

Full installer suite: **33/33 passing.**

Also makes the install-test fixtures hermetic by disabling commit/tag signing in the throwaway repos, so the suite no longer depends on the host's git signing configuration.

https://claude.ai/code/session_01EGADcLzU6YPHgyNqqLpkWB

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGADcLzU6YPHgyNqqLpkWB)_