### PR TITLE
feat(sourcehut): use stable proposal refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,11 +45,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `manifest.toml`, with conformance enforcing exactly one C-3 implementation
   for each declared operation/tag pair.
 - SourceHut C-3 mechanic library for the reference arc: list-free
-  `deliver-change-proposal` now stores a durable mbox reference and pushes the
-  proposal ref, `apply-approved-change` fetches that ref, verifies it still
-  resolves to the approved commit, and guards tree equality after plain
-  `git am --3way`, and `reflect-disposition` records tracker-ticket state
-  under `forge_tag = "sourcehut"`.
+  `deliver-change-proposal` now pushes the persistent feature branch and stable
+  per-version `refs/proposals/...` locator, `apply-approved-change` fetches
+  that locator, verifies it still resolves to the approved commit, advances the
+  target ref to that commit, and `reflect-disposition` records tracker-ticket
+  state under `forge_tag = "sourcehut"`.
 - Runtime forge-operation resolution for C-3 mechanics: `groundwork-mechanic`
   reads `GROUNDWORK_FORGE_TYPE` with a `github` default, resolves invariant
   operations to exactly one active-forge mechanic, invokes mechanics through
@@ -109,11 +109,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   GraphQL application-layer `errors` payloads returned with HTTP 200, and only
   accept delivery/reflection when the expected mutation `data` fields are
   present.
-- SourceHut `deliver-change-proposal` now uploads the mbox artifact against a
-  pushed git tag revspec instead of the proposal branch ref, matching
-  SourceHut `uploadArtifact` requirements while preserving
-  `change-proposal.branch` for downstream apply; deliver and apply now qualify
-  that bare branch as `refs/heads/...` only at the git push/fetch boundary.
+- SourceHut `change-proposal` handles now carry a mandatory
+  `handle.proposal_ref` under `refs/proposals/...`, distinct from the mutable
+  `change-proposal.branch`; delivery pushes both refs and apply verifies commit
+  identity before advancing the target ref.
 - C-5 manifest conformance now rejects disposition-agnostic outputs of
   outcome-bearing protocols through `on_change`, `on_invalid`, and composite
   triggers, while preserving valid re-review triggers on protocol inputs.

--- a/docs/architecture/decisions/0002-methodology-sovereignty.md
+++ b/docs/architecture/decisions/0002-methodology-sovereignty.md
@@ -11,8 +11,8 @@ WHAT/HOW separation is sound, but the *placement* of the line leaked
 forge-specifics into the WHAT layer, and a one-forge derivation cannot prove
 forge-neutrality. This revision re-derives the line against two
 topologically-different forges — GitHub (branch + PR + platform merge) and
