### PR TITLE
fix(forge): read runtime-owned forge identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `groundwork-mechanic` now reads runtime-owned scoped forge identity from
+  `RUNA_FORGE_TYPE`, `RUNA_FORGE_OWNER`, `RUNA_FORGE_NAME`, and
+  `RUNA_FORGE_TRACKER_ID`, while leaving methodology-owned
+  `GROUNDWORK_FORGE_ENDPOINT` and `GROUNDWORK_FORGE_REPO_ID` handling unchanged.
+
 ## [0.3.0-rc.1] — 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ When `manifest.toml`, `mechanics/`, and the forge-operation resolver are
 present, the installer also projects a managed runtime bundle under
 `~/.groundwork/`. The bundle contains the manifest, mechanic library, resolver
 module, and `bin/groundwork-mechanic`, so installed protocol sessions can
-resolve forge-invariant operations through the active `GROUNDWORK_FORGE_TYPE`
+resolve forge-invariant operations through the active `RUNA_FORGE_TYPE`
 configuration without reaching back into the source checkout. Installed
 protocol copies reference the managed resolver path directly, so users do not
 need to add `~/.groundwork/bin` to `PATH`.
@@ -113,11 +113,11 @@ atoms:
 
 | Variable | Holds | Example | Forge-assigned? |
 |---|---|---|---|
-| `GROUNDWORK_FORGE_TYPE` | active forge selector, defaulting to `github` | `sourcehut` | no |
+| `RUNA_FORGE_TYPE` | active forge selector, defaulting to `github` | `sourcehut` | no |
+| `RUNA_FORGE_OWNER` | tracker/repo owner handle | `operator` | no |
+| `RUNA_FORGE_NAME` | tracker/repo name | `weforge` | no |
+| `RUNA_FORGE_TRACKER_ID` | tracker integer ID | `4` | yes |
 | `GROUNDWORK_FORGE_ENDPOINT` | deployment host used to derive service hosts | `weforge.build` | no |
-| `GROUNDWORK_FORGE_OWNER` | tracker/repo owner handle | `operator` | no |
-| `GROUNDWORK_FORGE_NAME` | tracker/repo name | `weforge` | no |
-| `GROUNDWORK_FORGE_TRACKER_ID` | tracker integer ID | `4` | yes |
 | `GROUNDWORK_FORGE_REPO_ID` | git repo integer ID | `42` | yes |
 
 For SourceHut, the resolver derives `todo_query_url` as
@@ -125,8 +125,10 @@ For SourceHut, the resolver derives `todo_query_url` as
 `https://git.<endpoint>/query`, and `ssh_remote` as
 `git@git.<endpoint>:~<owner>/<name>`, while `tracker_id` and `repo_id` come
 directly from their atoms. For GitHub, it derives `repository` as
-`<owner>/<name>`. The atoms are the only deployment facts; composed endpoints
-and remotes are not separate configuration values.
+`<owner>/<name>`. Runa owns the four scoped identity atoms it injects into
+agent and MCP environments; Groundwork still owns endpoint and repo-id atoms
+that are not part of runtime scoped identity. The atoms are the only deployment
+facts; composed endpoints and remotes are not separate configuration values.
 
 The cross-repo seam for this ticket identity is documented in
 [`docs/architecture/connecting-structure.md`](docs/architecture/connecting-structure.md#phase-2-forge-tagging-seam).

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -406,6 +406,8 @@ cat "{response}"
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_secret_probe_methodology(root, 'printf "%s\\n" "$token"')
+            environment = os.environ.copy()
+            environment.pop("RUNA_FORGE_TYPE", None)
 
             result = subprocess.run(
                 [
@@ -417,6 +419,7 @@ cat "{response}"
                     "probe",
                     "token=super-secret",
                 ],
+                env=environment,
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -438,6 +441,8 @@ cat "{response}"
                     "print(data); print(os.environ[\"token\"])'"
                 ),
             )
