### PR TITLE
docs(decompose): codify epic completion boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Decompose now codifies recipient-facing epic completion boundaries, including
+  the capability-epic convention that component release work feeds a terminal
+  ecosystem-release work-unit (closes #383).
 - Interactive Groundwork protocol sessions now route through runa's validated
   session surface via `runa go --work-unit <id>` instead of the manual
   artifact-delivery adapter, preserving the operator/agent layering where the

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -75,6 +75,23 @@ For epics with 4+ tasks, include a dependency graph showing execution layers
 (see [`work-unit-model.md`](../../docs/architecture/work-unit-model.md) § Dependency
 Graph Format) so implementers can parallelize independent work.
 
+**Epic completion is recipient-facing.** An epic is complete when its output is
+real for its recipient, not merely when its task list is empty. Classify the
+epic by the terminal step that makes the output real:
+
+- **capability epics** deliver operator-facing capability. Their decomposition
+  includes the required component release work plus a terminal
+  ecosystem-release work-unit. That terminal work-unit depends on the component
+  release inputs and makes the capability public fact.
+- **knowledge/spike epics** terminate in an ADR or recorded decision.
+- **decomposition/planning epics** terminate in filed sub-issues.
+- **process/ceremony epics** terminate in the adopted process.
+
+Capability-epic release identity belongs to the commons release authority:
+ADR-0011, ADR-0012, ADR-0014, and `ECOSYSTEM-RELEASE.md`. Decompose requires
+the terminal ecosystem-release step, but does not define the manifest schema,
+version choice, verification, or publication procedure.
+
 ### The work-unit as contract
 
 **Must stand alone without external context.** A work-unit is a contract, not a
@@ -112,13 +129,18 @@ work-unit bodies against template schemas.
    against actual need — not against the requirements document's
    framing or the existing system's structure.
 2. Extract deliverables — artifacts that must exist when done.
-3. Split into vertical slices that are independently verifiable.
-4. Group by module boundary where it clarifies ownership.
-5. Build dependency graph (Mermaid `graph TD` + layered text summary —
+3. Classify the epic completion boundary: capability, knowledge/spike,
+   decomposition/planning, or process/ceremony. If the epic mixes boundaries,
+   split it or reckon the primary recipient-facing completion boundary before
+   filing tasks.
+4. Split into vertical slices that are independently verifiable, including the
+   terminal completion work for the selected boundary.
+5. Group by module boundary where it clarifies ownership.
+6. Build dependency graph (Mermaid `graph TD` + layered text summary —
    see [`work-unit-model.md`](../../docs/architecture/work-unit-model.md) § Dependency Graph Format).
-6. Size-check each candidate: split if oversized, merge if trivial.
-7. Create task work-units in topological order (lowest execution layer first).
-8. Create or update parent epic with task checklist and dependency graph.
+7. Size-check each candidate: split if oversized, merge if trivial.
+8. Create task work-units in topological order (lowest execution layer first).
+9. Create or update parent epic with task checklist and dependency graph.
 
 ### define-task-boundary
 

--- a/protocols/decompose/references/templates.md
+++ b/protocols/decompose/references/templates.md
@@ -155,13 +155,19 @@ capability -> component release work plus terminal ecosystem-release work-unit
 - [ ] #9 — `loadout install` (depends on #5, #7, #8)
 - [ ] #10 — `loadout clean` (depends on #5, #8)
 
+### Ecosystem release
+
+- [ ] #11 — terminal ecosystem-release work-unit: publish the shipped `loadout install` and `loadout clean` commands as public fact (depends on #9, #10)
+
 ## Dependency graph
 
 ```
-#5 config ──────┬── #9 install
-#6 frontmatter ─┤
-#7 skill/mod ───┤── #10 clean
-#8 linker ──────┘
+#5 config ──────┐
+#6 frontmatter ─┼── #9 install ──┐
+#7 skill/mod ───┤                │
+#8 linker ──────┘                ├── #11 ecosystem release
+#5 config ──────┐                │
+#8 linker ──────┴── #10 clean ───┘
 ```
 
 ## Acceptance criteria
@@ -169,6 +175,7 @@ capability -> component release work plus terminal ecosystem-release work-unit
 - [ ] `loadout install` produces identical symlink layout to `install.sh`
 - [ ] No Python dependency at runtime
 - [ ] `cargo install --path .` places binary in `~/.cargo/bin/loadout`
+- [ ] Ecosystem release makes the Rust parity capability public fact
 ```
 
 ---

--- a/protocols/decompose/references/templates.md
+++ b/protocols/decompose/references/templates.md
@@ -91,6 +91,16 @@ when it's complete.]
 
 Full spec: [link to design doc or roadmap section]
 
+## Completion boundary
+
+Classify the epic by the terminal step that makes its output real for its
+recipient.
+
+- capability -> component release work plus terminal ecosystem-release work-unit
+- knowledge/spike -> ADR or recorded decision
+- decomposition/planning -> filed sub-issues
+- process/ceremony -> adopted process
+
 ## Task issues
 
 ### [Layer name] (e.g., Library modules, CLI commands)
@@ -126,6 +136,10 @@ Replace the three bash scripts with a single Rust binary. The
 with zero Python dependency at runtime.
 
 Full spec: docs/ROADMAP.md — Phase 2
+
+## Completion boundary
+
+capability -> component release work plus terminal ecosystem-release work-unit
 
 ## Task issues
 

--- a/tests/test_decompose_epic_completion_docs.py
+++ b/tests/test_decompose_epic_completion_docs.py
@@ -1,0 +1,68 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DECOMPOSE_PROTOCOL = ROOT / "protocols" / "decompose" / "PROTOCOL.md"
+DECOMPOSE_TEMPLATES = ROOT / "protocols" / "decompose" / "references" / "templates.md"
+
+
+def normalized(path: Path) -> str:
+    return re.sub(r"\s+", " ", path.read_text(encoding="utf-8"))
+
+
+class DecomposeEpicCompletionDocsTests(unittest.TestCase):
+    def test_protocol_names_epic_completion_taxonomy_and_terminal_steps(self) -> None:
+        body = normalized(DECOMPOSE_PROTOCOL)
+
+        expected = [
+            "capability epics",
+            "operator-facing capability",
+            "component release work plus a terminal ecosystem-release work-unit",
+            "knowledge/spike epics",
+            "ADR or recorded decision",
+            "decomposition/planning epics",
+            "filed sub-issues",
+            "process/ceremony epics",
+            "adopted process",
+        ]
+
+        for phrase in expected:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, body)
+
+    def test_protocol_references_commons_release_authority_without_reimplementing_it(self) -> None:
+        body = normalized(DECOMPOSE_PROTOCOL)
+
+        expected = [
+            "ADR-0011",
+            "ADR-0012",
+            "ADR-0014",
+            "ECOSYSTEM-RELEASE.md",
+            "does not define the manifest schema, version choice, verification, or publication procedure",
+        ]
+
+        for phrase in expected:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, body)
+
+    def test_epic_template_prompts_for_completion_boundary(self) -> None:
+        body = normalized(DECOMPOSE_TEMPLATES)
+
+        expected = [
+            "## Completion boundary",
+            "Classify the epic by the terminal step that makes its output real for its recipient.",
+            "capability -> component release work plus terminal ecosystem-release work-unit",
+            "knowledge/spike -> ADR or recorded decision",
+            "decomposition/planning -> filed sub-issues",
+            "process/ceremony -> adopted process",
+        ]
+
+        for phrase in expected:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decompose_epic_completion_docs.py
+++ b/tests/test_decompose_epic_completion_docs.py
@@ -13,6 +13,16 @@ def normalized(path: Path) -> str:
 
 
 class DecomposeEpicCompletionDocsTests(unittest.TestCase):
+    def capability_epic_example(self) -> str:
+        body = DECOMPOSE_TEMPLATES.read_text(encoding="utf-8")
+        match = re.search(
+            r"### Example: epic issue\n\n```markdown\n(?P<example>.*?)\n```\n\n---\n\n## Bug Report",
+            body,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        return match.group("example")
+
     def test_protocol_names_epic_completion_taxonomy_and_terminal_steps(self) -> None:
         body = normalized(DECOMPOSE_PROTOCOL)
 
@@ -31,6 +41,20 @@ class DecomposeEpicCompletionDocsTests(unittest.TestCase):
         for phrase in expected:
             with self.subTest(phrase=phrase):
                 self.assertIn(phrase, body)
+
+    def test_capability_epic_example_includes_terminal_ecosystem_release_task(self) -> None:
+        example = self.capability_epic_example()
+        task_issues = re.search(
+            r"## Task issues\n(?P<section>.*?)\n## Dependency graph",
+            example,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(task_issues)
+
+        self.assertRegex(
+            task_issues.group("section"),
+            r"- \[ \] #\d+ .*ecosystem-release.*public fact",
+        )
 
     def test_protocol_references_commons_release_authority_without_reimplementing_it(self) -> None:
         body = normalized(DECOMPOSE_PROTOCOL)


### PR DESCRIPTION
## Summary

- Codifies Groundwork's decompose convention for recipient-facing epic completion boundaries.
- Adds the capability-epic rule: component release work feeds a terminal ecosystem-release work-unit, while commons remains the release authority.
- Updates the epic issue template and adds focused documentation tests.

## Changes

- Added epic completion taxonomy and capability-epic terminal release guidance to `protocols/decompose/PROTOCOL.md`.
- Added a completion-boundary prompt to `protocols/decompose/references/templates.md`.
- Added focused unittest coverage for the new decompose convention.
- Recorded the methodology-facing change in `CHANGELOG.md`.

## GitHub Issue(s)

Closes #383

## Test plan

- `python -m unittest tests.test_decompose_epic_completion_docs`
- `python -m unittest tests.test_protocol_artifact_delivery_docs`
- `python -m tooling.conformance`
- `./scripts/release-check metadata`
- `python -m unittest discover tests`
- `git diff --check`
