### PR TITLE
feat(config): principles-corpus selection in methodology configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Principles-corpus configuration surface** (ADR-0005). The principles
+  corpus reckon consults now resolves through deployment-owned methodology
+  configuration at `${XDG_CONFIG_HOME:-~/.config}/groundwork/principles.toml`:
+  a `[corpus]` table discriminated by `source` (`embedded` | `path` | `git`),
+  schema-validated (`schemas/principles-config.schema.json`) and parsed with
+  named errors (`tooling/principles_config.py`). The configured source is
+  distinct from the resolved local corpus the resolution layer materializes
+  at setup; absent configuration selects the embedded default, and a present
+  but invalid configuration fails loudly rather than silently degrading.
+  Documented for ordinary (zero-config) and power-user (external corpus)
+  paths in `docs/principles-corpus.md` (closes #399).
 - **Acquisition: entry from an existing forge ticket** (ADR-0004). The new
   `acquire` skill reads a ticket already on the tracker through the existing
   `read-ticket` mechanic and materializes a `work-unit` artifact from it

--- a/docs/architecture/decisions/0005-principles-corpus-configuration.md
+++ b/docs/architecture/decisions/0005-principles-corpus-configuration.md
@@ -1,0 +1,101 @@
+# ADR-0005: Principles Corpus Configuration
+
+**Status:** Provisional \
+**Date:** 2026-06-12 \
+**Traces to:** [pentaxis93/principles](https://github.com/pentaxis93/principles)
+(Sovereignty, Single Home, Grounding, Parsimony); epic
+[tesserine/groundwork#397](https://github.com/tesserine/groundwork/issues/397).
+
+## Context
+
+Reckon reasons from a principles corpus during Orient. Until this
+decision, the corpus was an inline operational dependency: reckon's skill
+text linked one repository (`pentaxis93/principles`) directly. The desired
+property is not "no runtime dependency" — reckon *should* depend on a
+corpus — but "no hard-coded dependency": the corpus must resolve through
+configuration, with a minimal embedded default so a bare checkout reasons
+offline with zero configuration.
+
+Selecting the configuration surface required deciding between three
+candidates observed in the substrate:
+
+1. **`manifest.toml`** — the methodology topology surface runa reads.
+2. **Environment atoms** — the deployment env-var lineage, since partially
+   migrated to runtime-owned `RUNA_*` atoms (#389).
+3. **A dedicated config file** — deployment-owned, outside the methodology
+   tree.
+
+## Decision
+
+A dedicated, deployment-owned TOML config file at
+`${XDG_CONFIG_HOME:-~/.config}/groundwork/principles.toml`, schema-validated
+against `schemas/principles-config.schema.json`, parsed by
+`tooling/principles_config.py`.
+
+The config declares the **configured source** (`embedded` | `path` |
+`git`). It is distinct from the **resolved local corpus** — the stable
+local location (`~/.groundwork/principles/` under the managed runtime
+root) that the resolution layer materializes the source into at setup,
+and which reckon consults during reasoning. Absent configuration resolves
+to the embedded default shipped in-tree at `principles/`.
+
+### Why not `manifest.toml`
+
+The manifest ships *with* the methodology and describes its invariant
+topology to runa. Corpus selection is a per-deployment override — a
+different owner (the deployment, not the methodology author) and a
+different lifecycle (changeable without editing the methodology tree).
+Sovereignty places the choice with its owner; putting a deployment knob
+in the shipped manifest crosses that boundary.
+
+### Why not environment atoms
+
+Post-#389, env atoms are runtime-owned session identity (`RUNA_FORGE_*`)
+or narrowly-scoped forge deployment values. The corpus is methodology
+content resolved once at setup, not per-session identity. Env vars also
+offer no structural validation; the repo's established
+structural-impossibility tier (TOML + JSON Schema, the C-2/C-3 prior art)
+is available to a file and not to an environment.
+
+### Why TOML + JSON Schema
+
+Consistency with every other configured surface in this repository
+(`manifest.toml`, workflow contracts, mechanics): `tomllib` parsing,
+Draft 2020-12 validation, named per-path errors. One convention, not two
+(Single Home).
+
+### Failure semantics
+
+A *missing* config file is the ordinary path and selects the embedded
+default. A *present but invalid* file (unreadable, invalid TOML, schema
+violation, relative corpus path) fails loudly with named errors. The
+distinction is deliberate: zero-config is first-class, but an expressed
+configuration that cannot be honored must never silently degrade the
+reasoning substrate.
+
+## Consequences
+
+### Good
+
+- Reckon's corpus dependency becomes configurable without becoming
+  optional: the embedded default preserves standalone, offline operation.
+- `pentaxis93/principles` appears only as an example value in
+  documentation — the canonical choice for Tesserine deployments, never a
+  baked-in operational default.
+- The source/resolved distinction gives the resolution layer (setup-time
+  materialization) and reckon (read-only consultation of local content) a
+  clean contract, and makes "no live fetch mid-reckon" structurally
+  expressible.
+
+### Neutral
+
+- The config file is invisible to the conformance runner (it lives
+  outside the tree); its schema is conformance-checked, and its parsing
+  is test-covered. Setup-time validation is the resolution layer's
+  responsibility.
+
+### Bad
+
+- One more deployment-owned file location to know about. Mitigated by the
+  zero-config default and by `docs/principles-corpus.md` documenting both
+  paths.

--- a/docs/principles-corpus.md
+++ b/docs/principles-corpus.md
@@ -1,0 +1,86 @@
+# The Principles Corpus
+
+Reckon reasons from navigational principles — first principles selected
+during Orient and reasoned FROM during Reconstruct. The corpus those
+principles are selected from is not hard-coded into any skill: it resolves
+through methodology configuration. This document specifies the
+configuration surface.
+
+## Two concepts, kept distinct
+
+- **The configured source** — where the corpus comes from. Declared in a
+  deployment-owned config file (below). One of: the embedded default
+  shipped in this repository, a local directory, or a remote git
+  repository.
+- **The resolved local corpus** — the local content reckon actually reads
+  during reasoning. The resolution layer materializes the configured
+  source into this location at setup time; reckon never live-fetches a
+  remote mid-reckon. In an installed deployment the resolved corpus lives
+  at `~/.groundwork/principles/`; in a standalone checkout the embedded
+  default at `principles/` is already local.
+
+## The ordinary path: zero configuration
+
+With no configuration present, the corpus is the minimal embedded default
+shipped in-tree at `principles/`. No config file, no network, no setup
+beyond the checkout itself. An empty config file, or one without a
+`[corpus]` table, selects the same default — absence of configuration is
+the first-class ordinary path, not an error path.
+
+The embedded default is a short, standalone, near-universal corpus. It is
+the fallback/default for standalone use — not the canonical authority for
+the Tesserine ecosystem, and not a digest of any external corpus.
+
+## The power-user path: configuring a corpus
+
+The config file is deployment-owned and lives outside the methodology
+tree at:
+
+```
+${XDG_CONFIG_HOME:-~/.config}/groundwork/principles.toml
+```
+
+It declares a single `[corpus]` table discriminated by `source`:
+
+```toml
+# The embedded default, stated explicitly (same as no file at all):
+[corpus]
+source = "embedded"
+```
+
+```toml
+# A corpus already on the local filesystem (absolute path required):
+[corpus]
+source = "path"
+path = "/srv/corpora/our-principles"
+```
+
+```toml
+# A remote git repository, fetched once at setup — for example, the
+# canonical corpus Tesserine's own deployments configure:
+[corpus]
+source = "git"
+url = "https://github.com/pentaxis93/principles"
+ref = "main"   # optional; the repository's default branch when absent
+```
+
+The shape is schema-validated
+([`schemas/principles-config.schema.json`](../schemas/principles-config.schema.json));
+parsing and validation live in
+[`tooling/principles_config.py`](../tooling/principles_config.py). A
+present-but-invalid configuration fails loudly with named errors — it
+never silently degrades to the default.
+
+## What this surface deliberately does not do
+
+- It names no privileged external corpus in code. `pentaxis93/principles`
+  above is an example value — the right one for Tesserine deployments,
+  but a configuration choice, not a baked-in default.
+- It does not pre-select which principles matter. The corpus speaks for
+  itself; reckon's Orient selects the relevant principles per domain from
+  the resolved corpus.
+- It does not synchronize during a session. Materialization happens at
+  setup; refreshing the resolved corpus is a setup-time action.
+
+Design rationale for the surface choice is recorded in
+[ADR-0005](architecture/decisions/0005-principles-corpus-configuration.md).

--- a/schemas/principles-config.schema.json
+++ b/schemas/principles-config.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/principles-config.schema.json",
+  "title": "Principles corpus configuration",
+  "description": "Deployment-owned selection of the principles corpus that reckon consults during Orient. The file lives outside the methodology tree (default: ${XDG_CONFIG_HOME:-~/.config}/groundwork/principles.toml) and declares the configured SOURCE of the corpus; the resolution layer materializes that source into the resolved local corpus that reckon actually reads. An absent file, an empty document, or an absent corpus table all select the embedded default corpus.",
+  "type": "object",
+  "properties": {
+    "corpus": {
+      "description": "Where the principles corpus comes from. Discriminated by `source`.",
+      "type": "object",
+      "oneOf": [
+        {
+          "description": "The minimal default corpus shipped in the groundwork tree. Zero-config, offline-capable; this is the first-class ordinary path, not an error path.",
+          "properties": {
+            "source": { "const": "embedded" }
+          },
+          "required": ["source"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A corpus already on the local filesystem: an absolute path to a directory of principle documents.",
+          "properties": {
+            "source": { "const": "path" },
+            "path": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Absolute path to the corpus directory."
+            }
+          },
+          "required": ["source", "path"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A remote git repository holding the corpus, fetched once at setup into the resolved local corpus location — never live-fetched during reasoning. Example value: https://github.com/pentaxis93/principles (the canonical corpus for Tesserine's own deployments).",
+          "properties": {
+            "source": { "const": "git" },
+            "url": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Clone URL of the corpus repository."
+            },
+            "ref": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Optional git ref (branch, tag, or commit) to materialize; the repository's default branch when absent."
+            }
+          },
+          "required": ["source", "url"],
+          "additionalProperties": false
+        }
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_principles_config.py
+++ b/tests/test_principles_config.py
@@ -1,0 +1,156 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from tooling.principles_config import (
+    EMBEDDED_CORPUS_PATH,
+    PrinciplesConfigError,
+    PrinciplesCorpusConfig,
+    default_config_path,
+    load_principles_config,
+    parse_principles_config,
+    resolved_corpus_path,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ZeroConfigDefaultTests(unittest.TestCase):
+    """The zero-config path is first-class: every absent-configuration shape
+    selects the embedded default."""
+
+    def test_missing_config_file_selects_embedded_default(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = load_principles_config(Path(directory) / "principles.toml")
+
+        self.assertEqual(config, PrinciplesCorpusConfig.embedded())
+
+    def test_empty_document_selects_embedded_default(self) -> None:
+        config = parse_principles_config({})
+
+        self.assertEqual(config, PrinciplesCorpusConfig.embedded())
+
+    def test_empty_config_file_selects_embedded_default(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config_file = Path(directory) / "principles.toml"
+            config_file.write_text("", encoding="utf-8")
+
+            config = load_principles_config(config_file)
+
+        self.assertEqual(config, PrinciplesCorpusConfig.embedded())
+
+    def test_explicit_embedded_source_selects_embedded_default(self) -> None:
+        config = parse_principles_config({"corpus": {"source": "embedded"}})
+
+        self.assertEqual(config, PrinciplesCorpusConfig.embedded())
+
+
+class ConfiguredSourceTests(unittest.TestCase):
+    def test_local_path_source_parses_to_absolute_path(self) -> None:
+        config = parse_principles_config({"corpus": {"source": "path", "path": "/srv/corpus"}})
+
+        self.assertEqual(config.source, "path")
+        self.assertEqual(config.path, Path("/srv/corpus"))
+
+    def test_git_source_parses_url_and_optional_ref(self) -> None:
+        config = parse_principles_config(
+            {"corpus": {"source": "git", "url": "https://example.org/owner/corpus", "ref": "v1.0.0"}}
+        )
+
+        self.assertEqual(config.source, "git")
+        self.assertEqual(config.url, "https://example.org/owner/corpus")
+        self.assertEqual(config.ref, "v1.0.0")
+
+    def test_git_source_ref_defaults_to_none(self) -> None:
+        config = parse_principles_config(
+            {"corpus": {"source": "git", "url": "https://example.org/owner/corpus"}}
+        )
+
+        self.assertIsNone(config.ref)
+
+    def test_sample_external_corpus_config_file_validates(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config_file = Path(directory) / "principles.toml"
+            config_file.write_text(
+                '[corpus]\nsource = "git"\nurl = "https://example.org/owner/corpus"\n',
+                encoding="utf-8",
+            )
+
+            config = load_principles_config(config_file)
+
+        self.assertEqual(config.source, "git")
+
+
+class InvalidConfigTests(unittest.TestCase):
+    """A present configuration never silently degrades to the default."""
+
+    def test_unknown_source_is_rejected(self) -> None:
+        with self.assertRaises(PrinciplesConfigError):
+            parse_principles_config({"corpus": {"source": "carrier-pigeon"}})
+
+    def test_git_source_without_url_is_rejected(self) -> None:
+        with self.assertRaises(PrinciplesConfigError):
+            parse_principles_config({"corpus": {"source": "git"}})
+
+    def test_path_source_without_path_is_rejected(self) -> None:
+        with self.assertRaises(PrinciplesConfigError):
+            parse_principles_config({"corpus": {"source": "path"}})
+
+    def test_relative_corpus_path_is_rejected_with_named_error(self) -> None:
+        with self.assertRaises(PrinciplesConfigError) as caught:
+            parse_principles_config({"corpus": {"source": "path", "path": "relative/corpus"}})
+
+        self.assertIn("corpus/path", caught.exception.paths)
+
+    def test_unknown_top_level_key_is_rejected(self) -> None:
+        with self.assertRaises(PrinciplesConfigError):
+            parse_principles_config({"corpse": {"source": "embedded"}})
+
+    def test_extraneous_key_on_embedded_source_is_rejected(self) -> None:
+        with self.assertRaises(PrinciplesConfigError):
+            parse_principles_config(
+                {"corpus": {"source": "embedded", "url": "https://example.org/owner/corpus"}}
+            )
+
+    def test_invalid_toml_is_rejected_with_named_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config_file = Path(directory) / "principles.toml"
+            config_file.write_text("[corpus\n", encoding="utf-8")
+
+            with self.assertRaises(PrinciplesConfigError) as caught:
+                load_principles_config(config_file)
+
+        self.assertIn("<toml>", caught.exception.paths)
+
+
+class NamedConceptTests(unittest.TestCase):
+    """The configured source and the resolved local corpus are distinct,
+    named concepts."""
+
+    def test_default_config_path_honors_xdg_config_home(self) -> None:
+        path = default_config_path({"XDG_CONFIG_HOME": "/etc/xdg-test"})
+
+        self.assertEqual(path, Path("/etc/xdg-test/groundwork/principles.toml"))
+
+    def test_default_config_path_falls_back_to_home_dot_config(self) -> None:
+        path = default_config_path({"HOME": "/home/someone"})
+
+        self.assertEqual(path, Path("/home/someone/.config/groundwork/principles.toml"))
+
+    def test_default_config_path_without_home_raises_named_error(self) -> None:
+        with self.assertRaises(PrinciplesConfigError):
+            default_config_path({})
+
+    def test_resolved_corpus_path_is_stable_under_runtime_root(self) -> None:
+        self.assertEqual(
+            resolved_corpus_path("/home/someone/.groundwork"),
+            Path("/home/someone/.groundwork/principles"),
+        )
+
+    def test_embedded_corpus_path_is_in_tree(self) -> None:
+        self.assertEqual(EMBEDDED_CORPUS_PATH, ROOT / "principles")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/principles_config.py
+++ b/tooling/principles_config.py
@@ -1,0 +1,158 @@
+"""Principles-corpus configuration: the deployment-owned selection surface.
+
+Two distinct concepts live here, and the distinction is load-bearing:
+
+- The **configured source** — where the corpus comes from (`embedded`,
+  `path`, or `git`), declared in a deployment-owned config file outside the
+  methodology tree. Absent file, empty document, or absent ``[corpus]``
+  table all select the embedded default: zero-config is the first-class
+  ordinary path, not an error path.
+- The **resolved local corpus** — the stable local location the resolution
+  layer materializes the configured source into, and the only location
+  reckon reads during reasoning. Resolution never live-fetches a remote
+  mid-reckon.
+
+This module owns parsing and validation of the configured source. The
+materialization step that produces the resolved local corpus belongs to the
+resolution layer (setup time), not here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PRINCIPLES_CONFIG_SCHEMA = ROOT / "schemas" / "principles-config.schema.json"
+
+# The embedded default corpus shipped in the groundwork tree.
+EMBEDDED_CORPUS_PATH = ROOT / "principles"
+
+# Resolved-local-corpus directory name under the managed runtime root
+# (`~/.groundwork`). The resolution layer materializes the configured source
+# here; reckon's documented consultation target is this location.
+RESOLVED_CORPUS_DIRECTORY_NAME = "principles"
+
+CONFIG_FILE_RELATIVE_PATH = Path("groundwork") / "principles.toml"
+
+SOURCE_EMBEDDED = "embedded"
+SOURCE_PATH = "path"
+SOURCE_GIT = "git"
+
+
+class PrinciplesConfigError(ValueError):
+    def __init__(self, errors: list[tuple[str, str]]) -> None:
+        self.errors = errors
+        self.paths = [path for path, _message in errors]
+        super().__init__(self._format())
+
+    def _format(self) -> str:
+        return "; ".join(f"{path}: {message}" for path, message in self.errors)
+
+
+@dataclass(frozen=True)
+class PrinciplesCorpusConfig:
+    """The configured corpus source, after parsing and validation."""
+
+    source: str
+    path: Path | None = None
+    url: str | None = None
+    ref: str | None = None
+
+    @classmethod
+    def embedded(cls) -> "PrinciplesCorpusConfig":
+        return cls(source=SOURCE_EMBEDDED)
+
+
+def default_config_path(environment: Mapping[str, str] | None = None) -> Path:
+    """Deployment config location: ``$XDG_CONFIG_HOME/groundwork/principles.toml``,
+    falling back to ``~/.config/groundwork/principles.toml``."""
+    env = os.environ if environment is None else environment
+    xdg_config_home = env.get("XDG_CONFIG_HOME")
+    if xdg_config_home:
+        return Path(xdg_config_home) / CONFIG_FILE_RELATIVE_PATH
+    home = env.get("HOME")
+    if not home:
+        raise PrinciplesConfigError(
+            [("<environment>", "cannot locate the principles config: neither XDG_CONFIG_HOME nor HOME is set")]
+        )
+    return Path(home) / ".config" / CONFIG_FILE_RELATIVE_PATH
+
+
+def resolved_corpus_path(runtime_root: Path | str) -> Path:
+    """The stable resolved-local-corpus location under a runtime root."""
+    return Path(runtime_root) / RESOLVED_CORPUS_DIRECTORY_NAME
+
+
+def load_principles_config(
+    path: Path | str | None = None,
+    environment: Mapping[str, str] | None = None,
+) -> PrinciplesCorpusConfig:
+    """Load the configured corpus source.
+
+    A missing config file selects the embedded default. A present but
+    unreadable, unparsable, or schema-invalid file raises
+    :class:`PrinciplesConfigError` with named errors — a present
+    configuration never silently degrades to the default.
+    """
+    config_path = Path(path) if path is not None else default_config_path(environment)
+    if not config_path.exists():
+        return PrinciplesCorpusConfig.embedded()
+
+    try:
+        raw = config_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise PrinciplesConfigError([("<read>", f"cannot read principles config {config_path}: {error}")]) from error
+
+    try:
+        document = tomllib.loads(raw)
+    except tomllib.TOMLDecodeError as error:
+        raise PrinciplesConfigError(
+            [("<toml>", f"{config_path.name} is invalid TOML: {error}")]
+        ) from error
+
+    return parse_principles_config(document)
+
+
+def parse_principles_config(document: dict[str, Any]) -> PrinciplesCorpusConfig:
+    errors = _schema_errors(document)
+    if errors:
+        raise PrinciplesConfigError(errors)
+
+    corpus = document.get("corpus")
+    if corpus is None:
+        return PrinciplesCorpusConfig.embedded()
+
+    source = corpus["source"]
+    if source == SOURCE_EMBEDDED:
+        return PrinciplesCorpusConfig.embedded()
+    if source == SOURCE_PATH:
+        corpus_path = Path(corpus["path"])
+        if not corpus_path.is_absolute():
+            raise PrinciplesConfigError(
+                [("corpus/path", f"corpus path must be absolute: {corpus_path}")]
+            )
+        return PrinciplesCorpusConfig(source=SOURCE_PATH, path=corpus_path)
+    return PrinciplesCorpusConfig(source=SOURCE_GIT, url=corpus["url"], ref=corpus.get("ref"))
+
+
+def _schema_errors(document: dict[str, Any]) -> list[tuple[str, str]]:
+    schema = json.loads(PRINCIPLES_CONFIG_SCHEMA.read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema)
+    errors: list[tuple[str, str]] = []
+
+    for error in sorted(validator.iter_errors(document), key=lambda item: list(item.path)):
+        path = "/".join(str(part) for part in error.path)
+        if error.validator == "required":
+            missing = error.message.split("'")[1]
+            path = f"{path}/{missing}" if path else missing
+        errors.append((path or "<root>", error.message))
+
+    return errors


### PR DESCRIPTION
Closes #399. Part of epic #397.

## Purpose

Introduce the methodology-configuration surface through which the principles corpus is selected, so reckon consults a *configured* corpus rather than a hard-coded repository.

## Implementation summary

- **`schemas/principles-config.schema.json`** — Draft 2020-12 schema for the deployment-owned config file: a `[corpus]` table discriminated by `source` (`embedded` | `path` | `git`), `oneOf`-enforced per variant, `additionalProperties: false` throughout. Picked up automatically by the conformance runner's schema-definition pass.
- **`tooling/principles_config.py`** — loader/validator following the `MechanicError` conventions (named per-path errors): `default_config_path()` (`${XDG_CONFIG_HOME:-~/.config}/groundwork/principles.toml`), `load_principles_config()` (missing file → embedded default; present-but-invalid → loud `PrinciplesConfigError`, never silent degradation), `PrinciplesCorpusConfig` dataclass, plus the two named location concepts: `EMBEDDED_CORPUS_PATH` (in-tree `principles/`) and `resolved_corpus_path()` (stable `principles/` location under the managed runtime root) for the resolution layer (#400) and reckon pointer (#402) to build on.
- **`docs/principles-corpus.md`** — both audiences: ordinary path (zero config, offline) and power-user path (external corpus, with `pentaxis93/principles` as the worked example value).
- **`docs/architecture/decisions/0005-principles-corpus-configuration.md`** — the location/format decision and rationale: why a dedicated deployment-owned TOML file rather than `manifest.toml` (wrong owner — manifest ships with the methodology) or env atoms (runtime-owned session identity post-#389; no structural validation), and the missing-vs-invalid failure semantics.
- **CHANGELOG** — Unreleased → Added.

## Acceptance criteria mapping

| Criterion | Where satisfied |
|---|---|
| Documented surface consistent with conventions, rationale recorded | `docs/principles-corpus.md`; ADR-0005 |
| Configured source vs resolved local corpus as distinct named concepts | Module docstring + `PrinciplesCorpusConfig`/`resolved_corpus_path`; docs §Two concepts |
| No configuration present → embedded default | `load_principles_config`; 4 tests in `ZeroConfigDefaultTests` |
| `pentaxis93/principles` only as example value, never baked-in default | Code defaults to `embedded`; the canonical repo appears only in docs/schema-description example text |
| Docs explain ordinary and power-user paths | `docs/principles-corpus.md` |
| Sample external config validates; empty config validates → default | `test_sample_external_corpus_config_file_validates`, `test_empty_config_file_selects_embedded_default` |

## Verification

- `python -m unittest discover -s tests` → **265 tests, OK** (2 skipped; 20 new in `tests/test_principles_config.py`)
- `python -m tooling.conformance` → **36 passed, 0 failed** (new schema validated by the schema-definition pass)
- `./scripts/release-check metadata` → pass

## Self-review findings (fixed before submission)

- ADR status corrected from `Accepted` to `Provisional` per ADR-0002/0003 convention.
- Schema `$id` normalized to the `raw.githubusercontent.com/...` form used by all sibling schemas.
- One test leaked a temp dir (`mkdtemp` without cleanup) — switched to `TemporaryDirectory`.

## Risks / follow-ups

- `docs/principles-corpus.md` describes the resolution layer's materialization as the contract it implements; #400 (next in the arc) makes it operational. The doc is written so #400/#405 extend rather than rewrite it.
- No reckon edits here (#402) and no default-corpus content (#401) — scope held to the configuration surface.