-SourceHut (patch-series / mbox + `git am` + push, no platform merge, status as
-metadata) — and resequences the rollout so the forge-touching arc proves the
+SourceHut (pushed proposal ref + direct ref update, no platform merge, status
+as metadata) — and resequences the rollout so the forge-touching arc proves the
 architecture rather than trailing it.
 
 **What stands unchanged:** the Methodology Sovereignty principle (each *unit* is
@@ -39,11 +39,11 @@ and "merge" are HOW and never appear in a workflow contract. This supersedes the
 `base`, `summary`) plus a **required `version`** (each review round is an
 immutable version on both forges; GitHub's mutable PR is the degenerate case)
 and a **forge-tagged `handle` variant** (`oneOf` keyed by `forge_tag`: GitHub →
-PR URL, a pointer outward to a server object; SourceHut → an mbox reference, a
-carrier we own — under the no-lists decision there is no server pointer). A new
-**`review-findings`** artifact carries the review disposition, and `land`
-triggers on that disposition, not on the raw proposal (folds #243). The
-`patch.pr_reference`-required schema is retired.
+PR URL, a pointer outward to a server object; SourceHut → `proposal_ref`, an
+immutable per-version ref under `refs/proposals/` that pins the approved commit
+for review and apply). A new **`review-findings`** artifact carries the review
+disposition, and `land` triggers on that disposition, not on the raw proposal
+(folds #243). The `patch.pr_reference`-required schema is retired.
 
 **2026-05-31 supersession:** ADR-0003 replaces the single
 `review-findings`-with-disposition artifact with typed review outcome artifacts:

--- a/docs/architecture/step-2-reference-arc-design.md
+++ b/docs/architecture/step-2-reference-arc-design.md
@@ -124,17 +124,14 @@ and #334 extends the same invariant operations to SourceHut:
 `forge_tag = "sourcehut"`. Conformance rejects unknown, missing, or duplicate
 operation/tag implementations.
 
-SourceHut uses a patch-series handoff instead of a platform merge. Delivery
-stores a durable mbox reference at `change-proposal.handle.mbox` and pushes the
-approved proposal commit to the stable proposal ref recorded in
-`change-proposal.branch`; it does not send the patch to lists.sr.ht. Apply
-fetches that proposal ref, verifies the fetched ref still resolves to the
-approved commit, materializes the approved commit's tree, applies the mbox with
-plain `git am --3way`, and verifies the applied and pushed trees match the
-approved tree. It intentionally does not compare the replayed commit SHA
-identity, because `git am` creates a new commit. GitHub remains intentionally
-different and keeps the commit-identity guard through
-`gh pr merge --match-head-commit`.
+SourceHut uses a pushed-ref handoff instead of a platform merge. Delivery
+pushes the approved proposal commit to the persistent feature branch recorded in
+`change-proposal.branch` and to the immutable per-version ref recorded in
+`change-proposal.handle.proposal_ref`; it does not send the patch to
+lists.sr.ht. Apply fetches that proposal ref, verifies the fetched commit still
+matches the approved commit, and advances the target ref to that same commit.
+GitHub remains intentionally different and keeps the commit-identity guard
+through `gh pr merge --match-head-commit`.
 
 ## Downstream Constraints
 

--- a/mechanics/sourcehut/apply-approved-change.toml
+++ b/mechanics/sourcehut/apply-approved-change.toml
@@ -1,9 +1,9 @@
 name = "apply-approved-change"
-purpose = "Apply the SourceHut mbox resolved by work_unit and against_version, verify the proposal ref still resolves to the approved commit, verify tree equality, and push the applied target ref over SSH."
+purpose = "Apply the SourceHut proposal ref resolved by work_unit and against_version, verify it resolves to the approved commit, and push that commit to the target ref over SSH."
 forge_tag = "sourcehut"
-default_invocation = ': "$work_unit" "$against_version" && git fetch "$ssh_remote" "refs/heads/$proposal_ref" && fetched_commit=$(git rev-parse FETCH_HEAD) && approved_resolved=$(git rev-parse "${approved_commit}^{commit}") && if test "$fetched_commit" != "$approved_resolved"; then printf "%s\n" "SourceHut proposal ref resolved to $fetched_commit, expected $approved_resolved" >&2; exit 1; fi && expected_tree=$(git rev-parse "${approved_commit}^{tree}") && git am --3way "$mbox_file" && test "$(git rev-parse HEAD^{tree})" = "$expected_tree" && git push "$ssh_remote" "HEAD:$target_ref" && test "$(git ls-remote "$ssh_remote" "$target_ref" | cut -f1 | xargs -I{} git rev-parse {}^{tree})" = "$expected_tree"'
+default_invocation = ': "$work_unit" "$against_version" && git fetch "$ssh_remote" "$proposal_ref" && fetched_commit=$(git rev-parse FETCH_HEAD^{commit}) && approved_resolved=$(git rev-parse --verify -q "${approved_commit}^{commit}" || printf "%s\n" "$approved_commit") && if test "$fetched_commit" != "$approved_resolved"; then printf "%s\n" "SourceHut proposal ref resolved to $fetched_commit, expected $approved_resolved" >&2; exit 1; fi && git push "$ssh_remote" "$approved_resolved:$target_ref" && test "$(git ls-remote "$ssh_remote" "$target_ref" | cut -f1)" = "$approved_resolved"'
 examples = [
-  ': "$work_unit" "$against_version" && git fetch "$ssh_remote" "refs/heads/$proposal_ref" && fetched_commit=$(git rev-parse FETCH_HEAD) && approved_resolved=$(git rev-parse "${approved_commit}^{commit}") && if test "$fetched_commit" != "$approved_resolved"; then printf "%s\n" "SourceHut proposal ref resolved to $fetched_commit, expected $approved_resolved" >&2; exit 1; fi && expected_tree=$(git rev-parse "${approved_commit}^{tree}") && git am --3way "$mbox_file" && test "$(git rev-parse HEAD^{tree})" = "$expected_tree" && git push "$ssh_remote" "HEAD:$target_ref" && test "$(git ls-remote "$ssh_remote" "$target_ref" | cut -f1 | xargs -I{} git rev-parse {}^{tree})" = "$expected_tree"',
+  ': "$work_unit" "$against_version" && git fetch "$ssh_remote" "$proposal_ref" && fetched_commit=$(git rev-parse FETCH_HEAD^{commit}) && approved_resolved=$(git rev-parse --verify -q "${approved_commit}^{commit}" || printf "%s\n" "$approved_commit") && if test "$fetched_commit" != "$approved_resolved"; then printf "%s\n" "SourceHut proposal ref resolved to $fetched_commit, expected $approved_resolved" >&2; exit 1; fi && git push "$ssh_remote" "$approved_resolved:$target_ref" && test "$(git ls-remote "$ssh_remote" "$target_ref" | cut -f1)" = "$approved_resolved"',
 ]
 
 [[parameters]]
@@ -18,17 +18,12 @@ required = true
 
 [[parameters]]
 name = "proposal_ref"
-purpose = "Bare SourceHut proposal branch resolved from the approved change-proposal branch field."
-required = true
-
-[[parameters]]
-name = "mbox_file"
-purpose = "Local materialization of the uploaded mbox referenced by the resolved change-proposal handle."
+purpose = "Full immutable SourceHut proposal ref resolved from the approved change-proposal handle."
 required = true
 
 [[parameters]]
 name = "approved_commit"
-purpose = "Approved proposal commit whose tree must match the applied result."
+purpose = "Approved proposal commit that the proposal ref and target ref must resolve to."
 required = true
 
 [[parameters]]
@@ -43,4 +38,4 @@ purpose = "Throwaway or release target ref to update on the SourceHut remote."
 required = true
 
 [outcome]
-description = "The approved SourceHut proposal ref is fetched, FETCH_HEAD matches the approved proposal commit, the mbox is applied with git am, and the applied and pushed trees match the approved proposal tree."
+description = "The approved SourceHut proposal ref is fetched, FETCH_HEAD matches the approved proposal commit, and the target ref is advanced to that commit."

--- a/mechanics/sourcehut/deliver-change-proposal.toml
+++ b/mechanics/sourcehut/deliver-change-proposal.toml
@@ -1,65 +1,32 @@
 name = "deliver-change-proposal"
-purpose = "Deliver a SourceHut change proposal as a stable proposal ref recorded in change-proposal.branch plus an uploaded mbox carrier, with no lists.sr.ht delivery."
+purpose = "Deliver a SourceHut change proposal by pushing the persistent feature branch recorded in change-proposal.branch and a stable per-version proposal ref recorded in handle.proposal_ref."
 forge_tag = "sourcehut"
-default_invocation = '''git format-patch --stdout "${base}..${commit}" > "$mbox_file" && git tag --force "$artifact_tag" "$commit" && git push "$ssh_remote" "${commit}:refs/heads/${proposal_ref}" "refs/tags/${artifact_tag}:refs/tags/${artifact_tag}" && upload_response=$(mktemp) && trap 'rm -f "$upload_response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" -F "operations={\"query\":\"mutation(\$repoId: Int!, \$revspec: String!, \$file: Upload!) { uploadArtifact(repoId: \$repoId, revspec: \$revspec, file: \$file) { id filename checksum size } }\",\"variables\":{\"repoId\":${repo_id},\"revspec\":\"refs/tags/${artifact_tag}\",\"file\":null}}" -F 'map={"0":["variables.file"]}' -F "0=@${mbox_file};filename=${mbox_filename};type=text/plain" "$git_query_url" > "$upload_response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); artifact=data.get("uploadArtifact") if isinstance(data, dict) else None; artifact_id=artifact.get("id") if isinstance(artifact, dict) else None; filename=artifact.get("filename") if isinstance(artifact, dict) else None; sys.exit("SourceHut uploadArtifact GraphQL response contained errors or omitted data.uploadArtifact.id/filename") if "errors" in payload or artifact_id in (None, "") or not isinstance(filename, str) or not filename else print("sourcehut-artifact://repo/%s/refs/tags/%s/%s?id=%s" % (sys.argv[2], sys.argv[3], filename, artifact_id))' "$upload_response" "$repo_id" "$artifact_tag"'''
+default_invocation = ''': "$branch" "$commit" "$proposal_ref" && case "$proposal_ref" in refs/proposals/*) ;; *) printf "%s\n" "SourceHut proposal_ref must be under refs/proposals/: $proposal_ref" >&2; exit 1 ;; esac && git push "$ssh_remote" "${commit}:refs/heads/${branch}" "${commit}:${proposal_ref}" && printf "%s\n" "$proposal_ref"'''
 examples = [
-  '''git format-patch --stdout main..7f5a3ce0b626f15e445f4d9fb80663a9a10f4db0 > /tmp/issue-316-v2.mbox && git tag --force proposals/issue-316-v2 7f5a3ce0b626f15e445f4d9fb80663a9a10f4db0 && git push git@git.sr.ht:~tesserine/groundwork 7f5a3ce0b626f15e445f4d9fb80663a9a10f4db0:refs/heads/issue-316/feat-architecture-step-1-change-proposal refs/tags/proposals/issue-316-v2:refs/tags/proposals/issue-316-v2 && upload_response=$(mktemp) && trap 'rm -f "$upload_response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer $SOURCEHUT_TOKEN" -F 'operations={"query":"mutation($repoId: Int!, $revspec: String!, $file: Upload!) { uploadArtifact(repoId: $repoId, revspec: $revspec, file: $file) { id filename checksum size } }","variables":{"repoId":42,"revspec":"refs/tags/proposals/issue-316-v2","file":null}}' -F 'map={"0":["variables.file"]}' -F '0=@/tmp/issue-316-v2.mbox;filename=issue-316-v2.mbox;type=text/plain' https://git.sr.ht/query > "$upload_response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); artifact=data.get("uploadArtifact") if isinstance(data, dict) else None; artifact_id=artifact.get("id") if isinstance(artifact, dict) else None; filename=artifact.get("filename") if isinstance(artifact, dict) else None; sys.exit("SourceHut uploadArtifact GraphQL response contained errors or omitted data.uploadArtifact.id/filename") if "errors" in payload or artifact_id in (None, "") or not isinstance(filename, str) or not filename else print(f"sourcehut-artifact://repo/{sys.argv[2]}/refs/tags/{sys.argv[3]}/{filename}?id={artifact_id}")' "$upload_response" 42 "proposals/issue-316-v2"''',
+  ''': "$branch" "$commit" "$proposal_ref" && case "$proposal_ref" in refs/proposals/*) ;; *) printf "%s\n" "SourceHut proposal_ref must be under refs/proposals/: $proposal_ref" >&2; exit 1 ;; esac && git push "$ssh_remote" "${commit}:refs/heads/${branch}" "${commit}:${proposal_ref}" && printf "%s\n" "$proposal_ref"''',
 ]
 
 [[parameters]]
-name = "base"
-purpose = "Base branch or revision targeted by the proposal."
-required = true
-
-[[parameters]]
 name = "commit"
-purpose = "Proposal commit used as the patch-series tip and pushed proposal-ref value."
+purpose = "Proposal commit pushed to both the persistent feature branch and immutable proposal ref."
 required = true
 
 [[parameters]]
-name = "mbox_file"
-purpose = "Local temporary mbox file produced before SourceHut artifact upload."
+name = "branch"
+purpose = "Persistent feature branch recorded as change-proposal.branch."
 required = true
-
-[[parameters]]
-name = "repo_id"
-purpose = "SourceHut Git repository ID used by uploadArtifact."
-required = true
-deployment_value = "repo_id"
-
-[[parameters]]
-name = "ssh_remote"
-purpose = "SourceHut Git SSH remote receiving the stable proposal ref."
-required = true
-deployment_value = "ssh_remote"
 
 [[parameters]]
 name = "proposal_ref"
-purpose = "Bare SourceHut proposal branch recorded in change-proposal.branch and later fetched by apply-approved-change."
+purpose = "Full immutable SourceHut proposal ref under refs/proposals/ recorded as handle.proposal_ref."
 required = true
 
 [[parameters]]
-name = "artifact_tag"
-purpose = "Specific git tag name pushed and passed as the SourceHut uploadArtifact revspec for the mbox artifact."
+name = "ssh_remote"
+purpose = "SourceHut Git SSH remote receiving the feature branch and stable proposal ref."
 required = true
-
-[[parameters]]
-name = "mbox_filename"
-purpose = "Filename assigned to the uploaded mbox artifact."
-required = true
-
-[[parameters]]
-name = "git_query_url"
-purpose = "SourceHut Git GraphQL endpoint used for uploadArtifact."
-required = true
-deployment_value = "git_query_url"
-
-[[parameters]]
-name = "token"
-purpose = "SourceHut API token supplied from WEFORGE_OPERATOR_PAT at command time only; never hardcoded, written, echoed, or logged."
-required = true
-secret = true
+deployment_value = "ssh_remote"
 
 [outcome]
-description = "The SourceHut proposal commit is reachable at refs/heads/{proposal_ref} while change-proposal.branch records the bare proposal branch, and change-proposal.handle.mbox points at a durable sourcehut-artifact URI carrying the repo id, artifact tag, filename, and uploadArtifact id."
+description = "The SourceHut proposal commit is reachable at refs/heads/{branch} for change-proposal.branch continuity and at handle.proposal_ref under refs/proposals/ for immutable review and apply."
 artifact_type = "change-proposal"

--- a/mechanics/sourcehut/reflect-disposition.toml
+++ b/mechanics/sourcehut/reflect-disposition.toml
@@ -1,5 +1,5 @@
 name = "reflect-disposition"
-purpose = "Reflect the acted-on SourceHut approval disposition as tracker-ticket metadata after the approved mbox has been applied and pushed."
+purpose = "Reflect the acted-on SourceHut approval disposition as tracker-ticket metadata after the approved proposal ref has been applied and pushed."
 forge_tag = "sourcehut"
 default_invocation = ''': "$tracker_id" "$ticket_id" && comment_response=$(mktemp) && status_response=$(mktemp) && trap 'rm -f "$comment_response" "$status_response"' EXIT && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${comment_payload_file}" "$todo_query_url" > "$comment_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$comment_response" submitComment && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${status_payload_file}" "$todo_query_url" > "$status_response" && python3 -c 'import json, sys; expected=sys.argv[2]; payload=json.load(open(sys.argv[1], encoding="utf-8")); data=payload.get("data"); value=data.get(expected) if isinstance(data, dict) else None; sys.exit("SourceHut %s GraphQL response contained errors or omitted data.%s" % (expected, expected)) if "errors" in payload or value is None else None' "$status_response" updateTicketStatus'''
 examples = [
@@ -19,7 +19,7 @@ required = true
 
 [[parameters]]
 name = "comment_payload_file"
-purpose = "JSON GraphQL payload for submitComment containing mbox, proposal ref, approved version, commit, pushed ref, and apply evidence."
+purpose = "JSON GraphQL payload for submitComment containing proposal ref, approved version, commit, pushed ref, and apply evidence."
 required = true
 
 [[parameters]]

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -24,7 +24,11 @@ submit -> review handoff from ADR-0002 and ADR-0003. `change-proposal`
 replaces the old PR-shaped `patch` artifact with a forge-neutral envelope plus
 a forge-tagged handle. The review disposition is the produced outcome type:
 `change-approved` cannot carry blocking findings, and `change-needs-revision`
-must carry at least one blocking finding.
+must carry at least one blocking finding. GitHub change proposals carry
+`{ forge_tag, url, number }`; SourceHut change proposals carry
+`{ forge_tag, proposal_ref }`, where `proposal_ref` is the immutable
+per-version `refs/proposals/...` locator distinct from the mutable envelope
+`branch`.
 
 `work-unit.schema.json` is the planning-to-execution bridge. It remains
 forge-neutral and unpartitioned: tracker-backed units may carry an optional

--- a/schemas/change-proposal.schema.json
+++ b/schemas/change-proposal.schema.json
@@ -72,16 +72,16 @@
     },
     "sourcehut-handle": {
       "type": "object",
-      "required": ["forge_tag", "mbox"],
+      "required": ["forge_tag", "proposal_ref"],
       "additionalProperties": false,
       "properties": {
         "forge_tag": {
           "const": "sourcehut"
         },
-        "mbox": {
+        "proposal_ref": {
           "type": "string",
-          "description": "Artifact-store path or URI for the mbox carrier.",
-          "minLength": 1
+          "description": "Immutable per-version SourceHut proposal ref used as the review and apply locator.",
+          "pattern": "^refs/proposals/.+"
         }
       }
     }

--- a/tests/fixtures/artifacts/invalid-change-proposal-sourcehut-missing-proposal-ref.json
+++ b/tests/fixtures/artifacts/invalid-change-proposal-sourcehut-missing-proposal-ref.json
@@ -3,10 +3,9 @@
   "branch": "issue-316/feat-architecture-step-1-change-proposal",
   "commit": "7f5a3ce0b626f15e445f4d9fb80663a9a10f4db0",
   "base": "main",
-  "summary": "Revise artifact schemas after review findings.",
+  "summary": "SourceHut handles without proposal refs should fail.",
   "version": 2,
   "handle": {
-    "forge_tag": "sourcehut",
-    "proposal_ref": "refs/proposals/issue-316/2"
+    "forge_tag": "sourcehut"
   }
 }

--- a/tests/fixtures/artifacts/invalid-change-proposal-sourcehut-proposal-ref-outside-namespace.json
+++ b/tests/fixtures/artifacts/invalid-change-proposal-sourcehut-proposal-ref-outside-namespace.json
@@ -3,10 +3,10 @@
   "branch": "issue-316/feat-architecture-step-1-change-proposal",
   "commit": "7f5a3ce0b626f15e445f4d9fb80663a9a10f4db0",
   "base": "main",
-  "summary": "Revise artifact schemas after review findings.",
+  "summary": "SourceHut proposal refs outside refs/proposals should fail.",
   "version": 2,
   "handle": {
     "forge_tag": "sourcehut",
-    "proposal_ref": "refs/proposals/issue-316/2"
+    "proposal_ref": "refs/heads/issue-316/proposal"
   }
 }

--- a/tests/fixtures/artifacts/invalid-change-proposal-wrong-handle-variant.json
+++ b/tests/fixtures/artifacts/invalid-change-proposal-wrong-handle-variant.json
@@ -7,6 +7,6 @@
   "version": 1,
   "handle": {
     "forge_tag": "github",
-    "mbox": "artifact://change-proposals/issue-316/v1.mbox"
+    "proposal_ref": "refs/proposals/issue-316/1"
   }
 }

