### PR TITLE
task(docs): repoint stale principle-authority references off the commons mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Stale principle-authority references healed: ADR-0002 and ADR-0003 now
+  trace Sovereignty, Parsimony, and Scale-Honest Design to the canonical
+  corpus at [pentaxis93/principles](https://github.com/pentaxis93/principles)
+  instead of the superseded `tesserine/commons` PRINCIPLES.md mirror, commons
+  ADR-0001 stub, and legacy `with-claude` register. The original citation
+  routes are preserved as provenance notes; commons references that correctly
+  cite shared contracts, schemas, and live ecosystem ADRs stand unchanged
+  (closes #403).
 - **Review reframed as the independent-judgment gate, not a "human gate."**
   Agents execute review like every protocol, and the session-surface contract
   places transition authority in the typed disposition; the invariant the gate

--- a/docs/architecture/decisions/0002-methodology-sovereignty.md
+++ b/docs/architecture/decisions/0002-methodology-sovereignty.md
@@ -2,7 +2,10 @@
 
 **Status:** Provisional — revised 2026-05-28 (regrounded on a second forge; see Revision below) \
 **Date:** 2026-05-02 (revised 2026-05-28) \
-**Traces to:** `tesserine/commons` PRINCIPLES.md P1 (Sovereignty); `tesserine/commons` ADR-0001 (Sovereignty).
+**Traces to:** [Sovereignty](https://github.com/pentaxis93/principles/blob/main/principles/sovereignty.md)
+— [pentaxis93/principles](https://github.com/pentaxis93/principles), the
+canonical principles corpus. (Originally cited via `tesserine/commons`
+PRINCIPLES.md P1 and commons ADR-0001, since ascended to the canonical home.)
 
 ## Revision (2026-05-28): regrounded on two forges
 
@@ -111,16 +114,18 @@ methodology layer is unavailable — when a unit's behavior is entangled in
 mixed-shape prose, no parser-level check applies, and substring-presence on
 prose strings becomes the entire verification surface for protocol behavior.
 
-The principle this decision rests on is `tesserine/commons` PRINCIPLES.md P1
-(Sovereignty), which declares: *the operator declares WHAT — direction,
-vision, intent; the agent owns HOW — execution, implementation, craft. It
-applies at every interface, at every scale.* A methodology document is a
-human-authored artifact addressed to an agent; the document plays the
-operator role, the invoking agent plays the agent role, and a unit that
-mixes WHAT and HOW crosses the sovereignty boundary inside its own
-boundary. ADR-0001 (Sovereignty) enumerates illustrative interfaces; the
-methodology-document interface is covered by P1's general fractal claim and
-does not require enumeration extension.
+The principle this decision rests on is
+[Sovereignty](https://github.com/pentaxis93/principles/blob/main/principles/sovereignty.md),
+cited at decision time in its commons form (`PRINCIPLES.md` P1, since
+ascended to the canonical corpus), which declares: *the operator declares
+WHAT — direction, vision, intent; the agent owns HOW — execution,
+implementation, craft. It applies at every interface, at every scale.* A
+methodology document is a human-authored artifact addressed to an agent;
+the document plays the operator role, the invoking agent plays the agent
+role, and a unit that mixes WHAT and HOW crosses the sovereignty boundary
+inside its own boundary. The methodology-document interface is covered by
+Sovereignty's general fractal claim ("it applies at every scale of
+interface") and does not require enumeration extension.
 
 ## Decision
 

--- a/docs/architecture/decisions/0003-disposition-as-artifact-type.md
+++ b/docs/architecture/decisions/0003-disposition-as-artifact-type.md
@@ -3,9 +3,15 @@
 **Status:** Provisional \
 **Date:** 2026-05-31 \
 **Traces to:** ADR-0002 (Methodology Sovereignty); `tesserine/runa`
-`docs/interface-contract.md` (the three-primitive interface); `tesserine/commons`
-PRINCIPLES.md P1 (Sovereignty). Governed by `with-claude` principles #5
-(Parsimony) and #10 (Scale-Honest Design).
+`docs/interface-contract.md` (the three-primitive interface);
+[Sovereignty](https://github.com/pentaxis93/principles/blob/main/principles/sovereignty.md).
+Governed by
+[Parsimony](https://github.com/pentaxis93/principles/blob/main/principles/parsimony.md)
+and [Evolvability](https://github.com/pentaxis93/principles/blob/main/principles/evolvability.md)
+(corollary *scale honesty*) — all at
+[pentaxis93/principles](https://github.com/pentaxis93/principles), the
+canonical corpus. (Originally cited via `tesserine/commons` PRINCIPLES.md P1
+and `with-claude` principles #5/#10, since ascended.)
 
 ## Revision (2026-05-31): outcomes are a required-choice output, not `may_produce`
 


### PR DESCRIPTION
Closes #403. Part of epic #397. Executes the #398 survey's repoint plan (https://github.com/tesserine/groundwork/issues/398#issuecomment-4689262165).

## Purpose

Heal the five references that still routed principle authority through the legacy `tesserine/commons` mirrors and the legacy `with-claude` register, so every groundwork-owned reference names the living canonical corpus.

## Implementation summary

- **ADR-0002** trace line: commons PRINCIPLES.md P1 + commons ADR-0001 → [Sovereignty](https://github.com/pentaxis93/principles/blob/main/principles/sovereignty.md) at `pentaxis93/principles`, with the original route preserved as a provenance note.
- **ADR-0002** body (§Context): the living-authority pointer now names canonical Sovereignty; the P1 declaration is kept verbatim as the decision-time form; the "ADR-0001 enumerates illustrative interfaces" sentence now rests on Sovereignty's own fractal claim ("it applies at every scale of interface" — verified present in the canonical document).
- **ADR-0003** trace line: commons P1 → Sovereignty; `with-claude` #5 (Parsimony) → [Parsimony](https://github.com/pentaxis93/principles/blob/main/principles/parsimony.md); `with-claude` #10 (Scale-Honest Design) → [Evolvability](https://github.com/pentaxis93/principles/blob/main/principles/evolvability.md) (corollary *scale honesty*) — mappings per corpus [SOURCES.md Register 4](https://github.com/pentaxis93/principles/blob/main/SOURCES.md).
- **CHANGELOG** — Unreleased → Changed.

## Acceptance criteria mapping

| Criterion | Evidence |
|---|---|
| Every #398-stale reference repointed to its prescribed target | 5/5: ADR-0002 trace (P1, ADR-0001), ADR-0002 body, ADR-0003 trace (P1, with-claude #5/#10) |
| ADR-0002 trace lines name the living corpus | Diff, ADR-0002 header |
| Remaining commons references are contracts/schemas/ecosystem-ADR citations | Untouched: AGENTS.md:5, RELEASING.md, decompose PROTOCOL + test, request-schema vendoring trio, ADR-0003:116 — confirmed live in #398 |
| Link-integrity over touched files | All four repointed URLs return HTTP 200 (curl, run at submission) |
| Zero new references to commons principle mirrors | Provenance notes mention the historical route as prose only — no links to mirrors introduced |

## Verification

- `python -m unittest discover -s tests` → 265 tests, OK (2 skipped)
- `python -m tooling.conformance` → 36 passed, 0 failed
- `./scripts/release-check metadata` → pass
- `curl` on all four repointed URLs → 200
- Re-run of #398 sweep (`grep -rn "PRINCIPLES.md P1|with-claude` principles|commons` ADR-0001" docs/`) → only provenance-note mentions remain; zero authority-routing hits

## Self-review

- Scope held: no commons-side changes (#404), no reckon edits (#402), no ADR reasoning rewritten beyond the authority pointers.
- Verified the canonical Sovereignty document actually carries the fractal claim and the P1 content (as a sourced projection) before resting ADR-0002's argument on it — the repoint is truthful, not cosmetic.

## Follow-ups

- #404 (commons-side mirror retirement) is now unblocked once this lands; gated additionally on the ecosystem-wide inbound-reference survey.