+            environment = {**os.environ, "GROUNDWORK_TEST_TOKEN": secret}
+            environment.pop("RUNA_FORGE_TYPE", None)
 
             result = subprocess.run(
                 [
@@ -450,7 +455,7 @@ cat "{response}"
                     "--secret-env",
                     "token=GROUNDWORK_TEST_TOKEN",
                 ],
-                env={**os.environ, "GROUNDWORK_TEST_TOKEN": secret},
+                env=environment,
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -601,6 +606,12 @@ cat "{response}"
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_github_deployment_probe_methodology(root)
+            environment = {
+                **os.environ,
+                "RUNA_FORGE_OWNER": "tesserine",
+                "RUNA_FORGE_NAME": "groundwork",
+            }
+            environment.pop("RUNA_FORGE_TYPE", None)
 
             result = subprocess.run(
                 [
@@ -611,11 +622,7 @@ cat "{response}"
                     "run",
                     "probe",
                 ],
-                env={
-                    **os.environ,
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "groundwork",
-                },
+                env=environment,
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -628,6 +635,12 @@ cat "{response}"
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_github_deployment_probe_methodology(root)
+            environment = {
+                **os.environ,
+                "RUNA_FORGE_OWNER": "tesserine",
+                "RUNA_FORGE_NAME": "groundwork",
+            }
+            environment.pop("RUNA_FORGE_TYPE", None)
 
             result = subprocess.run(
                 [
@@ -639,11 +652,7 @@ cat "{response}"
                     "probe",
                     "repository=attacker/repo",
                 ],
-                env={
-                    **os.environ,
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "groundwork",
-                },
+                env=environment,
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -73,10 +73,13 @@ class ForgeOperationTests(unittest.TestCase):
         self.assertEqual("github", active_forge_type({}, None))
 
     def test_active_forge_type_uses_explicit_override_before_environment(self) -> None:
-        self.assertEqual("sourcehut", active_forge_type({"GROUNDWORK_FORGE_TYPE": "github"}, "sourcehut"))
+        self.assertEqual("sourcehut", active_forge_type({"RUNA_FORGE_TYPE": "github"}, "sourcehut"))
 
-    def test_active_forge_type_uses_groundwork_forge_type_environment(self) -> None:
-        self.assertEqual("sourcehut", active_forge_type({"GROUNDWORK_FORGE_TYPE": "sourcehut"}, None))
+    def test_active_forge_type_uses_runa_forge_type_environment(self) -> None:
+        self.assertEqual("sourcehut", active_forge_type({"RUNA_FORGE_TYPE": "sourcehut"}, None))
+
+    def test_active_forge_type_does_not_fall_back_to_groundwork_forge_type_environment(self) -> None:
+        self.assertEqual("github", active_forge_type({"GROUNDWORK_FORGE_TYPE": "sourcehut"}, None))
 
     def test_resolve_operation_returns_exact_active_forge_mechanic(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -158,8 +161,8 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_OWNER": "tesserine",
-                    "GROUNDWORK_FORGE_NAME": "groundwork",
+                    "RUNA_FORGE_OWNER": "tesserine",
+                    "RUNA_FORGE_NAME": "groundwork",
                 },
             ):
                 result = run_invocation(
@@ -180,8 +183,8 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_OWNER": "tesserine",
-                    "GROUNDWORK_FORGE_NAME": "groundwork",
+                    "RUNA_FORGE_OWNER": "tesserine",
+                    "RUNA_FORGE_NAME": "groundwork",
                 },
             ):
                 result = run_invocation(
@@ -212,7 +215,7 @@ class ForgeOperationTests(unittest.TestCase):
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
                     "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                    "RUNA_FORGE_TRACKER_ID": "4",
                 },
             ):
                 result = run_invocation(
@@ -231,7 +234,7 @@ class ForgeOperationTests(unittest.TestCase):
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
                     "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                    "RUNA_FORGE_TRACKER_ID": "4",
                 },
             ):
                 result = run_invocation(
@@ -273,9 +276,9 @@ cat "{response}"
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
                     "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "GROUNDWORK_FORGE_OWNER": "operator",
-                    "GROUNDWORK_FORGE_NAME": "weforge",
-                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                    "RUNA_FORGE_OWNER": "operator",
+                    "RUNA_FORGE_NAME": "weforge",
+                    "RUNA_FORGE_TRACKER_ID": "4",
                 },
             ):
                 result = run_invocation(
@@ -291,9 +294,9 @@ cat "{response}"
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
                     "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "GROUNDWORK_FORGE_OWNER": "operator",
-                    "GROUNDWORK_FORGE_NAME": "weforge",
-                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                    "RUNA_FORGE_OWNER": "operator",
+                    "RUNA_FORGE_NAME": "weforge",
+                    "RUNA_FORGE_TRACKER_ID": "4",
                 },
             ):
                 error_result = run_invocation(
@@ -477,9 +480,9 @@ cat "{response}"
                 env={
                     **os.environ,
                     "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "GROUNDWORK_FORGE_OWNER": "operator",
-                    "GROUNDWORK_FORGE_NAME": "weforge",
-                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                    "RUNA_FORGE_OWNER": "operator",
+                    "RUNA_FORGE_NAME": "weforge",
+                    "RUNA_FORGE_TRACKER_ID": "4",
                     "GROUNDWORK_FORGE_REPO_ID": "42",
                 },
                 text=True,
@@ -490,7 +493,7 @@ cat "{response}"
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual("42\n", result.stdout)
 
-    def test_cli_resolves_sourcehut_deployment_values_from_groundwork_atoms(self) -> None:
+    def test_cli_resolves_sourcehut_deployment_values_from_runtime_and_groundwork_atoms(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_sourcehut_deployment_probe_methodology(root)
@@ -509,9 +512,9 @@ cat "{response}"
                 env={
                     **os.environ,
                     "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "GROUNDWORK_FORGE_OWNER": "operator",
-                    "GROUNDWORK_FORGE_NAME": "weforge",
-                    "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                    "RUNA_FORGE_OWNER": "operator",
+                    "RUNA_FORGE_NAME": "weforge",
+                    "RUNA_FORGE_TRACKER_ID": "4",
                     "GROUNDWORK_FORGE_REPO_ID": "42",
                 },
                 text=True,
@@ -537,11 +540,11 @@ cat "{response}"
             self.write_sourcehut_tracker_probe_methodology(root)
             environment = {
                 **os.environ,
-                "GROUNDWORK_FORGE_TYPE": "sourcehut",
+                "RUNA_FORGE_TYPE": "sourcehut",
                 "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                "GROUNDWORK_FORGE_OWNER": "operator",
-                "GROUNDWORK_FORGE_NAME": "weforge",
-                "GROUNDWORK_FORGE_TRACKER_ID": "4",
+                "RUNA_FORGE_OWNER": "operator",
+                "RUNA_FORGE_NAME": "weforge",
+                "RUNA_FORGE_TRACKER_ID": "4",
             }
             environment.pop("GROUNDWORK_FORGE_REPO_ID", None)
 
@@ -582,8 +585,8 @@ cat "{response}"
                 env={
                     **os.environ,
                     "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "GROUNDWORK_FORGE_OWNER": "operator",
-                    "GROUNDWORK_FORGE_NAME": "weforge",
+                    "RUNA_FORGE_OWNER": "operator",
+                    "RUNA_FORGE_NAME": "weforge",
                     "GROUNDWORK_FORGE_REPO_ID": "42",
                 },
                 text=True,
@@ -592,9 +595,9 @@ cat "{response}"
             )
 
         self.assertNotEqual(0, result.returncode)
-        self.assertIn("GROUNDWORK_FORGE_TRACKER_ID", result.stderr)
+        self.assertIn("RUNA_FORGE_TRACKER_ID", result.stderr)
 
-    def test_cli_resolves_github_repository_from_groundwork_atoms_with_default_forge_type(self) -> None:
+    def test_cli_resolves_github_repository_from_runtime_atoms_with_default_forge_type(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_github_deployment_probe_methodology(root)
@@ -610,8 +613,8 @@ cat "{response}"
                 ],
                 env={
                     **os.environ,
-                    "GROUNDWORK_FORGE_OWNER": "tesserine",
-                    "GROUNDWORK_FORGE_NAME": "groundwork",
+                    "RUNA_FORGE_OWNER": "tesserine",
+                    "RUNA_FORGE_NAME": "groundwork",
                 },
                 text=True,
                 stdout=subprocess.PIPE,
@@ -638,8 +641,8 @@ cat "{response}"
                 ],
                 env={
                     **os.environ,
-                    "GROUNDWORK_FORGE_OWNER": "tesserine",
-                    "GROUNDWORK_FORGE_NAME": "groundwork",
+                    "RUNA_FORGE_OWNER": "tesserine",
+                    "RUNA_FORGE_NAME": "groundwork",
                 },
                 text=True,
                 stdout=subprocess.PIPE,

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -20,6 +20,20 @@ from tooling.forge_operations import (
 
 ROOT = Path(__file__).resolve().parents[1]
 EARLY_ARC_OPERATIONS = ["create-ticket", "read-ticket", "claim-work-unit", "record-progress"]
+RUNA_FORGE_ENVIRONMENT_ATOMS = (
+    "RUNA_FORGE_TYPE",
+    "RUNA_FORGE_OWNER",
+    "RUNA_FORGE_NAME",
+    "RUNA_FORGE_TRACKER_ID",
+)
+
+
+def forge_cli_environment(**values: str) -> dict[str, str]:
+    environment = os.environ.copy()
+    for atom in RUNA_FORGE_ENVIRONMENT_ATOMS:
+        environment.pop(atom, None)
+    environment.update(values)
+    return environment
 
 
 class ForgeOperationTests(unittest.TestCase):
@@ -107,6 +121,7 @@ class ForgeOperationTests(unittest.TestCase):
                     "resolve",
                     "close-out",
                 ],
