### PR TITLE
feat(principles): minimal embedded default principles corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Minimal embedded default principles corpus** at `principles/PRINCIPLES.md`:
+  eight sequenced, near-universal principles with one gloss each, framed
+  explicitly as the standalone fallback/default — not the Tesserine ecosystem
+  authority and not a digest of any external corpus. Authored fresh from the
+  near-universal criterion; independence and smallness are test-gated
+  (`tests/test_embedded_corpus.py`: short, sequenced, fallback-framed, zero
+  external references). Resolution selects it whenever no corpus is
+  configured (closes #401).
 - **Principles-corpus configuration surface** (ADR-0005). The principles
   corpus reckon consults now resolves through deployment-owned methodology
   configuration at `${XDG_CONFIG_HOME:-~/.config}/groundwork/principles.toml`:

--- a/principles/PRINCIPLES.md
+++ b/principles/PRINCIPLES.md
@@ -1,0 +1,40 @@
+# Default Principles
+
+This is groundwork's embedded default principles corpus: the navigational
+principles reckon selects from during Orient when no external corpus is
+configured. It exists so a bare checkout reasons well with zero
+configuration and zero network.
+
+**Its role is fallback and default, not authority.** It is not the
+canonical principles corpus of the Tesserine ecosystem, and it is not a
+summary or selection of any other corpus. It was authored against a
+single criterion: principles of sound work that nearly every practitioner
+already accepts. Deployments that want a richer or more opinionated
+corpus configure one (see `docs/principles-corpus.md`); this default then
+steps aside entirely.
+
+The principles are sequenced: each presumes the ones before it.
+
+1. **Understand before acting.** Know what problem you are solving, and
+   for whom, before choosing any solution.
+
+2. **Prefer evidence to assumption.** A claim about the world earns trust
+   by being checked against the world, not by being plausible.
+
+3. **Keep it as simple as the need allows.** Add nothing the problem does
+   not demand; remove what no longer serves it.
+
+4. **Do one thing at a time.** Small, complete steps compose; large,
+   entangled ones conceal their own failures.
+
+5. **Fail loudly, early, and exactly once.** Surface an error where it
+   occurs, name it, and never let silence stand in for success.
+
+6. **Show, don't claim.** Done means demonstrated — by a test, a run, an
+   observable result — not asserted.
+
+7. **Write for the reader.** Communicate so the recipient can act
+   correctly without coming back to ask.
+
+8. **Let the outcome teach.** Compare what happened with what was
+   intended, and feed the difference into the next attempt.

--- a/tests/test_embedded_corpus.py
+++ b/tests/test_embedded_corpus.py
@@ -1,0 +1,47 @@
+import re
+import unittest
+
+from tooling.principles_config import EMBEDDED_CORPUS_PATH
+
+
+CORPUS_FILE = EMBEDDED_CORPUS_PATH / "PRINCIPLES.md"
+
+
+class EmbeddedDefaultCorpusTests(unittest.TestCase):
+    """Gates on the embedded default corpus: present, small, sequenced,
+    framed as fallback, and independent of any external corpus."""
+
+    def corpus(self) -> str:
+        return CORPUS_FILE.read_text(encoding="utf-8")
+
+    def test_corpus_exists_at_the_embedded_location(self) -> None:
+        self.assertTrue(CORPUS_FILE.is_file())
+
+    def test_corpus_is_short(self) -> None:
+        # Smallness is the spec, not a compromise. The cap is generous
+        # headroom over the authored size, not a target.
+        self.assertLessEqual(len(self.corpus().splitlines()), 80)
+
+    def test_principles_are_sequenced(self) -> None:
+        numbers = [int(match) for match in re.findall(r"^(\d+)\. ", self.corpus(), re.MULTILINE)]
+
+        self.assertGreaterEqual(len(numbers), 3)
+        self.assertEqual(numbers, list(range(1, len(numbers) + 1)))
+
+    def test_framing_states_the_fallback_role_not_ecosystem_authority(self) -> None:
+        corpus = " ".join(self.corpus().split())
+
+        self.assertIn("fallback", corpus)
+        self.assertIn("not the canonical", corpus)
+
+    def test_corpus_is_standalone_with_no_external_references(self) -> None:
+        # Independence gate: the default is its own corpus — not a digest,
+        # subset, or pointer to the canonical one — and works offline.
+        corpus = self.corpus()
+
+        self.assertNotIn("pentaxis93", corpus)
+        self.assertNotIn("://", corpus)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #401. Part of epic #397.

## Purpose

Ship the minimal embedded default principles corpus so groundwork remains fully standalone — a bare checkout reasons offline with zero configuration.

## Implementation summary

- **`principles/PRINCIPLES.md`** — one short markdown artifact (39 lines): eight sequenced near-universal principles, one gloss each, with framing text that states its role (standalone fallback/default; explicitly *not* the Tesserine ecosystem authority, *not* a summary or selection of any other corpus). The location is exactly the `EMBEDDED_CORPUS_PATH` that `tooling/principles_config.py` (#399) already names, so resolution selects it whenever configuration is absent.
- **`tests/test_embedded_corpus.py`** — durable gates: present at the embedded location; short (hard line cap with headroom); sequenced (1..N verified); fallback-framed; standalone (zero `://` URLs and zero external corpus names — the corpus cannot silently drift into a pointer to or digest of the canonical one).
- **CHANGELOG** — Unreleased → Added.

## The independence gate (review focus)

The non-goal in #401 is the load-bearing one: this must not be a digest of `pentaxis93/principles`. How that was held:

- **Authoring criterion:** "principles of sound work that nearly every practitioner already accepts" — the field's folk canon (understand the problem first; evidence over assumption; KISS; small steps; fail fast and loudly; show your work; write for the reader; retrospect). Authored fresh against that criterion.
- **Its own framing:** plain imperative names, its own sequencing logic (each principle presumes the previous), no movement structure, no projections/relations apparatus, no recognition/corrective machinery — none of the canonical corpus's vocabulary or architecture.
- **Inevitable rhyme, named honestly:** any two corpora of near-universal reasoning principles will overlap conceptually (that is what *near-universal* means). The defect the epic forbids is *condensation* — selecting from or summarizing the canonical corpus. The mechanical gate (`test_corpus_is_standalone_with_no_external_references`) plus the framing text hold the boundary the spec draws.

## Acceptance criteria mapping

| Criterion | Evidence |
|---|---|
| Single short markdown artifact, sequenced, minimal gloss | 39 lines, 8 numbered principles, one gloss each; gated by `test_corpus_is_short` + `test_principles_are_sequenced` |
| Framing states role: standalone default, not ecosystem authority | Framing paragraph; gated by `test_framing_states_the_fallback_role_not_ecosystem_authority` |
| Independence from `pentaxis93/principles` recorded as review gate | This section + `test_corpus_is_standalone_with_no_external_references` |
| Resolution selects it when configuration absent | Already true from #399: absent config → `source="embedded"` → `EMBEDDED_CORPUS_PATH`; `test_corpus_exists_at_the_embedded_location` closes the loop |
| Reckon completes Orient/Reconstruct against it with no external corpus | Functional check rides #400's offline-default test per the issue's own verification note; #402 points reckon here |

## Verification

- `python -m unittest discover -s tests` → 270 tests, OK (2 skipped; 5 new)
- `python -m tooling.conformance` → 36 passed, 0 failed
- `./scripts/release-check metadata` → pass

## Self-review findings (fixed before submission)

- The framing assertion was brittle to markdown line wrapping ("not the\ncanonical") — test now normalizes whitespace before asserting, so presentation changes don't break the gate.