### PR TITLE
fix(release): derive manifest version check from changelog

### DIFF
--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -237,8 +237,11 @@ def check_release_surface_files(root: Path) -> None:
 
 
 def run_metadata(root: Path) -> None:
-    manifest_version(root)
+    current = manifest_version(root)
     check_changelog_structure(root)
+    release_of_record = latest_released_version(root)
+    if current != release_of_record:
+        die(f"manifest version {current} disagrees with release-of-record {release_of_record}")
     check_methodology_integrity(root)
     check_release_surface_files(root)
 

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -80,6 +80,12 @@ def release_heading_for(version: str) -> str | None:
     return prefix
 
 
+def _release_heading_version(line: str) -> str | None:
+    if not RELEASE_HEADING_RE.fullmatch(line):
+        return None
+    return line[len("## [") : line.index("]")]
+
+
 def check_changelog_structure(root: Path) -> None:
     changelog = changelog_path(root)
     lines = changelog.read_text(encoding="utf-8").splitlines()
@@ -96,13 +102,24 @@ def check_changelog_structure(root: Path) -> None:
             if seen_release:
                 die("CHANGELOG.md places ## [Unreleased] after a release heading")
             continue
-        if not RELEASE_HEADING_RE.fullmatch(line):
+        version = _release_heading_version(line)
+        if version is None:
             die(f"CHANGELOG.md release heading is malformed: {line}")
-        version = line[len("## [") : line.index("]")]
         if version in seen_versions:
             die(f"CHANGELOG.md has duplicate release heading for [{version}]")
         seen_versions.add(version)
         seen_release = True
+
+
+def latest_released_version(root: Path) -> str:
+    check_changelog_structure(root)
+    lines = changelog_path(root).read_text(encoding="utf-8").splitlines()
+    start = lines.index("## [Unreleased]") + 1
+    for line in lines[start:]:
+        version = _release_heading_version(line)
+        if version is not None:
+            return version
+    die("CHANGELOG.md has no release heading")
 
 
 def require_release_heading(root: Path, version: str) -> None:

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -8,6 +8,8 @@ import textwrap
 import unittest
 from pathlib import Path
 
+from scripts import release_lib
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -222,6 +224,33 @@ class ReleaseCeremonyTests(unittest.TestCase):
             result,
             "CHANGELOG.md has duplicate release heading for [1.2.3-rc.1]",
         )
+
+    def test_manifest_version_must_match_latest_released_changelog_heading(self) -> None:
+        fixture = self.add_fixture("manifest-release-mismatch", "1.2.3")
+        fixture.write(
+            "manifest.toml",
+            """
+            name = "groundwork"
+            version = "1.2.4"
+
+            [[artifact_types]]
+            name = "claim"
+
+            [[protocols]]
+            name = "take"
+            requires = ["claim"]
+            accepts = []
+            produces = ["claim"]
+            may_produce = []
+            trigger = { type = "on_artifact", name = "claim" }
+            """,
+        )
+
+        with self.assertRaises(AssertionError):
+            self.assertEqual(
+                release_lib.manifest_version(fixture.root),
+                release_lib.latest_released_version(fixture.root),
+            )
 
     def test_notes_emit_matching_changelog_section_without_outer_blank_lines(self) -> None:
         fixture = self.add_fixture("notes-success", "1.2.3-rc.1")
@@ -448,7 +477,7 @@ class ReleaseRepositoryContractTests(unittest.TestCase):
         return (ROOT / relative).read_text(encoding="utf-8")
 
     def test_manifest_declares_current_methodology_version(self) -> None:
-        self.assertIn('version = "0.2.0"', self.read("manifest.toml"))
+        self.assertEqual(release_lib.manifest_version(ROOT), release_lib.latest_released_version(ROOT))
 
     def test_release_workflow_verifies_annotated_tags_and_has_no_path_filter(self) -> None:
         workflow = self.read(".github/workflows/release.yml")

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -8,10 +8,11 @@ import textwrap
 import unittest
 from pathlib import Path
 
-from scripts import release_lib
-
-
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import release_lib
 
 
 def run(
@@ -246,11 +247,13 @@ class ReleaseCeremonyTests(unittest.TestCase):
             """,
         )
 
-        with self.assertRaises(AssertionError):
-            self.assertEqual(
-                release_lib.manifest_version(fixture.root),
-                release_lib.latest_released_version(fixture.root),
-            )
+        result = fixture.run_release_check("metadata")
+
+        assert_failure_contains(
+            self,
+            result,
+            "manifest version 1.2.4 disagrees with release-of-record 1.2.3",
+        )
 
     def test_notes_emit_matching_changelog_section_without_outer_blank_lines(self) -> None:
         fixture = self.add_fixture("notes-success", "1.2.3-rc.1")


### PR DESCRIPTION
## Summary

- add `release_lib.latest_released_version(root)` as the shared changelog-derived release authority
- update the release ceremony manifest-version contract to compare `manifest_version(root)` against that authority instead of a hardcoded literal
- add a fixture regression proving manifest/changelog drift fails the check
- preserve direct execution of `tests/test_release_ceremony.py` by making the repo root importable before importing `scripts.release_lib`

Closes #391.

## Verification

- `python tests/test_release_ceremony.py` -> OK, 25 tests
- `python -m unittest tests.test_release_ceremony` -> OK, 25 tests
- `./scripts/release-check metadata` -> OK
- `python -m tooling.conformance` -> Summary: 37 passed, 0 failed
- `GROUNDWORK_RUNA_BIN=/nonexistent python -m unittest discover -s tests` -> OK, 238 tests, skipped=1
- `python -m unittest discover -s tests` -> fails only in `tests.test_interactive_session_surface.InteractiveSessionSurfaceTests.test_go_launches_configured_agent_and_agent_drives_session_surface_tools`: local sibling `runa` expects `RUNA_FORGE_OWNER`, while `main` still supplies `GROUNDWORK_FORGE_OWNER`; this is the forge-runtime env rename already present on `issue-389/groundwork-forge-mechanics-read-runtime`, not part of this standalone #391 branch.
- GitHub PR checks on `c61d3fa`: `Release metadata` passed, `Tests and conformance` passed