+                env=forge_cli_environment(),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -406,8 +421,6 @@ cat "{response}"
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_secret_probe_methodology(root, 'printf "%s\\n" "$token"')
-            environment = os.environ.copy()
-            environment.pop("RUNA_FORGE_TYPE", None)
 
             result = subprocess.run(
                 [
@@ -419,7 +432,7 @@ cat "{response}"
                     "probe",
                     "token=super-secret",
                 ],
-                env=environment,
+                env=forge_cli_environment(),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -441,8 +454,6 @@ cat "{response}"
                     "print(data); print(os.environ[\"token\"])'"
                 ),
             )
-            environment = {**os.environ, "GROUNDWORK_TEST_TOKEN": secret}
-            environment.pop("RUNA_FORGE_TYPE", None)
 
             result = subprocess.run(
                 [
@@ -455,7 +466,7 @@ cat "{response}"
                     "--secret-env",
                     "token=GROUNDWORK_TEST_TOKEN",
                 ],
-                env=environment,
+                env=forge_cli_environment(GROUNDWORK_TEST_TOKEN=secret),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -482,14 +493,13 @@ cat "{response}"
                     "run",
                     "probe",
                 ],
-                env={
-                    **os.environ,
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "RUNA_FORGE_TRACKER_ID": "4",
-                    "GROUNDWORK_FORGE_REPO_ID": "42",
-                },
+                env=forge_cli_environment(
+                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
+                    RUNA_FORGE_OWNER="operator",
+                    RUNA_FORGE_NAME="weforge",
+                    RUNA_FORGE_TRACKER_ID="4",
+                    GROUNDWORK_FORGE_REPO_ID="42",
+                ),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -514,14 +524,13 @@ cat "{response}"
                     "run",
                     "probe",
                 ],