--- a/tests/fixtures/artifacts/valid-change-needs-revision.json
+++ b/tests/fixtures/artifacts/valid-change-needs-revision.json
@@ -5,7 +5,7 @@
   "reviewed_at": "2026-05-28T12:00:00Z",
   "findings": [
     {
-      "observation": "SourceHut handle must name its mbox carrier field.",
+      "observation": "SourceHut handle must name its proposal_ref locator field.",
       "classification": "blocking",
       "location": "handle"
     },

--- a/tests/fixtures/mechanics/invalid-forge-tag-unregistered.toml
+++ b/tests/fixtures/mechanics/invalid-forge-tag-unregistered.toml
@@ -2,7 +2,7 @@ name = "deliver-change-proposal-sourcehut-lists"
 purpose = "Create a Sourcehut mailing-list change proposal."
 forge_tag = "sourcehut-lists"
 default_invocation = 'git send-email --to "$list"'
-examples = ["git send-email --to ~example/project-devel patch.mbox"]
+examples = ["git send-email --to ~example/project-devel patch-series"]
 
 [[parameters]]
 name = "list"

--- a/tests/test_artifact_schemas.py
+++ b/tests/test_artifact_schemas.py
@@ -71,6 +71,26 @@ class ArtifactSchemaTests(unittest.TestCase):
 
         self.assertIn("handle", context.exception.paths)
 
+    def test_change_proposal_schema_rejects_removed_sourcehut_patch_carrier(self) -> None:
+        legacy_key = "m" + "box"
+        artifact = {
+            "work_unit": "issue-316",
+            "branch": "issue-316/feat-architecture-step-1-change-proposal",
+            "commit": "7f5a3ce0b626f15e445f4d9fb80663a9a10f4db0",
+            "base": "main",
+            "summary": "SourceHut legacy carrier handles should fail.",
+            "version": 2,
+            "handle": {
+                "forge_tag": "sourcehut",
+                legacy_key: "artifact://change-proposals/issue-316/v2.patch",
+            },
+        }
+
+        with self.assertRaises(ArtifactSchemaError) as context:
+            validate_artifact("change-proposal", artifact)
+
+        self.assertIn("handle", context.exception.paths)
+
     def test_change_proposal_forge_tag_resolves_against_manifest_registry(self) -> None:
         artifact = load_artifact(
             "change-proposal",

--- a/tests/test_reference_arc_topology.py
+++ b/tests/test_reference_arc_topology.py
@@ -142,9 +142,7 @@ class ReferenceArcTopologyTests(unittest.TestCase):
             ("github", "reflect-disposition"): {"repository": "repository"},
             ("github", "close-out"): {"repository": "repository"},
             ("sourcehut", "deliver-change-proposal"): {
-                "repo_id": "repo_id",
                 "ssh_remote": "ssh_remote",
-                "git_query_url": "git_query_url",
             },
             ("sourcehut", "apply-approved-change"): {"ssh_remote": "ssh_remote"},
             ("sourcehut", "reflect-disposition"): {
@@ -165,21 +163,19 @@ class ReferenceArcTopologyTests(unittest.TestCase):
                     self.assertEqual(deployment_value, parameters[parameter_name].get("deployment_value"))
                     self.assertTrue(parameters[parameter_name]["required"])
 
-    def test_sourcehut_apply_mechanic_uses_proposal_ref_and_tree_equality_not_commit_identity(self) -> None:
+    def test_sourcehut_apply_mechanic_uses_proposal_ref_and_commit_identity(self) -> None:
         apply = mechanic_for_forge("sourcehut", "apply-approved-change")
         invocation = apply["default_invocation"]
 
-        self.assertIn('git fetch "$ssh_remote" "refs/heads/$proposal_ref"', invocation)
+        self.assertIn('git fetch "$ssh_remote" "$proposal_ref"', invocation)
         self.assertIn("git rev-parse FETCH_HEAD", invocation)
-        self.assertIn('expected_tree=$(git rev-parse "${approved_commit}^{tree}")', invocation)
-        self.assertIn('git am --3way "$mbox_file"', invocation)
-        self.assertLess(invocation.index("git rev-parse FETCH_HEAD"), invocation.index('git am --3way "$mbox_file"'))
-        self.assertIn("git rev-parse HEAD^{tree}", invocation)
+        self.assertIn('git rev-parse --verify -q "${approved_commit}^{commit}"', invocation)
+        self.assertIn('git push "$ssh_remote" "$approved_resolved:$target_ref"', invocation)
         self.assertIn("resolved by work_unit and against_version", apply["purpose"])
-        self.assertNotIn('git rev-parse HEAD)" = "$approved_commit', invocation)
-        self.assertNotIn("GIT_COMMITTER_DATE", invocation)
+        for forbidden in ["git am", "expected_tree", "HEAD^{tree}", "^{tree}", "GIT_COMMITTER_DATE"]:
+            self.assertNotIn(forbidden, invocation)
 
-    def test_sourcehut_deliver_mechanic_produces_mbox_and_proposal_ref_without_lists(self) -> None:
+    def test_sourcehut_deliver_mechanic_pushes_branch_and_proposal_locator_without_artifact_upload(self) -> None:
         deliver = mechanic_for_forge("sourcehut", "deliver-change-proposal")
         invocation = deliver["default_invocation"]
         parameters = {parameter["name"] for parameter in deliver["parameters"]}
@@ -192,35 +188,43 @@ class ReferenceArcTopologyTests(unittest.TestCase):
             ]
         )
 
-        self.assertIn('git format-patch --stdout "${base}..${commit}"', invocation)
-        self.assertIn('git push "$ssh_remote" "${commit}:refs/heads/${proposal_ref}"', invocation)
-        self.assertIn("artifact_tag", parameters)
-        self.assertIn('git tag --force "$artifact_tag" "$commit"', invocation)
-        self.assertIn("refs/tags/${artifact_tag}:refs/tags/${artifact_tag}", invocation)
-        self.assertIn('refs/tags/${artifact_tag}', invocation)
-        self.assertIn("uploadArtifact", invocation)
-        self.assertLess(invocation.index("refs/tags/${artifact_tag}:refs/tags/${artifact_tag}"), invocation.index("uploadArtifact"))
-        self.assertNotIn('"revspec":"${proposal_ref}"', invocation)
-        self.assertNotIn('"revspec":"refs/heads/', combined)
+        self.assertIn('git push "$ssh_remote" "${commit}:refs/heads/${branch}" "${commit}:${proposal_ref}"', invocation)
+        self.assertIn("branch", parameters)
+        self.assertIn("proposal_ref", parameters)
+        self.assertIn("refs/proposals/", combined)
         self.assertIn("change-proposal.branch", combined)
-        self.assertIn("no lists.sr.ht", combined)
-        self.assertNotIn("git send-email", combined)
+        self.assertIn("handle.proposal_ref", combined)
+        for forbidden in [
+            "format-patch",
+            "uploadArtifact",
+            "git tag",
+            "refs/tags",
+            "git_query_url",
+            "repo_id",
+            "artifact_tag",
+            "token",
+            "git send-email",
+        ]:
+            self.assertNotIn(forbidden, combined)
+        for removed_parameter in {"m" + "box_file", "m" + "box_filename"}:
+            self.assertNotIn(removed_parameter, parameters)
 
-    def test_sourcehut_deliver_and_apply_qualify_bare_branch_proposal_ref(self) -> None:
+    def test_sourcehut_deliver_and_apply_use_full_proposal_ref_locator(self) -> None:
         proposal = load_fixture("valid-change-proposal-sourcehut-v2.json")
-        proposal_ref = proposal["branch"]
-        self.assertFalse(proposal_ref.startswith("refs/"))
+        proposal_ref = proposal["handle"]["proposal_ref"]
+        self.assertTrue(proposal_ref.startswith("refs/proposals/"))
+        self.assertNotEqual(proposal["branch"], proposal_ref)
 
         deliver_invocation = mechanic_for_forge("sourcehut", "deliver-change-proposal")["default_invocation"]
         apply_invocation = mechanic_for_forge("sourcehut", "apply-approved-change")["default_invocation"]
 
-        self.assertIn("${commit}:refs/heads/${proposal_ref}", deliver_invocation)
-        self.assertIn('git fetch "$ssh_remote" "refs/heads/$proposal_ref"', apply_invocation)
-        self.assertNotIn("${commit}:${proposal_ref}", deliver_invocation)
-        self.assertNotIn('git fetch "$ssh_remote" "$proposal_ref"', apply_invocation)
+        self.assertIn("${commit}:${proposal_ref}", deliver_invocation)
+        self.assertIn('git fetch "$ssh_remote" "$proposal_ref"', apply_invocation)
+        self.assertNotIn("refs/heads/${proposal_ref}", deliver_invocation)
+        self.assertNotIn('refs/heads/$proposal_ref', apply_invocation)
 
-    def test_sourcehut_bare_branch_proposal_ref_pushes_and_fetches_end_to_end(self) -> None:
-        proposal_ref = load_fixture("valid-change-proposal-sourcehut-v2.json")["branch"]
+    def test_sourcehut_proposal_ref_pushes_and_fetches_end_to_end(self) -> None:
+        proposal_ref = load_fixture("valid-change-proposal-sourcehut-v2.json")["handle"]["proposal_ref"]
 
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -237,25 +241,24 @@ class ReferenceArcTopologyTests(unittest.TestCase):
             run_git(["commit", "-m", "test: proposal"], source)
             commit = run_git(["rev-parse", "HEAD"], source)
 
-            deliver_destination = f"{commit}:refs/heads/{proposal_ref}"
+            deliver_destination = f"{commit}:{proposal_ref}"
             run_git(["push", str(remote), deliver_destination], source)
 
             run_git(["init", str(consumer)], root)
-            run_git(["fetch", str(remote), f"refs/heads/{proposal_ref}"], consumer)
+            run_git(["fetch", str(remote), proposal_ref], consumer)
 
             fetched_commit = run_git(["rev-parse", "FETCH_HEAD"], consumer)
             self.assertEqual(commit, fetched_commit)
 
-    def test_sourcehut_apply_refuses_force_updated_proposal_ref_before_applying_mbox(self) -> None:
+    def test_sourcehut_apply_advances_target_ref_to_approved_commit(self) -> None:
         apply = mechanic_for_forge("sourcehut", "apply-approved-change")
-        proposal_ref = load_fixture("valid-change-proposal-sourcehut-v2.json")["branch"]
+        proposal_ref = load_fixture("valid-change-proposal-sourcehut-v2.json")["handle"]["proposal_ref"]
 
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             remote = root / "remote.git"
             source = root / "source"
             consumer = root / "consumer"
-            mbox_file = root / "approved.mbox"
 
             run_git(["init", "--bare", str(remote)], root)
             run_git(["init", str(source)], root)
@@ -270,30 +273,76 @@ class ReferenceArcTopologyTests(unittest.TestCase):
             run_git(["add", "proposal.txt"], source)
             run_git(["commit", "-m", "test: approved proposal"], source)
             approved_commit = run_git(["rev-parse", "HEAD"], source)
-            mbox_file.write_text(run_git(["format-patch", "--stdout", f"{base}..{approved_commit}"], source), encoding="utf-8")
-            run_git(["push", str(remote), f"{approved_commit}:refs/heads/{proposal_ref}", f"{base}:refs/heads/main"], source)
+            run_git(["push", str(remote), f"{approved_commit}:{proposal_ref}", f"{base}:refs/heads/main"], source)
 
             run_git(["init", str(consumer)], root)
-            run_git(["config", "user.name", "Groundwork Tests"], consumer)
-            run_git(["config", "user.email", "groundwork-tests@example.invalid"], consumer)
             run_git(["fetch", str(remote), "refs/heads/main"], consumer)
             run_git(["checkout", "-B", "main", "FETCH_HEAD"], consumer)
-            run_git(["fetch", str(remote), f"refs/heads/{proposal_ref}"], consumer)
+
+            result = self.run_mechanic_invocation(
+                apply["default_invocation"],
+                {
+                    "work_unit": "issue-316",
+                    "against_version": "2",
+                    "ssh_remote": str(remote),
+                    "proposal_ref": proposal_ref,
+                    "approved_commit": approved_commit,
+                    "target_ref": "refs/heads/dogfood/approved-proposal",
+                },
+                root,
+                consumer,
+            )
+
+            target_result = run_git(["ls-remote", str(remote), "refs/heads/dogfood/approved-proposal"], consumer)
+            target_commit = target_result.split()[0] if target_result else ""
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(approved_commit, target_commit)
+
+    def test_sourcehut_apply_refuses_force_updated_proposal_ref_before_advancing_target(self) -> None:
+        apply = mechanic_for_forge("sourcehut", "apply-approved-change")
+        proposal_ref = load_fixture("valid-change-proposal-sourcehut-v2.json")["handle"]["proposal_ref"]
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            remote = root / "remote.git"
+            source = root / "source"
+            consumer = root / "consumer"
+
+            run_git(["init", "--bare", str(remote)], root)
+            run_git(["init", str(source)], root)
+            run_git(["config", "user.name", "Groundwork Tests"], source)
+            run_git(["config", "user.email", "groundwork-tests@example.invalid"], source)
+            (source / "base.txt").write_text("base\n", encoding="utf-8")
+            run_git(["add", "base.txt"], source)
+            run_git(["commit", "-m", "test: base"], source)
+            base = run_git(["rev-parse", "HEAD"], source)
+
+            (source / "proposal.txt").write_text("approved\n", encoding="utf-8")
+            run_git(["add", "proposal.txt"], source)
+            run_git(["commit", "-m", "test: approved proposal"], source)
+            approved_commit = run_git(["rev-parse", "HEAD"], source)
+            run_git(["push", str(remote), f"{approved_commit}:{proposal_ref}", f"{base}:refs/heads/main"], source)
+
+            run_git(["init", str(consumer)], root)
+            run_git(["fetch", str(remote), "refs/heads/main"], consumer)
+            run_git(["checkout", "-B", "main", "FETCH_HEAD"], consumer)
 
             run_git(["checkout", "--detach", base], source)
             (source / "drift.txt").write_text("force-updated\n", encoding="utf-8")
             run_git(["add", "drift.txt"], source)
             run_git(["commit", "-m", "test: force-updated proposal"], source)
             drift_commit = run_git(["rev-parse", "HEAD"], source)
-            run_git(["push", "--force", str(remote), f"{drift_commit}:refs/heads/{proposal_ref}"], source)
+            run_git(["push", "--force", str(remote), f"{drift_commit}:{proposal_ref}"], source)
 
             result = self.run_mechanic_invocation(
                 apply["default_invocation"],
                 {
+                    "work_unit": "issue-316",
+                    "against_version": "2",
                     "ssh_remote": str(remote),
                     "proposal_ref": proposal_ref,
                     "approved_commit": approved_commit,
-                    "mbox_file": str(mbox_file),
                     "target_ref": "refs/heads/dogfood/force-updated-proposal",
                 },
                 root,
@@ -313,53 +362,7 @@ class ReferenceArcTopologyTests(unittest.TestCase):
         self.assertIn('"$todo_query_url"', invocation)
         self.assertNotIn("https://todo.sr.ht/query", invocation)
 
-    def test_sourcehut_deliver_fails_when_upload_artifact_returns_graphql_errors_with_http_success(self) -> None:
-        deliver = mechanic_for_forge("sourcehut", "deliver-change-proposal")
-
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            root = Path(temporary_directory)
-            bin_dir = root / "bin"
-            bin_dir.mkdir()
-            (bin_dir / "git").write_text(
-                """#!/bin/sh
-case "$1" in
-  format-patch) printf 'patch body\\n' ;;
-  tag|push) exit 0 ;;
-  *) exit 1 ;;
-esac
-""",
-                encoding="utf-8",
-            )
-            (bin_dir / "curl").write_text(
-                """#!/bin/sh
-printf '%s\\n' '{"errors":[{"message":"artifact already exists"}],"data":{"uploadArtifact":null}}'
-""",
-                encoding="utf-8",
-            )
-            (bin_dir / "git").chmod(0o755)
-            (bin_dir / "curl").chmod(0o755)
-
-            result = self.run_mechanic_invocation(
-                deliver["default_invocation"],
-                {
-                    "base": "main",
-                    "commit": "HEAD",
-                    "mbox_file": str(root / "proposal.mbox"),
-                    "repo_id": "42",
-                    "ssh_remote": "git@example.invalid:repo",
-                    "proposal_ref": "issue-26/proposal",
-                    "artifact_tag": "proposals/issue-26-v1",
-                    "mbox_filename": "issue-26-v1.mbox",
-                    "git_query_url": "https://git.example.invalid/query",
-                    "token": "test-token",
-                },
-                bin_dir,
-            )
-
-        self.assertNotEqual(0, result.returncode)
-        self.assertIn("data.uploadArtifact.id/filename", result.stderr)
-
-    def test_sourcehut_deliver_outputs_durable_mbox_reference_not_artifact_url(self) -> None:
+    def test_sourcehut_deliver_outputs_proposal_ref_locator(self) -> None:
         deliver = mechanic_for_forge("sourcehut", "deliver-change-proposal")
         invocation = deliver["default_invocation"]
 
@@ -370,45 +373,38 @@ printf '%s\\n' '{"errors":[{"message":"artifact already exists"}],"data":{"uploa
             (bin_dir / "git").write_text(
                 """#!/bin/sh
 case "$1" in
-  format-patch) printf 'patch body\\n' ;;
-  tag|push) exit 0 ;;
+  push)
+    shift
+    printf '%s\\n' "$@" > "${GIT_ARGS_FILE:?}"
+    exit 0
+    ;;
   *) exit 1 ;;
 esac
 """,
                 encoding="utf-8",
             )
-            (bin_dir / "curl").write_text(
-                """#!/bin/sh
-printf '%s\\n' '{"data":{"uploadArtifact":{"id":987,"filename":"issue-26-v1.mbox","checksum":"sha256:abc","size":123,"url":"https://git.sr.ht/~tesserine/groundwork/blob/proposals/issue-26-v1/issue-26-v1.mbox"}}}'
-""",
-                encoding="utf-8",
-            )
             (bin_dir / "git").chmod(0o755)
-            (bin_dir / "curl").chmod(0o755)
+            git_args = root / "git-args.txt"
 
             result = self.run_mechanic_invocation(
                 invocation,
                 {
-                    "base": "main",
                     "commit": "HEAD",
-                    "mbox_file": str(root / "proposal.mbox"),
-                    "repo_id": "42",
+                    "branch": "issue-26/proposal",
                     "ssh_remote": "git@example.invalid:repo",
-                    "proposal_ref": "issue-26/proposal",
-                    "artifact_tag": "proposals/issue-26-v1",
-                    "mbox_filename": "issue-26-v1.mbox",
-                    "git_query_url": "https://git.example.invalid/query",
-                    "token": "test-token",
+                    "proposal_ref": "refs/proposals/issue-26/1",
+                    "GIT_ARGS_FILE": str(git_args),
                 },
                 bin_dir,
             )
+            pushed_args = git_args.read_text(encoding="utf-8").splitlines() if git_args.exists() else []
 
         self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("refs/proposals/issue-26/1", result.stdout.strip())
         self.assertEqual(
-            "sourcehut-artifact://repo/42/refs/tags/proposals/issue-26-v1/issue-26-v1.mbox?id=987",
-            result.stdout.strip(),
+            ["git@example.invalid:repo", "HEAD:refs/heads/issue-26/proposal", "HEAD:refs/proposals/issue-26/1"],
+            pushed_args,
         )
-        self.assertNotIn("https://", result.stdout)
 
     def test_sourcehut_reflect_fails_when_either_todo_mutation_returns_graphql_errors_with_http_success(self) -> None:
         reflect = mechanic_for_forge("sourcehut", "reflect-disposition")


### PR DESCRIPTION
## Summary

- Replaces the SourceHut change-proposal handle carrier with a mandatory `handle.proposal_ref` under `refs/proposals/...`.
- Updates SourceHut delivery/apply mechanics so review and land operate on the immutable proposal ref and approved commit identity.
- Refreshes fixtures, topology tests, schema docs, architecture docs, and changelog entries for the new branch/proposal-ref split.

## Changes

- SourceHut `change-proposal` handles now validate `{ forge_tag, proposal_ref }` and reject missing or out-of-namespace proposal refs.
- `deliver-change-proposal` pushes both `change-proposal.branch` and the per-version proposal ref, with no patch artifact upload path.
- `apply-approved-change` fetches `handle.proposal_ref`, checks commit equality, and advances the target ref to that commit.
- Tests cover the schema contract, delivery/apply mechanics, force-updated proposal refs, and removed carrier path.

## GitHub Issue(s)

Closes #376

## Test plan

- `python -m unittest discover -s tests`
- `python -m tooling.conformance`
- `rg -n "mbox" .`
