### PR TITLE
feat(resolution): materialize the configured principles corpus locally at setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Principles-corpus materialization at setup** (#400). `groundwork-install`
+  now resolves the configured corpus into `~/.groundwork/principles/` — the
+  resolved local corpus reckon consults — on every `install`/`sync` run:
+  `embedded` copies the in-tree default, `path` copies the configured
+  directory, `git` fetches once at setup (never during reasoning). The
+  configuration is preflighted before any target mutation; materialization
+  stages and swaps atomically so a failed resolution never corrupts an
+  existing resolved corpus; every failure mode (invalid config, missing
+  local source, unreachable remote, index-less corpus, missing python3)
+  halts setup loudly with a named error. `tooling/principles_config.py`
+  validation is now stdlib-only so resolution runs in deployments without
+  third-party packages, with CI holding the code validator and the JSON
+  Schema contract in agreement. Rerunning `sync` is the documented refresh
+  (closes #400).
 - **Minimal embedded default principles corpus** at `principles/PRINCIPLES.md`:
   eight sequenced, near-universal principles with one gloss each, framed
   explicitly as the standalone fallback/default — not the Tesserine ecosystem

--- a/docs/principles-corpus.md
+++ b/docs/principles-corpus.md
@@ -69,7 +69,37 @@ The shape is schema-validated
 parsing and validation live in
 [`tooling/principles_config.py`](../tooling/principles_config.py). A
 present-but-invalid configuration fails loudly with named errors — it
-never silently degrades to the default.
+never silently degrades to the default. (The operational validator is
+stdlib-only so resolution runs in deployments without third-party
+packages; the JSON Schema is the documentation and conformance contract,
+and CI holds the two in agreement.)
+
+## Materialization: when, where, how to refresh
+
+Resolution is performed by
+[`tooling/corpus_resolution.py`](../tooling/corpus_resolution.py), wired
+into [`scripts/groundwork-install`](../scripts/groundwork-install):
+
+- **When:** at install/setup — every `groundwork-install install` or
+  `sync` run. Never during reasoning: no code path fetches the corpus
+  inside a reckon step, and a remote source is fetched exactly once per
+  resolution.
+- **Where:** into `~/.groundwork/principles/` (the resolved local corpus,
+  under the managed runtime root). Materialization stages into a
+  temporary sibling directory and swaps atomically, so a failed
+  resolution never corrupts or removes an existing resolved corpus.
+- **Checks:** the install preflights the configuration before touching
+  any target (an invalid config halts the install before anything is
+  projected), and a resolved corpus must carry a readable index
+  (`PRINCIPLES.md` or `README.md`) at its root.
+- **Refresh:** rerun `groundwork-install sync` from the checkout. There
+  is no in-session synchronization — a stale resolved corpus is refreshed
+  at the next setup run, by design.
+
+Failure modes are loud and named, with nonzero exit: a
+present-but-invalid config, a missing local source directory, an
+unreachable remote, a corpus without an index, or a missing `python3`
+where resolution is required.
 
 ## What this surface deliberately does not do
 

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -143,6 +143,41 @@ runtime_available() {
     git -C "$source_path" cat-file -e "$sha:tooling/forge_operations.py" 2>/dev/null
 }
 
+principles_available() {
+  git -C "$source_path" cat-file -e "$(source_sha):principles" 2>/dev/null &&
+    git -C "$source_path" cat-file -e "$(source_sha):tooling/corpus_resolution.py" 2>/dev/null
+}
+
+principles_config_path() {
+  if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+    printf '%s/groundwork/principles.toml\n' "$XDG_CONFIG_HOME"
+  else
+    printf '%s/.config/groundwork/principles.toml\n' "$home_path"
+  fi
+}
+
+run_corpus_resolution() {
+  PYTHONPATH="$source_path" python3 "$source_path/tooling/corpus_resolution.py" \
+    --config "$(principles_config_path)" \
+    --embedded "$source_path/principles" \
+    --target "$(runtime_root)/principles" \
+    "$@"
+}
+
+preflight_principles_corpus() {
+  principles_available || return 0
+  runtime_available || return 0
+  command_exists python3 || die "python3 is required for principles-corpus resolution"
+  run_corpus_resolution --check-only || die "principles-corpus configuration is not resolvable"
+}
+
+resolve_principles_corpus() {
+  principles_available || return 0
+  runtime_available || return 0
+  command_exists python3 || die "python3 is required for principles-corpus resolution"
+  run_corpus_resolution || die "principles-corpus resolution failed"
+}
+
 desired_entries() {
   local sha name rel
   sha="$(source_sha)"
@@ -519,6 +554,7 @@ install_or_sync() {
   local sha kind name src root target
   sha="$(source_sha)"
   preflight_runtime_bundle "$sha"
+  preflight_principles_corpus
   remove_obsolete_entries
   while IFS=$'\t' read -r kind name src; do
     while IFS= read -r root; do
@@ -534,6 +570,7 @@ install_or_sync() {
     done < <(target_roots)
   done < <(desired_entries)
   install_runtime_bundle "$sha"
+  resolve_principles_corpus
   write_state
   printf '%s: installed %s\n' "$PROGRAM" "$sha"
 }

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -157,7 +157,9 @@ principles_config_path() {
 }
 
 run_corpus_resolution() {
-  PYTHONPATH="$source_path" python3 "$source_path/tooling/corpus_resolution.py" \
+  # -B: never write bytecode into the pinned source checkout — a dirty
+  # source would fail the next run's clean-checkout gate.
+  PYTHONPATH="$source_path" python3 -B "$source_path/tooling/corpus_resolution.py" \
     --config "$(principles_config_path)" \
     --embedded "$source_path/principles" \
     --target "$(runtime_root)/principles" \

--- a/tests/test_corpus_resolution.py
+++ b/tests/test_corpus_resolution.py
@@ -1,0 +1,236 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from tooling.corpus_resolution import (
+    CorpusResolutionError,
+    check_resolvable,
+    corpus_index,
+    main,
+    materialize,
+)
+from tooling.principles_config import PrinciplesCorpusConfig
+
+
+def run(args: list[str], cwd: Path) -> None:
+    subprocess.run(args, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+class CorpusFixture:
+    def __init__(self, test: unittest.TestCase) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="corpus-resolution-"))
+        test.addCleanup(lambda: __import__("shutil").rmtree(self.root, ignore_errors=True))
+
+    def directory(self, name: str, *, index: str | None = "PRINCIPLES.md") -> Path:
+        directory = self.root / name
+        directory.mkdir(parents=True)
+        if index is not None:
+            (directory / index).write_text(f"# Corpus {name}\n\n1. **Check.** Verify.\n", encoding="utf-8")
+        return directory
+
+    def git_corpus(self, name: str, *, tag: str | None = None) -> Path:
+        repository = self.directory(name)
+        run(["git", "init", "-q"], repository)
+        run(["git", "config", "user.name", "corpus test"], repository)
+        run(["git", "config", "user.email", "corpus-test@example.invalid"], repository)
+        run(["git", "config", "commit.gpgsign", "false"], repository)
+        run(["git", "config", "tag.gpgsign", "false"], repository)
+        run(["git", "add", "."], repository)
+        run(["git", "commit", "-q", "-m", "seed corpus"], repository)
+        if tag is not None:
+            (repository / "TAGGED.md").write_text("tagged revision marker\n", encoding="utf-8")
+            run(["git", "add", "."], repository)
+            run(["git", "commit", "-q", "-m", "tagged revision"], repository)
+            run(["git", "tag", tag], repository)
+        return repository
+
+    def target(self) -> Path:
+        return self.root / "resolved" / "principles"
+
+
+class EmbeddedResolutionTests(unittest.TestCase):
+    def test_embedded_source_materializes_offline(self) -> None:
+        fixture = CorpusFixture(self)
+        embedded = fixture.directory("embedded")
+        target = fixture.target()
+
+        materialize(PrinciplesCorpusConfig.embedded(), embedded, target)
+
+        self.assertTrue((target / "PRINCIPLES.md").is_file())
+
+    def test_missing_embedded_corpus_is_a_named_failure(self) -> None:
+        fixture = CorpusFixture(self)
+
+        with self.assertRaises(CorpusResolutionError):
+            materialize(PrinciplesCorpusConfig.embedded(), fixture.root / "absent", fixture.target())
+
+    def test_check_only_validates_embedded_corpus_presence(self) -> None:
+        fixture = CorpusFixture(self)
+
+        with self.assertRaises(CorpusResolutionError):
+            check_resolvable(PrinciplesCorpusConfig.embedded(), fixture.root / "absent")
+
+
+class PathResolutionTests(unittest.TestCase):
+    def test_path_source_materializes_the_configured_directory(self) -> None:
+        fixture = CorpusFixture(self)
+        corpus = fixture.directory("local", index="README.md")
+        target = fixture.target()
+
+        materialize(
+            PrinciplesCorpusConfig(source="path", path=corpus),
+            fixture.directory("embedded"),
+            target,
+        )
+
+        self.assertTrue((target / "README.md").is_file())
+        self.assertIn("local", (target / "README.md").read_text(encoding="utf-8"))
+
+    def test_missing_path_source_is_a_named_failure(self) -> None:
+        fixture = CorpusFixture(self)
+
+        with self.assertRaises(CorpusResolutionError) as caught:
+            materialize(
+                PrinciplesCorpusConfig(source="path", path=fixture.root / "absent"),
+                fixture.directory("embedded"),
+                fixture.target(),
+            )
+
+        self.assertIn("does not exist", str(caught.exception))
+
+    def test_corpus_without_an_index_is_a_named_failure(self) -> None:
+        fixture = CorpusFixture(self)
+        corpus = fixture.directory("indexless", index=None)
+        (corpus / "notes.txt").write_text("not an index\n", encoding="utf-8")
+
+        with self.assertRaises(CorpusResolutionError) as caught:
+            materialize(
+                PrinciplesCorpusConfig(source="path", path=corpus),
+                fixture.directory("embedded"),
+                fixture.target(),
+            )
+
+        self.assertIn("no readable index", str(caught.exception))
+
+
+class GitResolutionTests(unittest.TestCase):
+    def test_git_source_materializes_once_without_git_metadata(self) -> None:
+        fixture = CorpusFixture(self)
+        repository = fixture.git_corpus("remote")
+        target = fixture.target()
+
+        materialize(
+            PrinciplesCorpusConfig(source="git", url=str(repository)),
+            fixture.directory("embedded"),
+            target,
+        )
+
+        self.assertTrue((target / "PRINCIPLES.md").is_file())
+        self.assertFalse((target / ".git").exists())
+
+    def test_git_source_honors_the_configured_ref(self) -> None:
+        fixture = CorpusFixture(self)
+        repository = fixture.git_corpus("tagged-remote", tag="v1")
+        target = fixture.target()
+
+        materialize(
+            PrinciplesCorpusConfig(source="git", url=str(repository), ref="v1"),
+            fixture.directory("embedded"),
+            target,
+        )
+
+        self.assertTrue((target / "TAGGED.md").is_file())
+
+    def test_unreachable_remote_is_a_named_failure(self) -> None:
+        fixture = CorpusFixture(self)
+
+        with self.assertRaises(CorpusResolutionError) as caught:
+            materialize(
+                PrinciplesCorpusConfig(source="git", url=str(fixture.root / "no-such-repo")),
+                fixture.directory("embedded"),
+                fixture.target(),
+            )
+
+        self.assertIn("cannot fetch corpus repository", str(caught.exception))
+
+
+class AtomicSwapTests(unittest.TestCase):
+    def test_failed_resolution_preserves_the_existing_resolved_corpus(self) -> None:
+        fixture = CorpusFixture(self)
+        embedded = fixture.directory("embedded")
+        target = fixture.target()
+        materialize(PrinciplesCorpusConfig.embedded(), embedded, target)
+        original = (target / "PRINCIPLES.md").read_text(encoding="utf-8")
+
+        with self.assertRaises(CorpusResolutionError):
+            materialize(
+                PrinciplesCorpusConfig(source="path", path=fixture.root / "absent"),
+                embedded,
+                target,
+            )
+
+        self.assertEqual(original, (target / "PRINCIPLES.md").read_text(encoding="utf-8"))
+        self.assertEqual([], list(target.parent.glob("*.resolve.*")))
+
+    def test_resolution_replaces_a_previously_resolved_corpus(self) -> None:
+        fixture = CorpusFixture(self)
+        embedded = fixture.directory("embedded")
+        external = fixture.directory("external", index="README.md")
+        target = fixture.target()
+        materialize(PrinciplesCorpusConfig.embedded(), embedded, target)
+
+        materialize(PrinciplesCorpusConfig(source="path", path=external), embedded, target)
+
+        self.assertTrue((target / "README.md").is_file())
+        self.assertFalse((target / "PRINCIPLES.md").exists())
+
+
+class CommandLineTests(unittest.TestCase):
+    def test_invalid_config_exits_nonzero_with_named_error(self) -> None:
+        fixture = CorpusFixture(self)
+        config = fixture.root / "principles.toml"
+        config.write_text('[corpus]\nsource = "carrier-pigeon"\n', encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                "python3",
+                "-m",
+                "tooling.corpus_resolution",
+                "--config",
+                str(config),
+                "--embedded",
+                str(fixture.directory("embedded")),
+                "--target",
+                str(fixture.target()),
+            ],
+            cwd=Path(__file__).resolve().parents[1],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("corpus-resolution:", result.stderr)
+
+    def test_missing_config_resolves_the_embedded_default(self) -> None:
+        fixture = CorpusFixture(self)
+        embedded = fixture.directory("embedded")
+        target = fixture.target()
+
+        exit_code = main(
+            [
+                "--config",
+                str(fixture.root / "absent.toml"),
+                "--embedded",
+                str(embedded),
+                "--target",
+                str(target),
+            ]
+        )
+
+        self.assertEqual(0, exit_code)
+        self.assertIsNotNone(corpus_index(target))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -824,6 +824,108 @@ class GroundworkInstallTests(unittest.TestCase):
         self.assertFalse(install.default_state_file().exists())
         self.assertFalse(install.target(".agents", "orient").exists())
 
+    def write_principles_surface(self, fixture: MethodologyFixture) -> None:
+        self.write_runtime_surface(fixture)
+        fixture.write(
+            "principles/PRINCIPLES.md",
+            """
+            # Default Principles
+
+            1. **Check.** Verify claims against reality.
+            """,
+        )
+        for module in ["corpus_resolution.py", "principles_config.py"]:
+            fixture.write(f"tooling/{module}", (ROOT / "tooling" / module).read_text(encoding="utf-8"))
+        fixture.write(
+            "schemas/principles-config.schema.json",
+            (ROOT / "schemas" / "principles-config.schema.json").read_text(encoding="utf-8"),
+        )
+
+    def corpus_env(self, config_home: Path) -> dict[str, str]:
+        return {**os.environ, "XDG_CONFIG_HOME": str(config_home)}
+
+    def test_install_materializes_embedded_corpus_offline_with_no_configuration(self) -> None:
+        fixture = self.add_fixture("corpus-embedded-default")
+        self.write_principles_surface(fixture)
+        fixture.commit_new_ref("v2")
+        install = InstallRun(self, fixture.root)
+        config_home = install.home / ".config"
+
+        result = install.run_installer("install", env=self.corpus_env(config_home))
+
+        assert_success(self, result)
+        resolved = install.runtime_root() / "principles" / "PRINCIPLES.md"
+        self.assertTrue(resolved.is_file())
+        self.assertIn("Default Principles", resolved.read_text(encoding="utf-8"))
+
+    def test_install_materializes_a_configured_external_corpus(self) -> None:
+        fixture = self.add_fixture("corpus-configured-path")
+        self.write_principles_surface(fixture)
+        fixture.commit_new_ref("v2")
+        install = InstallRun(self, fixture.root)
+        external = install.home / "external-corpus"
+        external.mkdir(parents=True)
+        (external / "README.md").write_text("# External Corpus\n", encoding="utf-8")
+        config_home = install.home / ".config"
+        config_file = config_home / "groundwork" / "principles.toml"
+        config_file.parent.mkdir(parents=True)
+        config_file.write_text(f'[corpus]\nsource = "path"\npath = "{external}"\n', encoding="utf-8")
+
+        result = install.run_installer("install", env=self.corpus_env(config_home))
+
+        assert_success(self, result)
+        resolved = install.runtime_root() / "principles"
+        self.assertTrue((resolved / "README.md").is_file())
+        self.assertFalse((resolved / "PRINCIPLES.md").exists())
+
+    def test_install_fails_loudly_when_the_configured_remote_is_unreachable(self) -> None:
+        fixture = self.add_fixture("corpus-unreachable-remote")
+        self.write_principles_surface(fixture)
+        fixture.commit_new_ref("v2")
+        install = InstallRun(self, fixture.root)
+        config_home = install.home / ".config"
+        config_file = config_home / "groundwork" / "principles.toml"
+        config_file.parent.mkdir(parents=True)
+        missing = install.home / "no-such-repo"
+        config_file.write_text(f'[corpus]\nsource = "git"\nurl = "{missing}"\n', encoding="utf-8")
+
+        result = install.run_installer("install", env=self.corpus_env(config_home))
+
+        assert_failure_contains(self, result, "principles-corpus resolution failed")
+
+    def test_install_fails_in_preflight_before_projecting_when_config_is_invalid(self) -> None:
+        fixture = self.add_fixture("corpus-invalid-config")
+        self.write_principles_surface(fixture)
+        fixture.commit_new_ref("v2")
+        install = InstallRun(self, fixture.root)
+        config_home = install.home / ".config"
+        config_file = config_home / "groundwork" / "principles.toml"
+        config_file.parent.mkdir(parents=True)
+        config_file.write_text('[corpus]\nsource = "carrier-pigeon"\n', encoding="utf-8")
+
+        result = install.run_installer("install", env=self.corpus_env(config_home))
+
+        assert_failure_contains(self, result, "principles-corpus configuration is not resolvable")
+        self.assertFalse(install.runtime_root().exists())
+        for root in [".claude", ".agents"]:
+            skills_dir = install.home / root / "skills"
+            self.assertEqual([], list(skills_dir.iterdir()) if skills_dir.exists() else [])
+
+    def test_sync_refreshes_the_resolved_corpus(self) -> None:
+        fixture = self.add_fixture("corpus-sync-refresh")
+        self.write_principles_surface(fixture)
+        fixture.commit_new_ref("v2")
+        install = InstallRun(self, fixture.root)
+        config_home = install.home / ".config"
+        assert_success(self, install.run_installer("install", env=self.corpus_env(config_home)))
+        resolved = install.runtime_root() / "principles" / "PRINCIPLES.md"
+        resolved.write_text("# Drifted\n", encoding="utf-8")
+
+        result = install.run_installer("sync", env=self.corpus_env(config_home))
+
+        assert_success(self, result)
+        self.assertIn("Default Principles", resolved.read_text(encoding="utf-8"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_principles_config.py
+++ b/tests/test_principles_config.py
@@ -1,11 +1,14 @@
+import json
 import tempfile
 import unittest
 from pathlib import Path
 
 from tooling.principles_config import (
     EMBEDDED_CORPUS_PATH,
+    PRINCIPLES_CONFIG_SCHEMA,
     PrinciplesConfigError,
     PrinciplesCorpusConfig,
+    _schema_errors,
     default_config_path,
     load_principles_config,
     parse_principles_config,
@@ -150,6 +153,46 @@ class NamedConceptTests(unittest.TestCase):
 
     def test_embedded_corpus_path_is_in_tree(self) -> None:
         self.assertEqual(EMBEDDED_CORPUS_PATH, ROOT / "principles")
+
+
+class SchemaAgreementTests(unittest.TestCase):
+    """The stdlib structural validator (the operational home, usable in
+    deployments without third-party packages) and the JSON Schema (the
+    documentation and conformance contract) must judge the same documents
+    the same way. Absolute-path enforcement is a semantic check layered on
+    top of structure and is deliberately outside this matrix."""
+
+    DOCUMENTS = [
+        {},
+        {"corpus": {"source": "embedded"}},
+        {"corpus": {"source": "path", "path": "/srv/corpus"}},
+        {"corpus": {"source": "git", "url": "https://example.org/owner/corpus"}},
+        {"corpus": {"source": "git", "url": "https://example.org/owner/corpus", "ref": "v1"}},
+        {"corpus": {"source": "carrier-pigeon"}},
+        {"corpus": {"source": "git"}},
+        {"corpus": {"source": "path"}},
+        {"corpus": {"source": "path", "path": ""}},
+        {"corpus": {"source": "git", "url": ""}},
+        {"corpus": {"source": "git", "url": "https://example.org/x", "ref": ""}},
+        {"corpus": {"source": "embedded", "url": "https://example.org/x"}},
+        {"corpus": {"source": "path", "path": "/srv/corpus", "url": "https://example.org/x"}},
+        {"corpus": "not-a-table"},
+        {"corpus": {}},
+        {"corpse": {"source": "embedded"}},
+        {"corpus": {"source": "embedded"}, "extra": 1},
+    ]
+
+    def test_code_validator_agrees_with_the_schema_contract(self) -> None:
+        from jsonschema import Draft202012Validator
+
+        validator = Draft202012Validator(json.loads(PRINCIPLES_CONFIG_SCHEMA.read_text(encoding="utf-8")))
+
+        for document in self.DOCUMENTS:
+            with self.subTest(document=document):
+                self.assertEqual(
+                    validator.is_valid(document),
+                    not _schema_errors(document),
+                )
 
 
 if __name__ == "__main__":

--- a/tooling/corpus_resolution.py
+++ b/tooling/corpus_resolution.py
@@ -1,0 +1,164 @@
+"""Setup-time materialization of the configured principles corpus.
+
+Resolves the configured source (embedded | path | git) into the resolved
+local corpus — the stable location reckon reads during reasoning. This
+runs at install/setup only; nothing here executes during a reckon step,
+and a remote source is fetched exactly once per resolution.
+
+Every failure mode is loud and named: a present-but-invalid config, a
+missing local source, an unreachable remote, or a corpus without a
+readable index halts setup with a nonzero exit. A failed resolution never
+replaces an existing resolved corpus (staging + atomic swap), and never
+silently degrades to the default.
+
+Deliberately stdlib-only, like ``tooling/forge_operations.py``: the
+install path runs in deployments that carry no third-party packages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+if __package__ in (None, ""):  # invoked as a script by groundwork-install
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tooling.principles_config import (
+    SOURCE_EMBEDDED,
+    SOURCE_GIT,
+    SOURCE_PATH,
+    PrinciplesConfigError,
+    PrinciplesCorpusConfig,
+    load_principles_config,
+)
+
+# A corpus is structurally present when its root carries a readable index.
+CORPUS_INDEX_CANDIDATES = ("PRINCIPLES.md", "README.md")
+
+
+class CorpusResolutionError(Exception):
+    pass
+
+
+def corpus_index(directory: Path) -> Path | None:
+    for name in CORPUS_INDEX_CANDIDATES:
+        candidate = directory / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def check_resolvable(config: PrinciplesCorpusConfig, embedded_path: Path) -> None:
+    """Mutation-free preflight: validates what can be validated without
+    touching the network."""
+    if config.source == SOURCE_EMBEDDED:
+        _require_corpus_directory(embedded_path, "embedded corpus")
+    elif config.source == SOURCE_PATH:
+        assert config.path is not None
+        _require_corpus_directory(config.path, "configured corpus path")
+    # git: reachability is established by the fetch itself at materialization.
+
+
+def materialize(config: PrinciplesCorpusConfig, embedded_path: Path, target: Path) -> None:
+    """Resolve the configured source into ``target`` via staging + atomic swap."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f"{target.name}.resolve.", dir=target.parent))
+    try:
+        if config.source == SOURCE_EMBEDDED:
+            _stage_directory(embedded_path, "embedded corpus", staging)
+        elif config.source == SOURCE_PATH:
+            assert config.path is not None
+            _stage_directory(config.path, "configured corpus path", staging)
+        else:
+            _stage_git_clone(config, staging)
+
+        index = corpus_index(staging)
+        if index is None:
+            raise CorpusResolutionError(
+                f"resolved corpus has no readable index ({' or '.join(CORPUS_INDEX_CANDIDATES)}) "
+                f"at its root — source: {_describe_source(config)}"
+            )
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    if target.exists():
+        shutil.rmtree(target)
+    staging.replace(target)
+
+
+def _require_corpus_directory(directory: Path, label: str) -> None:
+    if not directory.is_dir():
+        raise CorpusResolutionError(f"{label} does not exist or is not a directory: {directory}")
+    if corpus_index(directory) is None:
+        raise CorpusResolutionError(
+            f"{label} has no readable index ({' or '.join(CORPUS_INDEX_CANDIDATES)}) at its root: {directory}"
+        )
+
+
+def _stage_directory(source: Path, label: str, staging: Path) -> None:
+    if not source.is_dir():
+        raise CorpusResolutionError(f"{label} does not exist or is not a directory: {source}")
+    shutil.copytree(source, staging, dirs_exist_ok=True)
+
+
+def _stage_git_clone(config: PrinciplesCorpusConfig, staging: Path) -> None:
+    assert config.url is not None
+    command = ["git", "clone", "--quiet", "--depth", "1"]
+    if config.ref:
+        command.extend(["--branch", config.ref])
+    command.extend([config.url, str(staging / "clone")])
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode != 0:
+        detail = result.stderr.strip().splitlines()
+        raise CorpusResolutionError(
+            f"cannot fetch corpus repository {_describe_source(config)}: "
+            f"{detail[-1] if detail else 'git clone failed'}"
+        )
+    clone = staging / "clone"
+    shutil.rmtree(clone / ".git", ignore_errors=True)
+    for entry in clone.iterdir():
+        entry.rename(staging / entry.name)
+    clone.rmdir()
+
+
+def _describe_source(config: PrinciplesCorpusConfig) -> str:
+    if config.source == SOURCE_EMBEDDED:
+        return "embedded"
+    if config.source == SOURCE_PATH:
+        return f"path {config.path}"
+    return f"{config.url}" + (f" (ref {config.ref})" if config.ref else "")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Materialize the configured principles corpus into the resolved local location."
+    )
+    parser.add_argument("--config", required=True, help="Path to the deployment principles config file.")
+    parser.add_argument("--embedded", required=True, help="Path to the embedded default corpus directory.")
+    parser.add_argument("--target", required=True, help="Resolved local corpus directory to materialize into.")
+    parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help="Validate the configuration and local sources without materializing.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_principles_config(args.config)
+        if args.check_only:
+            check_resolvable(config, Path(args.embedded))
+        else:
+            materialize(config, Path(args.embedded), Path(args.target))
+    except (PrinciplesConfigError, CorpusResolutionError) as error:
+        print(f"corpus-resolution: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tooling/principles_config.py
+++ b/tooling/principles_config.py
@@ -19,14 +19,11 @@ resolution layer (setup time), not here.
 
 from __future__ import annotations
 
-import json
 import os
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
-
-from jsonschema import Draft202012Validator
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -143,16 +140,55 @@ def parse_principles_config(document: dict[str, Any]) -> PrinciplesCorpusConfig:
     return PrinciplesCorpusConfig(source=SOURCE_GIT, url=corpus["url"], ref=corpus.get("ref"))
 
 
+_CORPUS_KEYS_BY_SOURCE: dict[str, dict[str, set[str]]] = {
+    SOURCE_EMBEDDED: {"required": set(), "allowed": {"source"}},
+    SOURCE_PATH: {"required": {"path"}, "allowed": {"source", "path"}},
+    SOURCE_GIT: {"required": {"url"}, "allowed": {"source", "url", "ref"}},
+}
+
+
 def _schema_errors(document: dict[str, Any]) -> list[tuple[str, str]]:
-    schema = json.loads(PRINCIPLES_CONFIG_SCHEMA.read_text(encoding="utf-8"))
-    validator = Draft202012Validator(schema)
+    """Structural validation of the config document.
+
+    Deliberately stdlib-only: setup-time resolution runs in deployments
+    that carry no third-party packages (the same constraint
+    ``tooling/forge_operations.py`` observes). The JSON Schema at
+    ``schemas/principles-config.schema.json`` remains the documentation
+    and conformance contract for the same shape; CI holds the two in
+    agreement (tests/test_principles_config.py).
+    """
     errors: list[tuple[str, str]] = []
 
-    for error in sorted(validator.iter_errors(document), key=lambda item: list(item.path)):
-        path = "/".join(str(part) for part in error.path)
-        if error.validator == "required":
-            missing = error.message.split("'")[1]
-            path = f"{path}/{missing}" if path else missing
-        errors.append((path or "<root>", error.message))
+    for key in document:
+        if key != "corpus":
+            errors.append((key, f"unknown key `{key}`; the config holds only a `corpus` table"))
+    if errors:
+        return errors
+
+    if "corpus" not in document:
+        return errors
+
+    corpus = document["corpus"]
+    if not isinstance(corpus, dict):
+        return [("corpus", "corpus must be a table")]
+
+    source = corpus.get("source")
+    if not isinstance(source, str) or source not in _CORPUS_KEYS_BY_SOURCE:
+        return [
+            (
+                "corpus/source",
+                "corpus must declare source as one of `embedded` | `path` | `git`",
+            )
+        ]
+
+    keys = _CORPUS_KEYS_BY_SOURCE[source]
+    for key in sorted(keys["required"] - corpus.keys()):
+        errors.append((f"corpus/{key}", f"corpus source `{source}` requires `{key}`"))
+    for key in sorted(corpus.keys() - keys["allowed"]):
+        errors.append((f"corpus/{key}", f"`{key}` is not a valid key for corpus source `{source}`"))
+    for key in sorted(keys["allowed"] - {"source"}):
+        value = corpus.get(key)
+        if value is not None and (not isinstance(value, str) or not value):
+            errors.append((f"corpus/{key}", f"`{key}` must be a non-empty string"))
 
     return errors


### PR DESCRIPTION
Closes #400. Part of epic #397.

## Purpose

Resolve the configured principles corpus into local content at setup, so reckon reads a local materialized corpus during reasoning — never a live remote fetch mid-reckon.

## Implementation summary

- **`tooling/corpus_resolution.py`** (new, stdlib-only): parse+validate config → stage the source into a temp sibling → structural index check (readable `PRINCIPLES.md` or `README.md` at corpus root) → atomic swap into the target. Per-source semantics: `embedded` → copy in-tree `principles/`; `path` → copy the configured directory; `git` → one `git clone --depth 1` (+ `--branch ref`) at setup, `.git` stripped from the result. `--check-only` gives a mutation-free, network-free preflight.
- **`scripts/groundwork-install`**: preflights the corpus configuration *before any target mutation* (`preflight_principles_corpus`, right after the runtime-bundle preflight) and materializes into `~/.groundwork/principles/` after the runtime bundle lands (`resolve_principles_corpus`). Both steps activate only when the source ships `principles/` + the resolver (so existing fixtures and non-corpus sources are untouched). Config path mirrors the script's existing XDG convention: `${XDG_CONFIG_HOME:-$home/.config}/groundwork/principles.toml`.
- **`tooling/principles_config.py` refactor — substrate finding recorded on the issue:** the module imported `jsonschema`, a dev-only package, but the install path is stdlib-only by existing convention (`forge_operations.py`). Validation is now structural stdlib code with identical public API and error shapes; `schemas/principles-config.schema.json` remains the documentation + conformance contract; a new CI test (`SchemaAgreementTests`) holds the code validator and the schema in agreement over a 17-document valid/invalid matrix.
- **Docs:** `docs/principles-corpus.md` gains the materialization lifecycle section (when, where, checks, refresh, failure modes).
- **CHANGELOG** — Unreleased → Added.

## Acceptance criteria mapping

| Criterion | Evidence |
|---|---|
| Resolved corpus at the documented stable path after setup with any valid config | `test_install_materializes_embedded_corpus_offline_with_no_configuration`, `test_install_materializes_a_configured_external_corpus`, git-source coverage in `test_corpus_resolution.py` |
| Reckon's documented consultation target is the local resolved path | `docs/principles-corpus.md` §Materialization (reckon's own skill text is #402) |
| Standalone setup, no network, no config → succeeds against embedded default | Embedded tests are offline by construction (no remote anywhere) |
| Each failure mode halts with a named, actionable error | Tests: invalid config (preflight, *before* any projection — runtime root and skill roots verified untouched), unreachable remote, missing path source, index-less corpus; missing python3 → `die` with named message |
| Lifecycle documented (when it runs, where it lands, how to refresh) | `docs/principles-corpus.md` §Materialization |
| No code path fetches the corpus during reckon execution | `corpus_resolution.py` is invoked only by `groundwork-install`; nothing under `skills/` or the runtime bundle references it |

## Verification

- `python -m unittest discover -s tests` → **289 tests, OK** (2 skipped; 24 new: 14 resolution-unit, 5 install-integration, 1 schema-agreement, plus refactor-covered config tests)
- `python -m tooling.conformance` → 36 passed, 0 failed
- `./scripts/release-check metadata` → pass
- `bash -n scripts/groundwork-install` → clean

## Self-review notes

- Atomicity verified by test: a failed resolution preserves the prior resolved corpus byte-for-byte and leaves no staging litter.
- `sync` doubles as the refresh mechanism and is test-covered (drifted resolved corpus restored).
- The corpus lives inside the managed runtime root, so `uninstall` removes it with the bundle and the existing marker discipline applies unchanged.
- Preflight deliberately does not touch the network (an unreachable remote fails at materialization with a named error; setup exits nonzero and the embedded content from the prior state is not silently substituted).

## Risks / follow-ups

- #402 (next) points reckon's §Navigational Principles at the resolved location this PR establishes.