### PR TITLE
refactor(reckon): point Orient at the configured corpus — no inline URL, no pre-selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,11 +65,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   §Navigational Principles is a clean pointer to the resolved local corpus
   (installed: `~/.groundwork/principles/`; bare checkout: in-tree
   `principles/`): the inline `pentaxis93/principles` URLs, the privileged
-  "three universals" pre-selection (Position→Grounding,
-  Momentum→Traceability, Shape→Parsimony), and the Register-5 SOURCES.md
-  note are deleted — not relocated. Orient alone selects the governing
-  principles, per domain, from the corpus index; the corpus speaks for
-  itself (closes #402).
+  three-principle pre-selection, and the corpus-register mapping note are
+  deleted — not relocated. Orient alone selects the governing principles,
+  per domain, from the corpus index; the corpus speaks for itself
+  (closes #402).
 - Stale principle-authority references healed: ADR-0002 and ADR-0003 now
   trace Sovereignty, Parsimony, and Scale-Honest Design to the canonical
   corpus at [pentaxis93/principles](https://github.com/pentaxis93/principles)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Reckon's Orient now points at the configured corpus** (reckon 5.2.0).
+  §Navigational Principles is a clean pointer to the resolved local corpus
+  (installed: `~/.groundwork/principles/`; bare checkout: in-tree
+  `principles/`): the inline `pentaxis93/principles` URLs, the privileged
+  "three universals" pre-selection (Position→Grounding,
+  Momentum→Traceability, Shape→Parsimony), and the Register-5 SOURCES.md
+  note are deleted — not relocated. Orient alone selects the governing
+  principles, per domain, from the corpus index; the corpus speaks for
+  itself (closes #402).
 - Stale principle-authority references healed: ADR-0002 and ADR-0003 now
   trace Sovereignty, Parsimony, and Scale-Honest Design to the canonical
   corpus at [pentaxis93/principles](https://github.com/pentaxis93/principles)

--- a/skills/reckon/SKILL.md
+++ b/skills/reckon/SKILL.md
@@ -11,8 +11,8 @@ description: >-
   earning its chain (momentum). Dead reckoning: advance from an established
   fix using trusted constants.
 metadata:
-  version: "5.1.0"
-  updated: "2026-06-11"
+  version: "5.2.0"
+  updated: "2026-06-12"
 ---
 
 # Reckon
@@ -96,26 +96,20 @@ to optimize — they are constants that govern how verified constraints
 compose into solutions. Select the relevant ones during Orient; they fire
 during Reconstruct.
 
-The principles are defined in the canonical corpus at
-[pentaxis93/principles](https://github.com/pentaxis93/principles), not here
-— they are consulted, never duplicated, which is itself one of them
-([Single Home](https://github.com/pentaxis93/principles/blob/main/principles/single-home.md)).
-Consult the [corpus index](https://github.com/pentaxis93/principles#readme)
-during Orient and select what governs reasoning in this domain. What stays
-in this skill is the cognition methodology — the move, the chain
-discipline, the recognition-and-corrective machinery — not the principle
-definitions.
+The principles are defined in the resolved principles corpus, not here —
+they are consulted, never duplicated. Which corpus that is resolves
+through methodology configuration, and it is materialized locally at
+setup: in an installed deployment the resolved corpus lives at
+`~/.groundwork/principles/`; in a bare groundwork checkout it is the
+embedded default at `principles/`. (Selection and lifecycle:
+`docs/principles-corpus.md` in the groundwork repository.)
 
-Reckon's two faces resolve to three universals that govern most reasoning
-here:
-
-- **Position** grounds in [Grounding](https://github.com/pentaxis93/principles/blob/main/principles/grounding.md): reason from what is needed, not from what exists — an adjacent problem's solution is evidence, not a template.
-- **Momentum** answers to [Traceability](https://github.com/pentaxis93/principles/blob/main/principles/traceability.md): every inference earns its chain back to ground or principle.
-- **Shape** answers to [Parsimony](https://github.com/pentaxis93/principles/blob/main/principles/parsimony.md): everything earns its place — among rival designs meeting the same constraints, fewer moving parts win until a constraint demands more.
-
-The in-file register these three replace is classified item by item in the
-corpus [SOURCES.md](https://github.com/pentaxis93/principles/blob/main/SOURCES.md),
-Register 5.
+During Orient, read the corpus index (`PRINCIPLES.md` or `README.md` at
+the corpus root) and select what governs reasoning in this domain. The
+corpus speaks for itself: no principle is privileged in advance of
+Orient, and selection is per-domain, per-inquiry. What stays in this
+skill is the cognition methodology — the move, the chain discipline, the
+recognition-and-corrective machinery — not the principle definitions.
 
 ## Recognition Index
 
@@ -191,6 +185,6 @@ right, but a chain that cannot be shown cannot be trusted).
 *The default is to float — in inherited frames, borrowed categories,
 accepted costs, unquestioned structures, precedent as constraint,
 descriptions of what is, and analogical reasoning from correct ground.
-Orient returns you to what is needed. Grounding returns you to what is
-true. Principles give you direction. The chain keeps you honest. Reckon
-from there.*
+Orient returns you to what is needed. Verify returns you to what is
+true. The selected principles give you direction. The chain keeps you
+honest. Reckon from there.*


### PR DESCRIPTION
Closes #402. Part of epic #397. Final issue of the config arc (#399 → #400/#401 → this).

## Purpose

Reduce reckon's §Navigational Principles to a clean pointer at the configured/local corpus, restoring Orient as the sole selector of relevant principles. The corpus speaks for itself.

## Implementation summary

`skills/reckon/SKILL.md`:

- **§Navigational Principles** now carries exactly what the issue prescribes and nothing else: what navigational principles are (constants reasoned FROM), where the resolved corpus lives (installed deployments: `~/.groundwork/principles/`, materialized by #400; bare checkout: the embedded default at `principles/` from #401), and the Orient instruction (read the corpus index — `PRINCIPLES.md` or `README.md` at the corpus root — and select what governs the domain; no principle is privileged in advance of Orient).
- **Deleted, not relocated:** the inline `pentaxis93/principles` URLs; the three-universals pre-selection (Position→Grounding, Momentum→Traceability, Shape→Parsimony); the Register-5 SOURCES.md mapping note.
- **One remnant beyond the survey's line list** (claimed on the issue): the closing italic block named a corpus principle ("Grounding returns you to what is true"). Reworded to the Move's own vocabulary ("Orient… Verify…") so skill text names no principle anywhere.
- Version 5.1.0 → 5.2.0 (mirrors #393's minor bump for the same-kind change), `updated: 2026-06-12`.
- The Move (Steps 0–5), chain discipline, recognition index, and corruption modes are untouched.
- `skills/reckon/references/` consistency sweep: confirmed no-op — they reference "navigational principles" generically and carry no corpus URLs.
- The doc pointer to `docs/principles-corpus.md` is deliberately plain text, not a relative markdown link: skills are projected standalone into `~/.claude/skills/`, where a relative link would dangle.

## Acceptance criteria mapping

| Criterion | Evidence |
|---|---|
| Corpus referenced exclusively through the configured/local abstraction; `grep -rn "pentaxis93/principles" skills/reckon/` → zero operational URLs | Zero hits, period |
| No named privileged subset; selection performed in Orient against the resolved corpus, and the text says so | New section text; name-search (`Grounding\|Traceability\|Parsimony\|Single Home`) across `skills/` + `protocols/` → zero hits |
| Pre-selection deleted, not relocated | Repo-wide `grep -rni "three universals"` → zero; no new composition/section reproduces it (diff is pure deletion + pointer) |
| Tests/examples/docs referencing old wording updated and green | No test pinned the old wording (verified before editing); suite green |
| Version metadata bumped per convention | 5.2.0, dated |

## Verification

- `grep -rn "pentaxis93/principles" skills/reckon/` → no hits
- `grep -rni "three universals" .` → no hits
- Principle-name triplet search across `skills/` and `protocols/` → no hits
- `python -m unittest discover -s tests` → 289 tests, OK (2 skipped)
- `python -m tooling.conformance` → 36 passed, 0 failed
- `./scripts/release-check metadata` → pass

## Self-review

- Scope held: only §Navigational Principles, the closing italic line, and version metadata changed; the cognition methodology is byte-identical.
- The epic's Definition-of-done greps for this child now pass from a fresh tree; #405 will wire them in as durable CI gates.