### PR TITLE
fix(docs): remove agent-execution traps; gate notation and script paths in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dependency-graph notation conflict resolved.** `templates.md` mandated
+  ASCII art while the decompose protocol and `work-unit-model.md` mandated
+  Mermaid `graph TD` plus a layered text summary. The Mermaid + layered
+  format is now canonical everywhere (`work-unit-model.md` § Dependency
+  Graph Format); the templates reference, epic template, and worked epic
+  example all use it, and `tests/test_dependency_graph_notation.py` fails
+  if a competing notation reappears.
+- **Script paths resolve from the methodology root.** The work-unit-craft
+  skill cited `scripts/issue_lint.py` (a path that resolves from nowhere);
+  the decompose protocol and acquire skill cited script paths that resolved
+  only from their own directories. All script references now use
+  methodology-root-relative paths with the root stated, and
+  `test_reference_links.py` gains a gate requiring every slash-containing
+  `.py`/`.sh` path in instruction files to resolve from the root.
+- **Own-repo absolute GitHub links converted to relative** in the orient
+  and work-unit-craft skills, bringing them under the existing relative
+  link gate. Issue and PR references remain absolute by design.
+
 ### Added
+
+- `docs/architecture/decisions/README.md` — decision register with a status
+  rubric: Proposed/Provisional decisions are binding descriptions of the
+  current design pending operator ratification, which is why shipped
+  topology (ADR-0004) can carry Proposed status.
 
 - **Corpus lifecycle documentation and durable coherence gates** closing the
   configurable-principles-corpus epic (#397). README gains "The Principles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `RELEASING.md` Tooling Provenance section and a `release_lib.py`
+  provenance docstring: the release scripts are groundwork-owned (a
+  distinct Python lineage), the ceremony convention is canonical in
+  commons, and no repo is the tooling upstream.
 - `docs/architecture/decisions/README.md` — decision register with a status
   rubric: Proposed/Provisional decisions are binding descriptions of the
   current design pending operator ratification, which is why shipped

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,19 @@ Tag grammar follows commons ADR-0012 exactly: numeric identifiers do not allow
 leading zeroes, release candidates start at `rc.1`, and alpha, beta, and build
 metadata forms are outside this repo's release surface.
 
+## Tooling Provenance
+
+`scripts/release-check`, `scripts/release-cut`, and the `release_lib.py`
+library behind them are groundwork-owned implementations of the shared
+release ceremony — convention canonical in
+[commons RELEASE.md](https://github.com/tesserine/commons/blob/main/RELEASE.md)
+and ADR-0006/0011/0012. groundwork's implementation is a distinct Python
+lineage; the bash siblings in agentd, base, commons, and runa share ancestry
+([commons#21](https://github.com/tesserine/commons/issues/21)) but every
+implementation is independently owned: no repo is the tooling upstream, and
+fixes do not propagate automatically. Ownership details:
+[base RELEASING.md § Release Tooling Ownership](https://github.com/tesserine/base/blob/main/RELEASING.md#release-tooling-ownership).
+
 ## Pre-Release Gate
 
 A releasable commit is on `main`, up to date with `origin/main`, and has a

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,37 @@
+# Methodology Decision Records
+
+Architecture decisions scoped to the groundwork methodology. Ecosystem-level
+decisions live in the
+[commons ADR register](https://github.com/tesserine/commons/blob/main/adr/README.md);
+nothing here duplicates that scope.
+
+## Status rubric
+
+groundwork is pre-1.0 and its decisions are ratified by the operator, not by
+shipping. Status names the **governance state**, not the implementation
+state — a decision can be fully shipped and still await ratification:
+
+- **Proposed** — authored and delivered for operator review. May already
+  describe shipped behavior; the decision itself has not been reviewed.
+- **Provisional** — operating decision: it is the methodology's current
+  design and is binding on contributors and agents, but it is held open for
+  revision while the methodology stabilizes. Revisions are recorded in-file
+  (see ADR-0002's Revision section).
+- **Accepted** — operator-ratified. Changing it requires a superseding ADR.
+- **Superseded** — replaced; the Status line names the successor.
+
+An agent executing the methodology treats Proposed and Provisional ADRs as
+authoritative for *what the system currently is*; the open status signals
+only that the operator may still revise the decision.
+
+## Register
+
+| # | Title | Status | Date |
+| --- | --- | --- | --- |
+| [0001](0001-internal-development-history-policy.md) | Internal Development History Policy | Provisional | 2026-03-10 |
+| [0002](0002-methodology-sovereignty.md) | Methodology Sovereignty | Provisional (revised 2026-05-28) | 2026-05-02 |
+| [0003](0003-disposition-as-artifact-type.md) | Disposition as Artifact Type | Provisional | 2026-05-31 |
+| [0004](0004-contract-first-scoped-pipeline.md) | Contract-First Scoped Pipeline | Proposed — delivered for operator review | 2026-06-11 |
+| [0005](0005-principles-corpus-configuration.md) | Principles Corpus Configuration | Provisional | 2026-06-12 |
+
+New decisions add a row here in the same change.

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -120,8 +120,9 @@ the earlier discussion" to understand, it is incomplete.
 7. Assemble using template from `references/templates.md`. Title format:
    `<type>(<scope>): <what>`.
 
-A structural linter is available at `scripts/issue_lint.py` for validating
-work-unit bodies against template schemas. The `work-unit-craft` skill
+A structural linter is available at `protocols/decompose/scripts/issue_lint.py`
+(path from the groundwork methodology root) for validating work-unit bodies
+against template schemas. The `work-unit-craft` skill
 carries the full authoring discipline — the sovereignty test, body-vs-comment
 authority, and the corruption modes that make records mis-steer implementing
 agents; consult it when authoring or re-scoping a record.

--- a/protocols/decompose/references/templates.md
+++ b/protocols/decompose/references/templates.md
@@ -110,10 +110,16 @@ recipient.
 
 ## Dependency graph
 
+```mermaid
+graph TD
+  A[#A task-title] --> C[#C task-title]
+  A --> D[#D task-title]
+  B[#B task-title] --> D
 ```
-#A ──┬── #C
-     │
-#B ──┴── #D
+
+```
+Layer 0 (no deps):  #A, #B
+Layer 1 (needs 0):  #C, #D
 ```
 
 ## Acceptance criteria
@@ -161,13 +167,22 @@ capability -> component release work plus terminal ecosystem-release work-unit
 
 ## Dependency graph
 
+```mermaid
+graph TD
+  A[#5 config] --> E[#9 install]
+  B[#6 frontmatter] --> E
+  C[#7 skill/mod] --> E
+  D[#8 linker] --> E
+  A --> F[#10 clean]
+  D --> F
+  E --> G[#11 ecosystem release]
+  F --> G
 ```
-#5 config ──────┐
-#6 frontmatter ─┼── #9 install ──┐
-#7 skill/mod ───┤                │
-#8 linker ──────┘                ├── #11 ecosystem release
-#5 config ──────┐                │
-#8 linker ──────┴── #10 clean ───┘
+
+```
+Layer 0 (no deps):  #5, #6, #7, #8
+Layer 1 (needs 0):  #9, #10
+Layer 2 (needs 1):  #11
 ```
 
 ## Acceptance criteria
@@ -327,37 +342,32 @@ end state (correct attribution posture) without prescribing the solution.
 
 ## Dependency Graph Notation
 
-Use ASCII art for dependency graphs in epic issues. Keep it simple.
+Canonical format:
+[`work-unit-model.md` § Dependency Graph Format](../../../docs/architecture/work-unit-model.md#dependency-graph-format).
+Epic issues with 4+ tasks carry the graph in **both** representations; no
+other notation (ASCII art included) is valid.
 
-### Linear chain
+### Mermaid diagram
 
-```
-#5 config → #7 skill → #9 install
-```
+Arrows mean "must complete before":
 
-### Fan-out (one foundation, many dependents)
-
-```
-#5 config ──┬── #9 install
-             ├── #10 clean
-             ├── #11 list
-             └── #13 new
-```
-
-### Diamond (multiple foundations merge)
-
-```
-#5 config ──────┬── #9 install
-#7 skill ───────┤
-#8 linker ──────┘
+```mermaid
+graph TD
+  A[#5 config] --> B[#7 skill]
+  B --> C[#9 install]
+  A --> D[#10 clean]
 ```
 
-### Layered (with labels)
+### Layered text summary
+
+For machine readability:
 
 ```
-Foundation:   #5 config    #6 frontmatter    #8 linker
-                  │              │                │
-Integration:  #7 skill (depends on #5, #6)       │
-                  │                               │
-Commands:     #9 install (depends on #5, #7, #8) ─┘
+Layer 0 (no deps):  #5
+Layer 1 (needs 0):  #7, #10
+Layer 2 (needs 1):  #9
 ```
+
+Keep node labels short: issue number plus a one- or two-word title. The
+layered summary lists every issue exactly once, at the lowest layer its
+dependencies allow.

--- a/scripts/release_lib.py
+++ b/scripts/release_lib.py
@@ -1,3 +1,13 @@
+"""groundwork-owned implementation of the Tesserine release ceremony.
+
+Convention canonical: commons RELEASE.md + ADR-0006/0011/0012
+(https://github.com/tesserine/commons). This library verifies groundwork's
+own release surface (manifest.toml version-of-record, methodology
+integrity). Sibling release-check implementations in agentd, base, commons,
+and runa share ancestry (commons#21) but are independently owned: no repo
+is the tooling upstream and fixes do not propagate automatically.
+"""
+
 from __future__ import annotations
 
 import argparse

--- a/skills/acquire/SKILL.md
+++ b/skills/acquire/SKILL.md
@@ -53,8 +53,10 @@ session that entrypoint opens.
    the materializer:
 
    ```
-   ... | python3 scripts/materialize.py
+   ... | python3 skills/acquire/scripts/materialize.py
    ```
+
+   (Script path from the groundwork methodology root.)
 
    It derives the work-unit body — `title`, `description`, and
    `acceptance_criteria` from the ticket content, `handle` carried through

--- a/skills/orient/SKILL.md
+++ b/skills/orient/SKILL.md
@@ -30,7 +30,7 @@ work, or orienting mid-task, the graph tells you where you are: what's in
 progress, what's blocked, what's next. Agent sessions are bounded — context
 windows end, agents rotate — and the work-unit graph is the persistence
 layer that survives those boundaries. Work from the graph, not from memory.
-See [work-unit-model.md](https://github.com/tesserine/groundwork/blob/main/docs/architecture/work-unit-model.md).
+See [work-unit-model.md](../../docs/architecture/work-unit-model.md).
 
 ## The Shape of the Work
 
@@ -143,4 +143,4 @@ These are not stations; they engage when their trigger fires, at any stage.
 
 For the connecting structure — artifacts, manifest edges, schemas, and
 protocol topology — see
-[connecting-structure.md](https://github.com/tesserine/groundwork/blob/main/docs/architecture/connecting-structure.md).
+[connecting-structure.md](../../docs/architecture/connecting-structure.md).

--- a/skills/work-unit-craft/SKILL.md
+++ b/skills/work-unit-craft/SKILL.md
@@ -369,11 +369,12 @@ to start?" If the answer references unfinished work, that is a dependency.
 
 - `decompose`: the protocol where work-unit records are authored —
   `create-work-unit` and `decompose-epic` apply this craft; the structural
-  linter at `scripts/issue_lint.py` validates record bodies against template
+  linter at `protocols/decompose/scripts/issue_lint.py` (path from the
+  groundwork methodology root) validates record bodies against template
   schemas.
 - `reckon`: establishes the verified constraints a record states; fire it
   before framing the work-unit.
-- [`docs/architecture/work-unit-model.md`](https://github.com/tesserine/groundwork/blob/main/docs/architecture/work-unit-model.md):
+- [`docs/architecture/work-unit-model.md`](../../docs/architecture/work-unit-model.md):
   the work-unit state model and dependency graph format the record
   participates in.
 

--- a/tests/test_dependency_graph_notation.py
+++ b/tests/test_dependency_graph_notation.py
@@ -1,0 +1,98 @@
+"""The dependency-graph notation has exactly one canonical definition.
+
+Canonical: docs/architecture/work-unit-model.md § Dependency Graph Format —
+a Mermaid ``graph TD`` diagram plus a layered text summary. The decompose
+protocol and its templates reference must defer to it, and no instruction
+file may mandate a competing notation. This gate exists because the
+methodology once shipped two conflicting canonical formats (Mermaid in the
+model/protocol, ASCII art in the templates reference) and an agent
+decomposing an epic had to guess.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORK_UNIT_MODEL = ROOT / "docs" / "architecture" / "work-unit-model.md"
+DECOMPOSE_PROTOCOL = ROOT / "protocols" / "decompose" / "PROTOCOL.md"
+TEMPLATES = ROOT / "protocols" / "decompose" / "references" / "templates.md"
+
+
+def instruction_files() -> list[Path]:
+    return sorted(
+        [
+            *ROOT.glob("protocols/*/PROTOCOL.md"),
+            *ROOT.glob("protocols/*/references/*.md"),
+            *ROOT.glob("skills/*/SKILL.md"),
+            *ROOT.glob("skills/*/references/*.md"),
+        ]
+    )
+
+
+class DependencyGraphNotationTests(unittest.TestCase):
+    def test_work_unit_model_defines_the_canonical_format(self) -> None:
+        body = WORK_UNIT_MODEL.read_text(encoding="utf-8")
+        section = re.search(
+            r"## Dependency Graph Format\n(?P<section>.*?)(?:\n## |\Z)",
+            body,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(
+            section, "work-unit-model.md must keep its Dependency Graph Format section"
+        )
+        text = section.group("section")
+        self.assertIn("```mermaid", text)
+        self.assertIn("graph TD", text)
+        self.assertIn("Layered text summary", text)
+
+    def test_decompose_protocol_defers_to_the_canonical_format(self) -> None:
+        body = DECOMPOSE_PROTOCOL.read_text(encoding="utf-8")
+        self.assertIn("Mermaid `graph TD`", body)
+        self.assertIn("work-unit-model.md", body)
+
+    def test_templates_reference_defers_and_shows_both_representations(self) -> None:
+        body = TEMPLATES.read_text(encoding="utf-8")
+        notation = re.search(
+            r"## Dependency Graph Notation\n(?P<section>.*?)(?:\n## |\Z)",
+            body,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(
+            notation, "templates.md must keep its Dependency Graph Notation section"
+        )
+        text = notation.group("section")
+        self.assertIn("work-unit-model.md", text)
+        self.assertIn("```mermaid", text)
+        self.assertIn("Layer 0", text)
+
+    def test_every_templates_dependency_graph_block_is_mermaid(self) -> None:
+        body = TEMPLATES.read_text(encoding="utf-8")
+        sections = re.findall(
+            r"^## Dependency graph\n(.*?)(?=^## )", body, re.DOTALL | re.MULTILINE
+        )
+        self.assertNotEqual(
+            [], sections, "templates.md should contain dependency graph blocks"
+        )
+        for section in sections:
+            self.assertIn(
+                "```mermaid",
+                section,
+                "every dependency graph block in templates.md must use the "
+                "canonical Mermaid representation",
+            )
+
+    def test_no_instruction_file_mandates_a_competing_notation(self) -> None:
+        mandate = re.compile(r"Use ASCII art", re.IGNORECASE)
+        for path in instruction_files():
+            with self.subTest(source=path.relative_to(ROOT)):
+                self.assertIsNone(
+                    mandate.search(path.read_text(encoding="utf-8")),
+                    f"{path.relative_to(ROOT)} mandates a notation that competes "
+                    "with work-unit-model.md § Dependency Graph Format",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reference_links.py
+++ b/tests/test_reference_links.py
@@ -32,9 +32,32 @@ def relative_targets(body: str) -> list[str]:
     return targets
 
 
+SCRIPT_PATH = re.compile(r"(?<![\w/.@-])([\w.-]+(?:/[\w.-]+)+\.(?:py|sh))(?![\w/])")
+
+
 class ReferenceLinkTests(unittest.TestCase):
     def test_instruction_files_exist_to_scan(self) -> None:
         self.assertNotEqual([], instruction_files())
+
+    def test_script_paths_resolve_from_methodology_root(self) -> None:
+        """Slash-containing .py/.sh paths in instruction files must resolve
+        from the methodology root.
+
+        Markdown links are file-relative (they render on the forge), but
+        script invocation paths are read by agents whose working directory
+        is not the instruction file's directory — a script path is only
+        unambiguous when it is methodology-root-relative. Bare filenames
+        (no slash) are prose mentions and exempt.
+        """
+        for path in instruction_files():
+            body = path.read_text(encoding="utf-8")
+            for target in SCRIPT_PATH.findall(body):
+                with self.subTest(source=path.relative_to(ROOT), target=target):
+                    self.assertTrue(
+                        (ROOT / target).is_file(),
+                        f"{path.relative_to(ROOT)} references script path {target}, "
+                        "which does not resolve from the methodology root",
+                    )
 
     def test_relative_references_in_instruction_files_resolve(self) -> None:
         for path in instruction_files():


### PR DESCRIPTION
Part of the ecosystem-wide documentation coherence pass (refs tesserine/commons#5).

## What this does

- **Dependency-graph notation reconciled**: Mermaid `graph TD` + layered text summary (work-unit-model.md § Dependency Graph Format) is the single canonical format; templates.md's ASCII mandate, epic template block, and worked example now conform. `tests/test_dependency_graph_notation.py` fails if a competing notation reappears.
- **Script paths resolve from the methodology root**: fixes the broken `scripts/issue_lint.py` citation in work-unit-craft and the cwd-fragile invocations in decompose and acquire. `test_reference_links.py` gains a gate requiring every slash-containing `.py`/`.sh` path in instruction files to resolve from the root — the pre-fix paths fail it.
- **Own-repo absolute GitHub file links → relative** (orient, work-unit-craft), bringing them under the existing link gate.
- **docs/architecture/decisions/README.md**: decision register + status rubric — Proposed/Provisional ADRs are binding descriptions of the current design pending operator ratification, which is why shipped topology (ADR-0004) can carry Proposed status.
- RELEASING tooling-provenance section; release_lib.py provenance docstring.

## Verification

- `python -m unittest discover -s tests`: 299 passed (2 pre-existing skips).
- `python -m tooling.conformance`: 36 passed, 0 failed.
- Release ceremony suite passes with the provenance docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