-                env={
-                    **os.environ,
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "RUNA_FORGE_TRACKER_ID": "4",
-                    "GROUNDWORK_FORGE_REPO_ID": "42",
-                },
+                env=forge_cli_environment(
+                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
+                    RUNA_FORGE_OWNER="operator",
+                    RUNA_FORGE_NAME="weforge",
+                    RUNA_FORGE_TRACKER_ID="4",
+                    GROUNDWORK_FORGE_REPO_ID="42",
+                ),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -543,14 +552,13 @@ cat "{response}"
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_sourcehut_tracker_probe_methodology(root)
-            environment = {
-                **os.environ,
-                "RUNA_FORGE_TYPE": "sourcehut",
-                "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                "RUNA_FORGE_OWNER": "operator",
-                "RUNA_FORGE_NAME": "weforge",
-                "RUNA_FORGE_TRACKER_ID": "4",
-            }
+            environment = forge_cli_environment(
+                RUNA_FORGE_TYPE="sourcehut",
+                GROUNDWORK_FORGE_ENDPOINT="weforge.build",
+                RUNA_FORGE_OWNER="operator",
+                RUNA_FORGE_NAME="weforge",
+                RUNA_FORGE_TRACKER_ID="4",
+            )
             environment.pop("GROUNDWORK_FORGE_REPO_ID", None)
 
             result = subprocess.run(
@@ -587,13 +595,12 @@ cat "{response}"
                     "run",
                     "probe",
                 ],
