### PR TITLE
docs(principles): corpus lifecycle documentation and durable verification gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Corpus lifecycle documentation and durable coherence gates** closing the
+  configurable-principles-corpus epic (#397). README gains "The Principles
+  Corpus" section and contents-table rows; `docs/principles-corpus.md` gains
+  what reckon reads during Orient and why nothing pre-digests the corpus,
+  the post-repair authority scoping (canonical corpus vs commons as
+  contracts/schemas/ecosystem decisions), and a "Verifying the coherence
+  upgrade" command section. New `tests/test_principles_coherence.py` holds
+  the epic's invariants permanently in CI: reckon carries no hard-coded
+  corpus repository, no methodology text names a privileged principle
+  subset, the pre-selection phrase is absent from every tracked file, and
+  no tracked file links to the legacy commons principle mirrors or stub
+  ADRs (closes #405).
 - **Principles-corpus materialization at setup** (#400). `groundwork-install`
   now resolves the configured corpus into `~/.groundwork/principles/` — the
   resolved local corpus reckon consults — on every `install`/`sync` run:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ not completeness.
 For how runa orchestrates this topology at runtime, see the
 [interface contract](https://github.com/tesserine/runa/blob/main/docs/interface-contract.md).
 
+## The Principles Corpus
+
+Reckon reasons from navigational principles selected during Orient. The
+corpus they are selected from is not hard-coded: it resolves through
+methodology configuration and is materialized locally at setup, so reckon
+reads local content during reasoning. With zero configuration the corpus
+is the minimal embedded default at [`principles/`](principles/) — a bare
+checkout reasons offline, out of the box. Deployments that want a richer
+corpus configure one (any git repository or local directory).
+→ [`docs/principles-corpus.md`](docs/principles-corpus.md)
+
 ## Interactive Installation
 
 Runa-served agents consume Groundwork through the methodology mount. Interactive
@@ -288,6 +299,7 @@ becomes a work-unit.
 | [`protocols/`](protocols/) | Protocol definitions for methodology stages |
 | [`skills/`](skills/) | Skills for orientation, cross-cutting disciplines, and stage-specific judgment |
 | [`schemas/`](schemas/) | JSON Schema contracts for artifacts and authoring substrates |
+| [`principles/`](principles/) | Embedded default principles corpus (standalone fallback; see [`docs/principles-corpus.md`](docs/principles-corpus.md)) |
 | [`tooling/`](tooling/) | Authoring-time parsers and validators |
 | [`docs/architecture/`](docs/architecture/) | Topology design rationale and work-unit state model |
 | [`docs/authoring/`](docs/authoring/) | Follow-direct guides for methodology authors |

--- a/docs/principles-corpus.md
+++ b/docs/principles-corpus.md
@@ -101,6 +101,21 @@ present-but-invalid config, a missing local source directory, an
 unreachable remote, a corpus without an index, or a missing `python3`
 where resolution is required.
 
+## What reckon reads during Orient
+
+Reckon's Orient step reads the **resolved local corpus** — never a remote
+— starting from its index (`PRINCIPLES.md` or `README.md` at the corpus
+root) and selects the principles that govern reasoning in the domain at
+hand. Selection happens live, per inquiry.
+
+That is why no layer of this design pre-digests the corpus: reckon's
+skill text names no privileged subset, the embedded default is not a
+summary of any richer corpus, and no "most important principles" list
+exists anywhere in the methodology. A pre-selection made before Orient
+would pre-empt the very judgment Orient exists to perform, and would
+silently bias every reconstruction toward whoever made the selection.
+The corpus speaks for itself.
+
 ## What this surface deliberately does not do
 
 - It names no privileged external corpus in code. `pentaxis93/principles`
@@ -114,3 +129,45 @@ where resolution is required.
 
 Design rationale for the surface choice is recorded in
 [ADR-0005](architecture/decisions/0005-principles-corpus-configuration.md).
+
+## Where authority lives after the source repair
+
+- **`pentaxis93/principles`** is the canonical principles corpus for the
+  Tesserine ecosystem's own deployments — configured, never hard-coded.
+- **`tesserine/commons`** is scoped as shared contracts, schemas, and
+  ecosystem-specific decisions (exit codes, the request contract, release
+  machinery, live ecosystem ADRs). It is no longer a principles home; its
+  legacy principle mirrors and pointer-stub ADRs are being retired under
+  [tesserine/commons#55](https://github.com/tesserine/commons/issues/55),
+  gated on every inbound reference being repointed first.
+- **Groundwork's ADRs** trace principle authority to the canonical corpus
+  (or this configured abstraction), with historical citation routes
+  preserved as provenance notes.
+
+## Verifying the coherence upgrade
+
+From a fresh clone, the upgrade's invariants verify mechanically:
+
+```bash
+python -m pip install -r requirements-dev.txt
+python -m unittest discover -s tests      # includes the durable gates
+python -m tooling.conformance
+```
+
+The durable gates live in `tests/test_principles_coherence.py` (reckon
+carries no hard-coded corpus repository; no methodology text names a
+privileged principle subset; no tracked file links to the legacy commons
+principle mirrors) and run in CI on every PR. Functional resolution gates
+live in `tests/test_corpus_resolution.py` and
+`tests/test_groundwork_install.py` (offline zero-config default,
+external-corpus materialization, loud named failures); embedded-default
+gates in `tests/test_embedded_corpus.py` (short, sequenced,
+fallback-framed, standalone).
+
+Equivalent manual inspections:
+
+```bash
+grep -rn "pentaxis93/principles" skills/reckon/          # expect: no hits
+grep -rniE "three\s+universals" .                        # expect: no hits
+grep -rnE "tesserine/commons/(blob|raw|tree)/\S*(PRINCIPLES|DESIGN-PRINCIPLES|adr/00(0[1-4]|07|13))" .   # expect: no hits
+```

--- a/tests/test_principles_coherence.py
+++ b/tests/test_principles_coherence.py
@@ -1,0 +1,92 @@
+"""Durable gates for the configurable-principles-corpus coherence upgrade.
+
+These hold the invariants of epic #397 permanently:
+
+- Reckon depends on a principles corpus, but never on a hard-coded one:
+  its skill text references the corpus only through the configured/local
+  abstraction.
+- Reckon does not pre-digest the corpus: no skill or protocol text names
+  a privileged subset of principles. Orient selects, per domain, from the
+  resolved corpus.
+- Principle authority never routes through the legacy commons mirrors:
+  no tracked file links to them. (Prose provenance notes that record the
+  historical citation route are legitimate; the gates target links.)
+
+Functional gates for the same epic live elsewhere: offline zero-config
+resolution and external-corpus materialization in
+tests/test_corpus_resolution.py and tests/test_groundwork_install.py;
+embedded-default smallness/independence in tests/test_embedded_corpus.py.
+"""
+
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# The phrase that named reckon's removed pre-selection, and the principle
+# names it privileged. Principle selection belongs to Orient alone.
+PRE_SELECTION_PHRASE = re.compile(r"three\s+universals", re.IGNORECASE)
+PRIVILEGED_PRINCIPLE_NAMES = re.compile(r"\bGrounding\b|\bTraceability\b|\bParsimony\b|\bSingle Home\b")
+
+# Link patterns into the legacy commons principle mirrors and superseded
+# pointer-stub ADRs (PRINCIPLES.md, DESIGN-PRINCIPLES.md, ADRs 0001-0004,
+# 0007, 0013).
+COMMONS_MIRROR_LINKS = re.compile(
+    r"tesserine/commons/(?:blob|raw|tree)/[^\s)\"']*(?:DESIGN-PRINCIPLES|PRINCIPLES\.md|adr/00(?:0[1-4]|07|13))"
+)
+
+
+def tracked_files() -> list[Path]:
+    listing = subprocess.run(
+        ["git", "ls-files"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [ROOT / line for line in listing.stdout.splitlines() if line]
+
+
+def readable_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return ""
+
+
+class ReckonCorpusPointerGates(unittest.TestCase):
+    def test_reckon_carries_no_hard_coded_corpus_repository(self) -> None:
+        for path in (ROOT / "skills" / "reckon").rglob("*"):
+            if path.is_file():
+                with self.subTest(file=path.relative_to(ROOT)):
+                    self.assertNotIn("pentaxis93/principles", readable_text(path))
+
+    def test_no_methodology_text_names_a_privileged_principle_subset(self) -> None:
+        for path in tracked_files():
+            if path.suffix != ".md":
+                continue
+            if path.parts[len(ROOT.parts)] not in {"skills", "protocols"}:
+                continue
+            with self.subTest(file=path.relative_to(ROOT)):
+                self.assertIsNone(PRIVILEGED_PRINCIPLE_NAMES.search(readable_text(path)))
+
+
+class PreSelectionAbsenceGates(unittest.TestCase):
+    def test_the_pre_selection_phrase_is_absent_from_every_tracked_file(self) -> None:
+        for path in tracked_files():
+            with self.subTest(file=path.relative_to(ROOT)):
+                self.assertIsNone(PRE_SELECTION_PHRASE.search(readable_text(path)))
+
+
+class CommonsMirrorLinkGates(unittest.TestCase):
+    def test_no_tracked_file_links_to_commons_principle_mirrors_or_stub_adrs(self) -> None:
+        for path in tracked_files():
+            with self.subTest(file=path.relative_to(ROOT)):
+                self.assertIsNone(COMMONS_MIRROR_LINKS.search(readable_text(path)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #405. Final child of epic #397.

## Purpose

Make the coherence upgrade understandable for each audience and mechanically verifiable, permanently.

## Implementation summary

**Docs per audience (at their conventional locations):**
- *Users* — README: new "The Principles Corpus" section (zero-config embedded default, offline out of the box; configurable override) and contents-table rows for `principles/` and `docs/principles-corpus.md`.
- *Power users* — `docs/principles-corpus.md` already carried the external-corpus configuration with the worked example (#399); unchanged.
- *Developers* — `docs/principles-corpus.md` already carried the materialization lifecycle (#400); this PR adds **What reckon reads during Orient** (and why no layer pre-digests the corpus), **Where authority lives after the source repair** (canonical corpus vs commons-as-contracts, with the mirror retirement tracked at commons#55), and **Verifying the coherence upgrade** (commands runnable from a fresh clone, plus the equivalent manual greps).

**Durable verification gates** — `tests/test_principles_coherence.py`, running in the existing CI test tier on every PR:
1. `skills/reckon/` carries no reference to a hard-coded corpus repository.
2. No `skills/` or `protocols/` markdown names a privileged principle subset (the names the removed pre-selection privileged, word-bounded).
3. The pre-selection's phrase is absent from every tracked file.
4. No tracked file links to the legacy commons principle mirrors or superseded stub ADRs (link patterns — prose provenance notes remain legitimate; the gate targets authority routing, not the record).

The gates scan `git ls-files`, so they hold from any fresh clone; they are written so their own source and the documented grep examples cannot trip them (regex escapes are not literal matches — verified by running them against the staged tree).

## Epic Definition-of-done → check mapping

| Epic DoD item | Automated / documented check |
|---|---|
| `grep -rn "pentaxis93/principles" skills/reckon/` clean; pre-selection absent | Gates 1–3 (CI) + documented greps |
| Fresh clone, no config, offline → resolves embedded default | `test_corpus_resolution.py` + `test_groundwork_install.py` offline tests (CI) |
| External corpus resolves to local content at setup; reckon consults local content | `test_install_materializes_a_configured_external_corpus` (CI); reckon's pointer text (#402) |
| ADR/owned references trace to living corpus; link integrity | #403 landed; gate 4 (CI) + `test_reference_links.py` |
| Commons follow-up filed/linked/gated | commons#55 + runa#191 (from #404), linked in docs |

## Verification

- `python -m unittest discover -s tests` → **293 tests, OK** (2 skipped; 4 new gates active)
- `python -m tooling.conformance` → 36 passed, 0 failed
- `./scripts/release-check metadata` → pass
- Documented fresh-clone command section matches what CI runs.

## Self-review

- No new functionality — docs and gates only, per the issue's non-goal.
- Gate 3's repo-wide phrase check forced a wording fix in an earlier changelog entry (caught and fixed in #402's PR before it landed); the gates were validated against the staged tree, not just the pre-change tree.