-                env={
-                    **os.environ,
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "GROUNDWORK_FORGE_REPO_ID": "42",
-                },
+                env=forge_cli_environment(
+                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
+                    RUNA_FORGE_OWNER="operator",
+                    RUNA_FORGE_NAME="weforge",
+                    GROUNDWORK_FORGE_REPO_ID="42",
+                ),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -606,12 +613,6 @@ cat "{response}"
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_github_deployment_probe_methodology(root)
-            environment = {
-                **os.environ,
-                "RUNA_FORGE_OWNER": "tesserine",
-                "RUNA_FORGE_NAME": "groundwork",
-            }
-            environment.pop("RUNA_FORGE_TYPE", None)
 
             result = subprocess.run(
                 [
@@ -622,7 +623,10 @@ cat "{response}"
                     "run",
                     "probe",
                 ],
-                env=environment,
+                env=forge_cli_environment(
+                    RUNA_FORGE_OWNER="tesserine",
+                    RUNA_FORGE_NAME="groundwork",
+                ),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -635,12 +639,6 @@ cat "{response}"
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_github_deployment_probe_methodology(root)
-            environment = {
-                **os.environ,
-                "RUNA_FORGE_OWNER": "tesserine",
-                "RUNA_FORGE_NAME": "groundwork",
-            }
-            environment.pop("RUNA_FORGE_TYPE", None)
 
             result = subprocess.run(
                 [
@@ -652,7 +650,10 @@ cat "{response}"
                     "probe",
                     "repository=attacker/repo",
                 ],
-                env=environment,
+                env=forge_cli_environment(
+                    RUNA_FORGE_OWNER="tesserine",
+                    RUNA_FORGE_NAME="groundwork",
+                ),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -247,7 +247,7 @@ class GroundworkInstallTests(unittest.TestCase):
         resolved = run(
             [str(resolver), "resolve", "close-out"],
             install.runtime_root(),
-            env={**os.environ, "GROUNDWORK_FORGE_TYPE": "sourcehut"},
+            env={**os.environ, "RUNA_FORGE_TYPE": "sourcehut"},
         )
         assert_success(self, resolved)
         self.assertEqual("close-out[sourcehut]\n", resolved.stdout)
@@ -294,7 +294,7 @@ class GroundworkInstallTests(unittest.TestCase):
             resolved = run(
                 argv,
                 install.runtime_root(),
-                env={**os.environ, "GROUNDWORK_FORGE_TYPE": "sourcehut", "PATH": "/usr/bin:/bin"},
+                env={**os.environ, "RUNA_FORGE_TYPE": "sourcehut", "PATH": "/usr/bin:/bin"},
             )
             assert_success(self, resolved)
             self.assertEqual("close-out[sourcehut]\n", resolved.stdout)
@@ -331,7 +331,7 @@ class GroundworkInstallTests(unittest.TestCase):
         resolved = run(
             argv,
             install.runtime_root(),
-            env={**os.environ, "GROUNDWORK_FORGE_TYPE": "sourcehut", "PATH": "/usr/bin:/bin"},
+            env={**os.environ, "RUNA_FORGE_TYPE": "sourcehut", "PATH": "/usr/bin:/bin"},
         )
         assert_success(self, resolved)
         self.assertEqual("close-out[sourcehut]\n", resolved.stdout)

--- a/tests/test_interactive_session_surface.py
+++ b/tests/test_interactive_session_surface.py
@@ -61,10 +61,10 @@ def append_agent_command_config(project_dir: Path, command: list[Path]) -> None:
 
 def groundwork_env() -> dict[str, str]:
     env = os.environ.copy()
-    env.pop("GROUNDWORK_FORGE_TYPE", None)
-    env.pop("GROUNDWORK_FORGE_TRACKER_ID", None)
-    env["GROUNDWORK_FORGE_OWNER"] = "tesserine"
-    env["GROUNDWORK_FORGE_NAME"] = "groundwork"
+    env.pop("RUNA_FORGE_TYPE", None)
+    env.pop("RUNA_FORGE_TRACKER_ID", None)
+    env["RUNA_FORGE_OWNER"] = "tesserine"
+    env["RUNA_FORGE_NAME"] = "groundwork"
     return env
 
 

--- a/tooling/forge_operations.py
+++ b/tooling/forge_operations.py
@@ -9,6 +9,10 @@ from typing import Any, Mapping
 
 
 ROOT = Path(__file__).resolve().parents[1]
+RUNA_FORGE_TYPE = "RUNA_FORGE_TYPE"
+RUNA_FORGE_OWNER = "RUNA_FORGE_OWNER"
+RUNA_FORGE_NAME = "RUNA_FORGE_NAME"
+RUNA_FORGE_TRACKER_ID = "RUNA_FORGE_TRACKER_ID"
 
 
 class ForgeOperationError(ValueError):
@@ -18,7 +22,7 @@ class ForgeOperationError(ValueError):
 def active_forge_type(environment: Mapping[str, str], override: str | None) -> str:
     if override:
         return override
-    return environment.get("GROUNDWORK_FORGE_TYPE") or "github"
+    return environment.get(RUNA_FORGE_TYPE) or "github"
 
 
 def resolve_operation(root: Path | str, operation: str, *, forge_type: str | None = None) -> dict[str, Any]:
@@ -59,7 +63,7 @@ def render_shell_invocation(mechanic: Mapping[str, Any], values: Mapping[str, st
     provided_deployment_values = sorted(set(values) & set(deployment_parameters))
     if provided_deployment_values:
         raise ForgeOperationError(
-            f"deployment-resolved parameter(s) must come from GROUNDWORK_*: {', '.join(provided_deployment_values)}"
+            f"deployment-resolved parameter(s) must come from the configured forge environment: {', '.join(provided_deployment_values)}"
         )
     deployment_values = _deployment_parameter_values(mechanic, os.environ)
     resolved_values = {**values, **deployment_values}
@@ -96,7 +100,7 @@ def run_invocation(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Resolve and invoke Groundwork forge operations.")
     parser.add_argument("--root", default=str(ROOT), help="Groundwork methodology root. Defaults to this checkout.")
-    parser.add_argument("--forge-type", help="Active forge type override. Defaults to GROUNDWORK_FORGE_TYPE, then github.")
+    parser.add_argument("--forge-type", help="Active forge type override. Defaults to RUNA_FORGE_TYPE, then github.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     resolve_parser = subparsers.add_parser("resolve", help="Print the resolved mechanic path-equivalent name.")
@@ -229,24 +233,24 @@ def _resolve_deployment_value(
 ) -> str:
     if forge_type == "github":
         if deployment_value == "owner":
-            return _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
+            return _required_environment(environment, RUNA_FORGE_OWNER)
         if deployment_value == "name":
-            return _required_environment(environment, "GROUNDWORK_FORGE_NAME")
+            return _required_environment(environment, RUNA_FORGE_NAME)
         if deployment_value == "repository":
-            owner = _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
-            name = _required_environment(environment, "GROUNDWORK_FORGE_NAME")
+            owner = _required_environment(environment, RUNA_FORGE_OWNER)
+            name = _required_environment(environment, RUNA_FORGE_NAME)
             return f"{owner}/{name}"
         raise ForgeOperationError(
             f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
         )
     if forge_type == "sourcehut":
         if deployment_value == "owner":
-            return _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
+            return _required_environment(environment, RUNA_FORGE_OWNER)
         if deployment_value == "name":
-            return _required_environment(environment, "GROUNDWORK_FORGE_NAME")
+            return _required_environment(environment, RUNA_FORGE_NAME)
         if deployment_value == "repository":
-            owner = _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
-            name = _required_environment(environment, "GROUNDWORK_FORGE_NAME")
+            owner = _required_environment(environment, RUNA_FORGE_OWNER)
+            name = _required_environment(environment, RUNA_FORGE_NAME)
             return f"{owner}/{name}"
         if deployment_value == "todo_query_url":
             endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
@@ -256,11 +260,11 @@ def _resolve_deployment_value(
             return f"https://git.{endpoint}/query"
         if deployment_value == "ssh_remote":
             endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
-            owner = _required_environment(environment, "GROUNDWORK_FORGE_OWNER")
-            name = _required_environment(environment, "GROUNDWORK_FORGE_NAME")
+            owner = _required_environment(environment, RUNA_FORGE_OWNER)
+            name = _required_environment(environment, RUNA_FORGE_NAME)
             return f"git@git.{endpoint}:~{owner}/{name}"
         if deployment_value == "tracker_id":
-            return _required_environment(environment, "GROUNDWORK_FORGE_TRACKER_ID")
+            return _required_environment(environment, RUNA_FORGE_TRACKER_ID)
         if deployment_value == "repo_id":
             return _required_environment(environment, "GROUNDWORK_FORGE_REPO_ID")
         raise ForgeOperationError(


### PR DESCRIPTION
## Summary

- Moves Groundwork forge mechanic identity reads to runa-owned `RUNA_FORGE_*` atoms.
- Keeps `GROUNDWORK_FORGE_ENDPOINT` and `GROUNDWORK_FORGE_REPO_ID` under the methodology-owned namespace.
- Makes forge CLI subprocess tests hermetic against inherited parent `RUNA_FORGE_*` atoms.

## Changes

- `groundwork-mechanic` now resolves active forge type, owner, name, repository, SourceHut remote owner/name, and tracker id from `RUNA_FORGE_*`.
- Added regression coverage that `GROUNDWORK_FORGE_TYPE` is not a fallback for the runtime-emitted forge type.
- Updated forge-operation, install, and interactive-session tests to use the runtime-owned identity surface while preserving endpoint/repo-id handling.
- Centralized forge CLI test environment construction so subprocess tests scrub inherited runtime forge atoms before adding back only intended values.

## GitHub Issue(s)

Closes #389

## Test plan

- `RUNA_FORGE_TYPE=sourcehut RUNA_FORGE_OWNER=x RUNA_FORGE_NAME=y RUNA_FORGE_TRACKER_ID=999 python -m unittest tests.test_forge_operations`
- `python -m unittest tests.test_forge_operations`
- `python -m unittest discover -s tests` (currently fails only on the existing release-version check expecting `0.2.0` while `manifest.toml` has `0.3.0-rc.1`)
- `python -m tooling.conformance`
- `git diff --check`
- `rg "GROUNDWORK_FORGE_(TYPE|OWNER|NAME|TRACKER_ID)" tooling tests README.md CHANGELOG.md`
