### PR TITLE
feat(install): methodology self-install for runtime-driven deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Methodology self-install for runtime-driven deployments** (#416).
+  `scripts/install` (logic in `tooling/install.py`, stdlib-only) installs
+  exactly what the methodology interface contract channel does not deliver:
+  skills verbatim into `~/.claude/skills` and `~/.agents/skills` (no
+  PROTOCOL.md→SKILL.md projection, no handoff insertion, no resolver
+  rewriting), the `~/.groundwork` methodology runtime bundle, and the
+  principles corpus — recording the operator's `--corpus-git`/`--corpus-path`/
+  `--corpus-embedded` input into the deployment-owned `principles.toml`
+  (ADR-0005) before materializing it through the existing resolution layer.
+  Idempotent convergence (a second run exits 0 with no managed-state change;
+  skills removed from the tree are pruned), loud named-path preflights,
+  disjoint ownership identity from the legacy installer (legacy-placed
+  entries are conflicts directed to `groundwork-install uninstall`, never
+  adopted), and commit-traceable markers. `tooling/principles_config.py`
+  gains `render_principles_config`/`write_principles_config` with a parse
+  round-trip invariant. Decision record:
+  `docs/architecture/decisions/0006-runtime-driven-self-install-surface.md`.
+  Coverage in `tests/test_install.py`. The legacy `scripts/groundwork-install`
+  is deprecated in favor of this surface; retirement is tracked in #415.
+
 ### Changed
 
 - README hero rewritten for the ecosystem README pass: groundwork positioned

--- a/README.md
+++ b/README.md
@@ -84,11 +84,53 @@ checkout reasons offline, out of the box. Deployments that want a richer
 corpus configure one (any git repository or local directory).
 → [`docs/principles-corpus.md`](docs/principles-corpus.md)
 
+## Install for Runtime-Driven Deployments
+
+In a runtime-driven deployment, a protocol runtime executes the methodology
+through the methodology interface contract and delivers protocol instruction
+content at execution time — so protocols are never installed for agent
+discovery. What that channel does not deliver, `scripts/install` installs from
+a clean checkout, idempotently and with no root or sudo requirement:
+
+```bash
+scripts/install install --corpus-git https://example.org/owner/corpus
+```
+
+- **Skills, verbatim** — every `skills/<name>/` carrying a `SKILL.md` lands
+  unmodified in `~/.claude/skills/<name>` and `~/.agents/skills/<name>`.
+  Skills are agent-invoked by judgment and are not runtime-delivered, so they
+  install natively; no projection or rewriting of any kind.
+- **The methodology runtime** — `~/.groundwork` with the manifest, the
+  mechanic library, the forge-operations module, and
+  `bin/groundwork-mechanic`.
+- **The principles corpus** — the `--corpus-git URL [--corpus-ref REF]`,
+  `--corpus-path PATH`, or `--corpus-embedded` operator input is recorded in
+  the deployment-owned `${XDG_CONFIG_HOME:-~/.config}/groundwork/principles.toml`
+  and materialized at `~/.groundwork/principles` through the resolution layer.
+  Without an input an existing configuration is honored; without either, the
+  embedded default resolves — zero-config stays the ordinary path.
+
+Re-running converges to the same state with exit 0; skills no longer shipped
+are removed; pre-existing content the installer does not own is reported as a
+named conflict, never overwritten or adopted (entries placed by the legacy
+`groundwork-install` are directed to its own uninstall). Content derives from
+the checkout's `HEAD` commit, recorded in each entry's ownership marker.
+`scripts/install uninstall` removes only marker-verified managed entries and
+leaves the deployment-owned config in place. State lives at
+`${XDG_STATE_HOME:-~/.local/state}/groundwork/install.tsv`. No shell startup
+file is created or modified by any run. Prerequisites: `git` and `python3`.
+
+The decision record is
+[ADR-0006](docs/architecture/decisions/0006-runtime-driven-self-install-surface.md).
+
 ## Interactive Installation
 
 Runa-served agents consume Groundwork through the methodology mount. Interactive
 Claude Code and Codex sessions can install the same skills and protocols into
-their local discovery directories from a pinned Groundwork checkout:
+their local discovery directories from a pinned Groundwork checkout. This
+protocols-as-skills projection serves deployments with no protocol runtime; it
+is deprecated in favor of the runtime-driven path above, and its retirement is
+tracked in [#415](https://github.com/tesserine/groundwork/issues/415):
 
 ```bash
 git checkout --detach v0.2.0

--- a/docs/architecture/decisions/0006-runtime-driven-self-install-surface.md
+++ b/docs/architecture/decisions/0006-runtime-driven-self-install-surface.md
@@ -1,0 +1,113 @@
+# ADR-0006: Runtime-Driven Self-Install Surface
+
+**Status:** Proposed — delivered for operator review \
+**Date:** 2026-06-12 \
+**Traces to:** [#416](https://github.com/tesserine/groundwork/issues/416)
+(the self-install), [#415](https://github.com/tesserine/groundwork/issues/415)
+(legacy retirement decision), first consumer
+[pentaxis93/babbie-ops#65](https://github.com/pentaxis93/babbie-ops/issues/65).
+
+## Context
+
+In a runtime-driven deployment, a protocol runtime executes the
+methodology through the methodology interface contract: each protocol's
+instruction content and validated inputs arrive at execution time through
+the runtime's session surface. The legacy installer
+(`scripts/groundwork-install`) predates that channel — it projects
+`protocols/*/PROTOCOL.md` documents as skills so a bare agent session can
+run them. In a runtime-driven deployment that projection installs a
+second, drifting copy of content the runtime already delivers
+authoritatively.
+
+What the contract channel does *not* deliver still needs installing:
+skills (agent-invoked by judgment, never runtime-delivered), the
+methodology runtime the forge steps execute through, and the resolved
+principles corpus.
+
+## Decision
+
+One idempotent, groundwork-owned, host- and runtime-agnostic installer:
+`scripts/install` (logic in `tooling/install.py`, stdlib-only). It owns
+exactly three surfaces and carries no projection machinery:
+
+1. **Skills, verbatim.** Every `skills/<name>/` carrying a `SKILL.md`
+   installs unmodified into `~/.claude/skills/<name>` and
+   `~/.agents/skills/<name>`, enumerated from the tree at the source
+   commit. No transformation of any shipped file; the only added file is
+   the ownership marker.
+2. **The methodology runtime.** `~/.groundwork` with `manifest.toml`,
+   `mechanics/`, the forge-operations module, and the
+   `bin/groundwork-mechanic` resolver wrapper.
+3. **The principles corpus.** The corpus source is an operator input
+   (`--corpus-git URL [--corpus-ref REF]` | `--corpus-path PATH` |
+   `--corpus-embedded` — ADR-0005's discriminated union as flags). The
+   installer records the input into the deployment-owned
+   `${XDG_CONFIG_HOME:-~/.config}/groundwork/principles.toml` and
+   materializes the resolved corpus at `~/.groundwork/principles` through
+   the existing resolution layer. Absent the input, an existing config is
+   honored; absent both, the embedded default resolves.
+
+### Naming
+
+The tool is `scripts/install`, not a prefixed variant: it is invoked by
+checkout path, never placed on `PATH`, so it cannot collide with
+coreutils `install` or shadow the legacy `groundwork-install` during the
+coexistence window — and once the legacy script retires (#415) it reads
+as exactly what it is, the repo's installer.
+
+### Ownership identity is disjoint from the legacy installer
+
+Markers are `.groundwork-managed` with
+`managed-by=groundwork scripts/install`; state lives at
+`${XDG_STATE_HOME:-~/.local/state}/groundwork/install.tsv`. The legacy
+installer's identity (`.groundwork-install`,
+`groundwork-install/interactive-install.tsv`) is never read as our own.
+Entries the legacy installer placed are **named conflicts directing the
+operator to `scripts/groundwork-install uninstall`**, never adopted:
+adoption would transfer ownership of content this installer did not
+write — including protocol projections it must never manage.
+
+### Convergence and failure semantics
+
+- Re-running converges with exit 0 and leaves every managed inode
+  untouched (compare-before-swap on all three surfaces, including the
+  recorded config and the state file).
+- An entry installed previously but no longer shipped is removed; removal
+  is gated on this installer's own marker, and a missing marker at a
+  deletion boundary fails loudly with state intact.
+- Pre-existing unmanaged state fails loudly with a named path before any
+  target is touched.
+- The corpus is staged (including the remote fetch) before any target
+  mutation, so an unreachable remote aborts a run with nothing changed,
+  and resolution-layer errors surface unmodified.
+- The source must be a clean checkout root; content derives from `HEAD`
+  and the recorded `source-sha` is the trace. There is no pinned-ref
+  gate: deployment recipes pin the ref they clone, and forcing detachment
+  here adds ceremony without traceability gain.
+- Uninstall removes only marker-verified managed entries and the runtime
+  root; the deployment-owned `principles.toml` is recorded into, never
+  deleted.
+
+## Consequences
+
+### Good
+
+- Runtime-driven deployments compose one upstream installer with their
+  own inputs (babbie-ops#65) instead of re-implementing install
+  knowledge; no protocol content is ever installed for agent discovery,
+  so nothing drifts against the contract channel.
+- The legacy installer's retirement (#415) reduces to deleting the
+  projection machinery — its legitimate jobs live here, in Python, with
+  the corpus layer imported rather than subprocessed.
+
+### Neutral
+
+- Two installers coexist until #415 lands; disjoint marker and state
+  namespaces plus the directed-conflict message make the boundary
+  explicit at every collision point.
+
+### Bad
+
+- A deployment migrating from the legacy installer must run its
+  uninstall first; the conflict message names that step, but it is a
+  manual step.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -33,5 +33,6 @@ only that the operator may still revise the decision.
 | [0003](0003-disposition-as-artifact-type.md) | Disposition as Artifact Type | Provisional | 2026-05-31 |
 | [0004](0004-contract-first-scoped-pipeline.md) | Contract-First Scoped Pipeline | Proposed — delivered for operator review | 2026-06-11 |
 | [0005](0005-principles-corpus-configuration.md) | Principles Corpus Configuration | Provisional | 2026-06-12 |
+| [0006](0006-runtime-driven-self-install-surface.md) | Runtime-Driven Self-Install Surface | Proposed — delivered for operator review | 2026-06-12 |
 
 New decisions add a row here in the same change.

--- a/docs/principles-corpus.md
+++ b/docs/principles-corpus.md
@@ -40,6 +40,13 @@ tree at:
 ${XDG_CONFIG_HOME:-~/.config}/groundwork/principles.toml
 ```
 
+Operators can write the file by hand, or have the self-installer record
+it: `scripts/install install --corpus-git URL [--corpus-ref REF]`
+(likewise `--corpus-path PATH` or `--corpus-embedded`) writes the
+supplied source into this file before materializing it. An existing file
+that already expresses the same source is left byte-untouched, so a
+hand-written config survives re-recording.
+
 It declares a single `[corpus]` table discriminated by `source`:
 
 ```toml
@@ -78,12 +85,14 @@ and CI holds the two in agreement.)
 
 Resolution is performed by
 [`tooling/corpus_resolution.py`](../tooling/corpus_resolution.py), wired
-into [`scripts/groundwork-install`](../scripts/groundwork-install):
+into both installers — [`scripts/install`](../scripts/install) (the
+self-install for runtime-driven deployments) and the legacy
+[`scripts/groundwork-install`](../scripts/groundwork-install):
 
-- **When:** at install/setup — every `groundwork-install install` or
-  `sync` run. Never during reasoning: no code path fetches the corpus
-  inside a reckon step, and a remote source is fetched exactly once per
-  resolution.
+- **When:** at install/setup — every `scripts/install install` or
+  `groundwork-install install`/`sync` run. Never during reasoning: no
+  code path fetches the corpus inside a reckon step, and a remote source
+  is fetched exactly once per resolution.
 - **Where:** into `~/.groundwork/principles/` (the resolved local corpus,
   under the managed runtime root). Materialization stages into a
   temporary sibling directory and swaps atomically, so a failed
@@ -92,9 +101,10 @@ into [`scripts/groundwork-install`](../scripts/groundwork-install):
   any target (an invalid config halts the install before anything is
   projected), and a resolved corpus must carry a readable index
   (`PRINCIPLES.md` or `README.md`) at its root.
-- **Refresh:** rerun `groundwork-install sync` from the checkout. There
-  is no in-session synchronization — a stale resolved corpus is refreshed
-  at the next setup run, by design.
+- **Refresh:** rerun the installer from the checkout (`scripts/install
+  install`, or `groundwork-install sync` on the legacy path). There is no
+  in-session synchronization — a stale resolved corpus is refreshed at
+  the next setup run, by design.
 
 Failure modes are loud and named, with nonzero exit: a
 present-but-invalid config, a missing local source directory, an

--- a/scripts/install
+++ b/scripts/install
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Methodology self-install for runtime-driven deployments.
+
+Thin shim: the installer logic lives in tooling/install.py.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tooling.install import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,565 @@
+"""Behavior coverage for `scripts/install` — the methodology self-install
+for runtime-driven deployments (#416).
+
+The installer owns exactly three surfaces: skills verbatim, the methodology
+runtime bundle, and principles-corpus recording + materialization. It never
+delivers protocol content — that is the runtime's channel.
+"""
+
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "scripts" / "install"
+MARKER_NAME = ".groundwork-managed"
+LEGACY_MARKER_NAME = ".groundwork-install"
+
+
+def run(
+    args: list[str],
+    cwd: Path,
+    *,
+    check: bool = False,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"command failed: {' '.join(args)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def assert_success(test: unittest.TestCase, result: subprocess.CompletedProcess[str]) -> None:
+    test.assertEqual(result.returncode, 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+
+
+def assert_failure_contains(
+    test: unittest.TestCase,
+    result: subprocess.CompletedProcess[str],
+    expected: str,
+) -> None:
+    test.assertNotEqual(result.returncode, 0, "command unexpectedly succeeded")
+    test.assertIn(expected, result.stderr)
+
+
+def tree_payload(directory: Path, *, exclude: frozenset[str] = frozenset({MARKER_NAME})) -> dict[str, bytes]:
+    """Relative path → bytes for every file under ``directory``."""
+    payload = {}
+    for path in sorted(directory.rglob("*")):
+        if path.is_file() and path.name not in exclude:
+            payload[str(path.relative_to(directory))] = path.read_bytes()
+    return payload
+
+
+class MethodologyFixture:
+    """A temp methodology checkout carrying the full self-install surface:
+    skills, protocols (present to prove non-projection), the runtime
+    surface, and an embedded principles corpus."""
+
+    def __init__(self, name: str) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix=f"groundwork-self-install-source-{name}-"))
+        self.write_initial_surface()
+        self.init_git()
+
+    def write(self, relative: str, contents: str) -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(contents).lstrip(), encoding="utf-8")
+
+    def remove(self, relative: str) -> None:
+        path = self.root / relative
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+    def write_initial_surface(self) -> None:
+        self.write("skills/orient/SKILL.md", "---\nname: orient\n---\n# Orient\n")
+        self.write("skills/reckon/SKILL.md", "---\nname: reckon\n---\n# Reckon\n")
+        self.write("skills/reckon/references/example.md", "reckon reference\n")
+        self.write("protocols/take/PROTOCOL.md", "---\nname: take\n---\n# Take\n")
+        self.write("principles/PRINCIPLES.md", "# Principles\n\n1. Understand.\n")
+        self.write(
+            "manifest.toml",
+            """
+            [[forge_tags]]
+            name = "github"
+
+            [[forge_tags]]
+            name = "sourcehut"
+
+            [[mechanics]]
+            name = "close-out"
+            forge_tags = ["github", "sourcehut"]
+            """,
+        )
+        for forge in ["github", "sourcehut"]:
+            self.write(
+                f"mechanics/{forge}/close-out.toml",
+                f"""
+                name = "close-out"
+                purpose = "Close out on {forge}."
+                forge_tag = "{forge}"
+                default_invocation = 'printf "%s\\n" "$message"'
+                examples = ['printf "%s\\n" "$message"']
+
+                [[parameters]]
+                name = "message"
+                purpose = "Completion message."
+                required = true
+
+                [outcome]
+                description = "Closed."
+                """,
+            )
+        self.write(
+            "tooling/forge_operations.py",
+            (ROOT / "tooling" / "forge_operations.py").read_text(encoding="utf-8"),
+        )
+
+    def init_git(self) -> None:
+        run(["git", "init", "-q"], self.root, check=True)
+        run(["git", "config", "user.name", "installer test"], self.root, check=True)
+        run(["git", "config", "user.email", "installer-test@example.invalid"], self.root, check=True)
+        run(["git", "config", "commit.gpgsign", "false"], self.root, check=True)
+        run(["git", "config", "tag.gpgsign", "false"], self.root, check=True)
+        run(["git", "checkout", "-q", "-b", "main"], self.root, check=True)
+        run(["git", "add", "."], self.root, check=True)
+        run(["git", "commit", "-q", "-m", "test: seed methodology"], self.root, check=True)
+
+    def commit(self, message: str) -> None:
+        run(["git", "add", "-A"], self.root, check=True)
+        run(["git", "commit", "-q", "-m", f"test: {message}"], self.root, check=True)
+
+    def head_sha(self) -> str:
+        return run(["git", "rev-parse", "HEAD"], self.root, check=True).stdout.strip()
+
+    def cleanup(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+class InstallRun:
+    """Invokes the installer with an isolated home, state dir, and config dir."""
+
+    def __init__(self, test: unittest.TestCase, source: Path) -> None:
+        self.test = test
+        self.source = source
+        self.home = Path(tempfile.mkdtemp(prefix="groundwork-self-install-home-"))
+        self.state = Path(tempfile.mkdtemp(prefix="groundwork-self-install-state-"))
+        test.addCleanup(lambda: shutil.rmtree(self.home, ignore_errors=True))
+        test.addCleanup(lambda: shutil.rmtree(self.state, ignore_errors=True))
+
+    def run_installer(
+        self,
+        *args: str,
+        include_state_dir: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        self.test.assertTrue(INSTALLER.is_file(), f"installer missing at {INSTALLER}")
+        command = [
+            str(INSTALLER),
+            *args,
+            "--source",
+            str(self.source),
+            "--home",
+            str(self.home),
+        ]
+        if include_state_dir:
+            command.extend(["--state-dir", str(self.state)])
+        run_env = {
+            "PATH": "/usr/bin:/bin",
+            "HOME": str(self.home),
+            "XDG_CONFIG_HOME": str(self.home / ".config"),
+        }
+        if env:
+            run_env.update(env)
+        return run(command, self.source, env=run_env)
+
+    def target(self, root: str, name: str) -> Path:
+        return self.home / root / "skills" / name
+
+    def state_file(self) -> Path:
+        return self.state / "install.tsv"
+
+    def runtime_root(self) -> Path:
+        return self.home / ".groundwork"
+
+    def config_file(self) -> Path:
+        return self.home / ".config" / "groundwork" / "principles.toml"
+
+
+class SelfInstallTests(unittest.TestCase):
+    def add_fixture(self, name: str) -> MethodologyFixture:
+        fixture = MethodologyFixture(name)
+        self.addCleanup(fixture.cleanup)
+        return fixture
+
+    def test_install_places_skills_byte_identical_in_both_discovery_roots(self) -> None:
+        fixture = self.add_fixture("skills-verbatim")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            skills_dir = install.home / root / "skills"
+            self.assertEqual(
+                {path.name for path in skills_dir.iterdir()},
+                {"orient", "reckon"},
+                f"unexpected inventory under {skills_dir}",
+            )
+            for name in ["orient", "reckon"]:
+                self.assertEqual(
+                    tree_payload(install.target(root, name)),
+                    tree_payload(fixture.root / "skills" / name),
+                    f"{root}/{name} is not byte-identical to the tree",
+                )
+
+
+    def test_install_projects_runtime_bundle_and_resolver_executes(self) -> None:
+        fixture = self.add_fixture("runtime-bundle")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertEqual(
+            (install.runtime_root() / "manifest.toml").read_bytes(),
+            (fixture.root / "manifest.toml").read_bytes(),
+        )
+        self.assertEqual(
+            tree_payload(install.runtime_root() / "mechanics"),
+            tree_payload(fixture.root / "mechanics"),
+        )
+        resolver = install.runtime_root() / "bin" / "groundwork-mechanic"
+        self.assertTrue(resolver.is_file())
+        resolved = run(
+            [str(resolver), "resolve", "close-out"],
+            install.runtime_root(),
+            env={"PATH": "/usr/bin:/bin", "RUNA_FORGE_TYPE": "sourcehut"},
+        )
+        assert_success(self, resolved)
+        self.assertEqual("close-out[sourcehut]\n", resolved.stdout)
+
+
+    def test_absent_input_and_config_resolves_embedded_default(self) -> None:
+        fixture = self.add_fixture("zero-config-corpus")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertEqual(
+            tree_payload(install.runtime_root() / "principles"),
+            tree_payload(fixture.root / "principles"),
+        )
+        self.assertFalse(install.config_file().exists(), "zero-config run must not write a config file")
+
+
+    def make_corpus_repository(self, name: str) -> Path:
+        """A local git repository carrying an external corpus."""
+        corpus = Path(tempfile.mkdtemp(prefix=f"groundwork-self-install-corpus-{name}-"))
+        self.addCleanup(lambda: shutil.rmtree(corpus, ignore_errors=True))
+        (corpus / "PRINCIPLES.md").write_text("# External Principles\n", encoding="utf-8")
+        run(["git", "init", "-q"], corpus, check=True)
+        run(["git", "config", "user.name", "corpus test"], corpus, check=True)
+        run(["git", "config", "user.email", "corpus-test@example.invalid"], corpus, check=True)
+        run(["git", "config", "commit.gpgsign", "false"], corpus, check=True)
+        run(["git", "add", "."], corpus, check=True)
+        run(["git", "commit", "-q", "-m", "test: seed corpus"], corpus, check=True)
+        return corpus
+
+    def test_operator_git_corpus_input_is_recorded_and_materialized(self) -> None:
+        fixture = self.add_fixture("operator-git-corpus")
+        corpus = self.make_corpus_repository("recorded")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install", "--corpus-git", f"file://{corpus}")
+
+        assert_success(self, result)
+        self.assertEqual(
+            install.config_file().read_text(encoding="utf-8"),
+            f'[corpus]\nsource = "git"\nurl = "file://{corpus}"\n',
+        )
+        self.assertEqual(
+            (install.runtime_root() / "principles" / "PRINCIPLES.md").read_text(encoding="utf-8"),
+            "# External Principles\n",
+        )
+        self.assertFalse((install.runtime_root() / "principles" / ".git").exists())
+
+
+    def test_absent_input_honors_existing_config(self) -> None:
+        fixture = self.add_fixture("existing-config")
+        install = InstallRun(self, fixture.root)
+        external = Path(tempfile.mkdtemp(prefix="groundwork-self-install-external-corpus-"))
+        self.addCleanup(lambda: shutil.rmtree(external, ignore_errors=True))
+        (external / "PRINCIPLES.md").write_text("# Operator Corpus\n", encoding="utf-8")
+        operator_written = f'# operator comment\n[corpus]\nsource = "path"\npath = "{external}"\n'
+        install.config_file().parent.mkdir(parents=True)
+        install.config_file().write_text(operator_written, encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertEqual(install.config_file().read_text(encoding="utf-8"), operator_written)
+        self.assertEqual(
+            (install.runtime_root() / "principles" / "PRINCIPLES.md").read_text(encoding="utf-8"),
+            "# Operator Corpus\n",
+        )
+
+    def test_rerecording_identical_corpus_input_does_not_rewrite_config(self) -> None:
+        fixture = self.add_fixture("idempotent-recording")
+        corpus = self.make_corpus_repository("rerecorded")
+        install = InstallRun(self, fixture.root)
+        url = f"file://{corpus}"
+        assert_success(self, install.run_installer("install", "--corpus-git", url))
+        before = install.config_file().stat()
+
+        result = install.run_installer("install", "--corpus-git", url)
+
+        assert_success(self, result)
+        after = install.config_file().stat()
+        self.assertEqual((before.st_ino, before.st_mtime_ns), (after.st_ino, after.st_mtime_ns))
+
+
+    def stat_snapshot(self, *directories: Path) -> dict[str, tuple[int, int]]:
+        """inode + mtime for every path under the given directories."""
+        snapshot = {}
+        for directory in directories:
+            for path in sorted(directory.rglob("*")):
+                stat = path.stat()
+                snapshot[str(path)] = (stat.st_ino, stat.st_mtime_ns)
+        return snapshot
+
+    def test_second_run_exits_zero_with_no_state_change(self) -> None:
+        fixture = self.add_fixture("idempotent-rerun")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        before = self.stat_snapshot(install.home, install.state)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertEqual(self.stat_snapshot(install.home, install.state), before)
+
+
+    def test_skill_removed_from_tree_is_removed_on_rerun(self) -> None:
+        fixture = self.add_fixture("stale-skill")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        fixture.remove("skills/reckon")
+        fixture.commit("drop reckon")
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            self.assertFalse(install.target(root, "reckon").exists())
+            self.assertTrue(install.target(root, "orient").is_dir())
+
+
+    def test_unmanaged_preexisting_entry_fails_loudly_with_named_path(self) -> None:
+        fixture = self.add_fixture("unmanaged-conflict")
+        install = InstallRun(self, fixture.root)
+        conflicting = install.target(".claude", "orient")
+        conflicting.mkdir(parents=True)
+        (conflicting / "SKILL.md").write_text("operator content\n", encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, str(conflicting))
+        self.assertEqual(
+            (conflicting / "SKILL.md").read_text(encoding="utf-8"),
+            "operator content\n",
+            "conflicting content must not be touched",
+        )
+        self.assertFalse((install.home / ".agents").exists(), "preflight must halt before any install")
+        self.assertFalse(install.runtime_root().exists(), "preflight must halt before any install")
+
+
+    def test_legacy_installed_entry_is_a_named_conflict_directing_to_legacy_uninstall(self) -> None:
+        fixture = self.add_fixture("legacy-conflict")
+        install = InstallRun(self, fixture.root)
+        legacy_entry = install.target(".claude", "orient")
+        legacy_entry.mkdir(parents=True)
+        (legacy_entry / "SKILL.md").write_text("legacy projection\n", encoding="utf-8")
+        (legacy_entry / LEGACY_MARKER_NAME).write_text(
+            "managed-by=groundwork-install\n", encoding="utf-8"
+        )
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, str(legacy_entry))
+        assert_failure_contains(self, result, "groundwork-install uninstall")
+        self.assertTrue((legacy_entry / "SKILL.md").is_file(), "legacy content must not be touched")
+
+
+    def test_dirty_source_checkout_is_rejected(self) -> None:
+        fixture = self.add_fixture("dirty-source")
+        fixture.write("skills/orient/SKILL.md", "---\nname: orient\n---\n# Drifted\n")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "dirty")
+        self.assertFalse((install.home / ".claude").exists())
+
+    def test_source_outside_a_checkout_root_is_rejected(self) -> None:
+        fixture = self.add_fixture("nested-source")
+        install = InstallRun(self, fixture.root / "skills")
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "checkout root")
+
+
+    def test_uninstall_removes_only_owned_entries_and_preserves_config_file(self) -> None:
+        fixture = self.add_fixture("uninstall")
+        corpus = self.make_corpus_repository("uninstalled")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install", "--corpus-git", f"file://{corpus}"))
+        operator_skill = install.home / ".claude" / "skills" / "operator-own"
+        operator_skill.mkdir()
+        (operator_skill / "SKILL.md").write_text("not ours\n", encoding="utf-8")
+
+        result = install.run_installer("uninstall")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            for name in ["orient", "reckon"]:
+                self.assertFalse(install.target(root, name).exists())
+        self.assertFalse(install.runtime_root().exists())
+        self.assertFalse(install.state_file().exists())
+        self.assertTrue((operator_skill / "SKILL.md").is_file(), "unmanaged content must survive")
+        self.assertTrue(install.config_file().is_file(), "deployment-owned config must survive")
+
+
+    def test_install_never_projects_protocols_into_discovery_roots(self) -> None:
+        fixture = self.add_fixture("no-projection")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            skills_dir = install.home / root / "skills"
+            self.assertEqual({path.name for path in skills_dir.iterdir()}, {"orient", "reckon"})
+        installed_bodies = [
+            path.read_text(encoding="utf-8")
+            for path in install.home.rglob("*.md")
+        ]
+        for body in installed_bodies:
+            self.assertNotIn("session-surface-handoff", body)
+
+    def test_installed_skill_referencing_mechanic_is_not_rewritten(self) -> None:
+        fixture = self.add_fixture("no-rewriting")
+        body = "---\nname: orient\n---\n# Orient\n\nRun `groundwork-mechanic resolve close-out`.\n"
+        fixture.write("skills/orient/SKILL.md", body)
+        fixture.commit("mechanic reference")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            self.assertEqual(
+                (install.target(root, "orient") / "SKILL.md").read_text(encoding="utf-8"),
+                body,
+            )
+
+    def test_skill_set_is_enumerated_from_tree(self) -> None:
+        fixture = self.add_fixture("enumerated")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        fixture.write("skills/survey/SKILL.md", "---\nname: survey\n---\n# Survey\n")
+        fixture.write("skills/not-a-skill/notes.md", "no SKILL.md here\n")
+        fixture.commit("add survey and a non-skill directory")
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            skills_dir = install.home / root / "skills"
+            self.assertEqual(
+                {path.name for path in skills_dir.iterdir()},
+                {"orient", "reckon", "survey"},
+            )
+
+    def test_marker_records_managed_by_and_source_commit(self) -> None:
+        fixture = self.add_fixture("traceable")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        sha = fixture.head_sha()
+        for managed in [install.target(".claude", "orient"), install.runtime_root()]:
+            marker = (managed / MARKER_NAME).read_text(encoding="utf-8")
+            self.assertIn("managed-by=groundwork scripts/install\n", marker)
+            self.assertIn(f"source-sha={sha}\n", marker)
+
+    def test_invalid_corpus_config_halts_before_touching_targets(self) -> None:
+        fixture = self.add_fixture("invalid-config")
+        install = InstallRun(self, fixture.root)
+        install.config_file().parent.mkdir(parents=True)
+        install.config_file().write_text('[corpus]\nsource = "carrier-pigeon"\n', encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "corpus")
+        for surface in [".claude", ".agents", ".groundwork"]:
+            self.assertFalse((install.home / surface).exists(), f"{surface} must be untouched")
+
+    def test_unreachable_corpus_git_source_fails_loudly_without_target_mutation(self) -> None:
+        fixture = self.add_fixture("unreachable-corpus")
+        install = InstallRun(self, fixture.root)
+        unreachable = self.make_corpus_repository("unreachable")
+        url = f"file://{unreachable}"
+        shutil.rmtree(unreachable)
+
+        result = install.run_installer("install", "--corpus-git", url)
+
+        assert_failure_contains(self, result, "cannot fetch corpus repository")
+        for surface in [".claude", ".agents", ".groundwork"]:
+            self.assertFalse((install.home / surface).exists(), f"{surface} must be untouched")
+
+    def test_no_shell_startup_file_created_or_modified(self) -> None:
+        fixture = self.add_fixture("no-startup-files")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertEqual(
+            {path.name for path in install.home.iterdir()},
+            {".claude", ".agents", ".groundwork"},
+        )
+
+    def test_state_lives_under_self_install_namespace_distinct_from_legacy(self) -> None:
+        fixture = self.add_fixture("state-namespace")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install", include_state_dir=False)
+
+        assert_success(self, result)
+        self.assertTrue(
+            (install.home / ".local" / "state" / "groundwork" / "install.tsv").is_file()
+        )
+        self.assertFalse((install.home / ".local" / "state" / "groundwork-install").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -13,6 +13,8 @@ import textwrap
 import unittest
 from pathlib import Path
 
+from tooling.principles_config import PrinciplesCorpusConfig, load_principles_config
+
 
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "scripts" / "install"
@@ -166,7 +168,7 @@ class InstallRun:
         self,
         *args: str,
         include_state_dir: bool = True,
-        env: dict[str, str] | None = None,
+        env: dict[str, str | None] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         self.test.assertTrue(INSTALLER.is_file(), f"installer missing at {INSTALLER}")
         command = [
@@ -185,7 +187,11 @@ class InstallRun:
             "XDG_CONFIG_HOME": str(self.home / ".config"),
         }
         if env:
-            run_env.update(env)
+            for key, value in env.items():
+                if value is None:
+                    run_env.pop(key, None)
+                else:
+                    run_env[key] = value
         return run(command, self.source, env=run_env)
 
     def target(self, root: str, name: str) -> Path:
@@ -300,6 +306,45 @@ class SelfInstallTests(unittest.TestCase):
         )
         self.assertFalse((install.runtime_root() / "principles" / ".git").exists())
 
+    def test_home_option_supplies_derived_paths_over_ambient_environment(self) -> None:
+        fixture = self.add_fixture("home-derived-paths")
+        corpus = self.make_corpus_repository("home-derived")
+        install = InstallRun(self, fixture.root)
+        ambient_home = Path(tempfile.mkdtemp(prefix="groundwork-self-install-ambient-home-"))
+        ambient_state = Path(tempfile.mkdtemp(prefix="groundwork-self-install-ambient-state-"))
+        self.addCleanup(lambda: shutil.rmtree(ambient_home, ignore_errors=True))
+        self.addCleanup(lambda: shutil.rmtree(ambient_state, ignore_errors=True))
+
+        result = install.run_installer(
+            "install",
+            "--corpus-git",
+            f"file://{corpus}",
+            include_state_dir=False,
+            env={
+                "HOME": str(ambient_home),
+                "XDG_CONFIG_HOME": None,
+                "XDG_STATE_HOME": str(ambient_state),
+            },
+        )
+
+        assert_success(self, result)
+        self.assertTrue(install.config_file().is_file())
+        self.assertEqual(
+            load_principles_config(install.config_file()),
+            PrinciplesCorpusConfig(source="git", url=f"file://{corpus}"),
+        )
+        self.assertFalse(
+            (ambient_home / ".config" / "groundwork").exists(),
+            "ambient HOME config tree must be untouched",
+        )
+        self.assertTrue(
+            (install.home / ".local" / "state" / "groundwork" / "install.tsv").is_file()
+        )
+        self.assertFalse(
+            (ambient_state / "groundwork").exists(),
+            "ambient XDG_STATE_HOME must not receive derived state",
+        )
+
 
     def test_absent_input_honors_existing_config(self) -> None:
         fixture = self.add_fixture("existing-config")
@@ -333,6 +378,22 @@ class SelfInstallTests(unittest.TestCase):
         assert_success(self, result)
         after = install.config_file().stat()
         self.assertEqual((before.st_ino, before.st_mtime_ns), (after.st_ino, after.st_mtime_ns))
+
+    def test_explicit_corpus_input_replaces_invalid_existing_config(self) -> None:
+        fixture = self.add_fixture("explicit-input-replaces-invalid-config")
+        corpus = self.make_corpus_repository("recovery")
+        install = InstallRun(self, fixture.root)
+        url = f"file://{corpus}"
+        install.config_file().parent.mkdir(parents=True)
+        install.config_file().write_text("[corpus\n", encoding="utf-8")
+
+        result = install.run_installer("install", "--corpus-git", url)
+
+        assert_success(self, result)
+        self.assertEqual(
+            load_principles_config(install.config_file()),
+            PrinciplesCorpusConfig(source="git", url=url),
+        )
 
 
     def stat_snapshot(self, *directories: Path) -> dict[str, tuple[int, int]]:
@@ -535,6 +596,11 @@ class SelfInstallTests(unittest.TestCase):
         assert_failure_contains(self, result, "cannot fetch corpus repository")
         for surface in [".claude", ".agents", ".groundwork"]:
             self.assertFalse((install.home / surface).exists(), f"{surface} must be untouched")
+        self.assertEqual(
+            list(install.home.glob(".groundwork.corpus.*")),
+            [],
+            "failed materialization must remove corpus staging directories",
+        )
 
     def test_no_shell_startup_file_created_or_modified(self) -> None:
         fixture = self.add_fixture("no-startup-files")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6,6 +6,7 @@ runtime bundle, and principles-corpus recording + materialization. It never
 delivers protocol content — that is the runtime's channel.
 """
 
+import os
 import shutil
 import subprocess
 import tempfile
@@ -667,6 +668,45 @@ class SelfInstallTests(unittest.TestCase):
             {path.name for path in install.home.iterdir()},
             {".claude", ".agents", ".groundwork"},
         )
+
+    def test_marker_owned_entry_with_stale_state_sha_is_not_a_conflict(self) -> None:
+        fixture = self.add_fixture("partial-failure-recovery")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        # Simulate a later run that updated the skill marker to a new
+        # source-sha but failed before rewriting install.tsv: the marker and
+        # the state row now disagree on the sha, though both are this
+        # installer's own records.
+        marker = install.target(".claude", "orient") / ".groundwork-managed"
+        marker.write_text(
+            marker.read_text(encoding="utf-8").replace(
+                f"source-sha={fixture.head_sha()}", "source-sha=0" * 1
+            ),
+            encoding="utf-8",
+        )
+        stale = marker.read_text(encoding="utf-8")
+        self.assertIn("source-sha=0\n", stale)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertIn(
+            f"source-sha={fixture.head_sha()}",
+            (install.target(".claude", "orient") / ".groundwork-managed").read_text(encoding="utf-8"),
+        )
+
+    def test_rerun_restores_resolver_executable_bit(self) -> None:
+        fixture = self.add_fixture("resolver-mode-drift")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        resolver = install.runtime_root() / "bin" / "groundwork-mechanic"
+        resolver.chmod(0o644)
+        self.assertFalse(os.access(resolver, os.X_OK))
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertTrue(os.access(resolver, os.X_OK), "rerun must restore the resolver executable bit")
 
     def test_state_lives_under_self_install_namespace_distinct_from_legacy(self) -> None:
         fixture = self.add_fixture("state-namespace")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -450,6 +450,60 @@ class SelfInstallTests(unittest.TestCase):
         self.assertFalse((install.home / ".agents").exists(), "preflight must halt before any install")
         self.assertFalse(install.runtime_root().exists(), "preflight must halt before any install")
 
+    def test_state_listed_skill_missing_marker_fails_loudly_and_preserves_drift(self) -> None:
+        fixture = self.add_fixture("state-listed-missing-marker")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        target = install.target(".agents", "orient")
+        (target / MARKER_NAME).unlink()
+        (target / "SKILL.md").write_text("operator rewrite\n", encoding="utf-8")
+        local_only = target / "operator-note.md"
+        local_only.write_text("operator note\n", encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "unmanaged conflict")
+        assert_failure_contains(self, result, str(target))
+        self.assertEqual((target / "SKILL.md").read_text(encoding="utf-8"), "operator rewrite\n")
+        self.assertEqual(local_only.read_text(encoding="utf-8"), "operator note\n")
+
+    def test_state_listed_skill_replaced_without_marker_fails_loudly(self) -> None:
+        fixture = self.add_fixture("state-listed-replaced")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        target = install.target(".agents", "reckon")
+        shutil.rmtree(target)
+        target.mkdir()
+        replacement = target / "SKILL.md"
+        replacement.write_text("operator replacement\n", encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "unmanaged conflict")
+        assert_failure_contains(self, result, str(target))
+        self.assertEqual(replacement.read_text(encoding="utf-8"), "operator replacement\n")
+        self.assertFalse((target / MARKER_NAME).exists())
+
+    def test_state_listed_skill_with_valid_marker_updates_normally(self) -> None:
+        fixture = self.add_fixture("state-listed-valid-marker")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        body = "---\nname: orient\n---\n# Orient v2\n"
+        fixture.write("skills/orient/SKILL.md", body)
+        fixture.commit("update orient")
+        sha = fixture.head_sha()
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        for root in [".claude", ".agents"]:
+            target = install.target(root, "orient")
+            self.assertEqual((target / "SKILL.md").read_text(encoding="utf-8"), body)
+            self.assertIn(
+                f"source-sha={sha}\n",
+                (target / MARKER_NAME).read_text(encoding="utf-8"),
+            )
+
 
     def test_legacy_installed_entry_is_a_named_conflict_directing_to_legacy_uninstall(self) -> None:
         fixture = self.add_fixture("legacy-conflict")

--- a/tests/test_principles_config.py
+++ b/tests/test_principles_config.py
@@ -1,5 +1,6 @@
 import json
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -12,7 +13,9 @@ from tooling.principles_config import (
     default_config_path,
     load_principles_config,
     parse_principles_config,
+    render_principles_config,
     resolved_corpus_path,
+    write_principles_config,
 )
 
 
@@ -153,6 +156,46 @@ class NamedConceptTests(unittest.TestCase):
 
     def test_embedded_corpus_path_is_in_tree(self) -> None:
         self.assertEqual(EMBEDDED_CORPUS_PATH, ROOT / "principles")
+
+
+class RenderConfigTests(unittest.TestCase):
+    """Rendering produces canonical TOML the parser reads back to an equal
+    config — the recording surface the self-installer writes operator corpus
+    inputs through."""
+
+    CONFIGS = [
+        PrinciplesCorpusConfig.embedded(),
+        PrinciplesCorpusConfig(source="path", path=Path("/srv/corpus")),
+        PrinciplesCorpusConfig(source="git", url="https://example.org/owner/corpus"),
+        PrinciplesCorpusConfig(source="git", url="https://example.org/owner/corpus", ref="v1.0.0"),
+    ]
+
+    def test_render_round_trips_every_source_kind(self) -> None:
+        for config in self.CONFIGS:
+            with self.subTest(config=config):
+                rendered = render_principles_config(config)
+
+                self.assertEqual(parse_principles_config(tomllib.loads(rendered)), config)
+
+    def test_render_escapes_quotes_and_backslashes_in_operator_values(self) -> None:
+        config = PrinciplesCorpusConfig(
+            source="git",
+            url='https://example.org/o"dd\\corpus',
+            ref='re"f\\1',
+        )
+
+        rendered = render_principles_config(config)
+
+        self.assertEqual(parse_principles_config(tomllib.loads(rendered)), config)
+
+    def test_write_creates_parent_directories_and_loads_back_equal(self) -> None:
+        config = PrinciplesCorpusConfig(source="git", url="https://example.org/owner/corpus")
+        with tempfile.TemporaryDirectory() as directory:
+            config_file = Path(directory) / "groundwork" / "principles.toml"
+
+            write_principles_config(config, config_file)
+
+            self.assertEqual(load_principles_config(config_file), config)
 
 
 class SchemaAgreementTests(unittest.TestCase):

--- a/tooling/install.py
+++ b/tooling/install.py
@@ -382,8 +382,17 @@ def write_state(options: Options, sha: str, skills: list[str]) -> None:
     temporary.replace(state_file)
 
 
-def state_owns_target(state_rows: list[tuple[str, str, str, str, str]], target: Path) -> bool:
-    return any(row[0] == str(target) for row in state_rows)
+def state_owns_target(
+    options: Options,
+    state_rows: list[tuple[str, str, str, str, str]],
+    target: Path,
+) -> bool:
+    """A state row is only evidence; the marker is the ownership authority."""
+    return any(
+        row_target == str(target)
+        and marker_matches(target, options.source, sha, kind, name)
+        for row_target, name, kind, sha, _root in state_rows
+    )
 
 
 def install_skill(source: Path, sha: str, name: str, target: Path) -> None:
@@ -423,7 +432,7 @@ def preflight_conflicts(options: Options, skills: list[str]) -> None:
     for root in target_roots(options.home):
         for name in skills:
             target = root / name
-            if target.exists() and not state_owns_target(state_rows, target):
+            if target.exists() and not state_owns_target(options, state_rows, target):
                 conflicts.append(target)
     runtime_root = options.home / ".groundwork"
     if runtime_root.exists() and not (runtime_root / MARKER_NAME).is_file():
@@ -474,7 +483,11 @@ def converge_skills(options: Options, sha: str, skills: list[str]) -> None:
             target = root / name
             if skill_is_current(options, state_rows, sha, name, root, desired):
                 continue
-            if state_owns_target(state_rows, target) and target.is_dir() and tree_payload(target) == desired:
+            if (
+                state_owns_target(options, state_rows, target)
+                and target.is_dir()
+                and tree_payload(target) == desired
+            ):
                 write_marker(target, options.source, sha, "skill", name)
                 continue
             install_skill(options.source, sha, name, target)

--- a/tooling/install.py
+++ b/tooling/install.py
@@ -278,6 +278,10 @@ def converge_runtime_bundle(options: Options, sha: str) -> None:
         if runtime_root.is_dir() and tree_payload(staging, include_marker=True) == bundle_payload(
             runtime_root
         ):
+            # Byte-identical contents do not imply correct modes: restore the
+            # resolver's executable bit if it drifted, since that is not
+            # captured by the payload comparison.
+            ensure_resolver_executable(runtime_root / "bin" / "groundwork-mechanic")
             return
         runtime_root.mkdir(parents=True, exist_ok=True)
         for child in RUNTIME_BUNDLE_CHILDREN:
@@ -289,6 +293,16 @@ def converge_runtime_bundle(options: Options, sha: str) -> None:
             (staging / child).replace(current)
     finally:
         shutil.rmtree(staging, ignore_errors=True)
+
+
+def ensure_resolver_executable(resolver: Path) -> None:
+    """Add the execute bits to the resolver if missing; idempotent, so it
+    leaves an already-executable resolver (and its mtime) untouched."""
+    if not resolver.is_file():
+        return
+    mode = resolver.stat().st_mode
+    if mode & 0o111 != 0o111:
+        resolver.chmod(mode | 0o111)
 
 
 def bundle_payload(runtime_root: Path) -> dict[str, bytes]:
@@ -323,6 +337,18 @@ def marker_matches(target: Path, source: Path, sha: str, kind: str, name: str) -
     if not marker.is_file():
         return False
     return marker.read_text(encoding="utf-8") == marker_content(source, sha, kind, name)
+
+
+def marker_is_ours(target: Path) -> bool:
+    """Ownership authority, independent of which commit the marker records.
+
+    A managed entry stays ours across version changes and across a run that
+    updated the marker but failed before recording state — so ownership is
+    the `managed-by` line alone, never the recorded source-sha."""
+    marker = target / MARKER_NAME
+    if not marker.is_file():
+        return False
+    return f"managed-by={MANAGED_BY}\n" in marker.read_text(encoding="utf-8")
 
 
 def tree_payload(directory: Path, *, include_marker: bool = False) -> dict[str, bytes]:
@@ -383,16 +409,14 @@ def write_state(options: Options, sha: str, skills: list[str]) -> None:
 
 
 def state_owns_target(
-    options: Options,
     state_rows: list[tuple[str, str, str, str, str]],
     target: Path,
 ) -> bool:
-    """A state row is only evidence; the marker is the ownership authority."""
-    return any(
-        row_target == str(target)
-        and marker_matches(target, options.source, sha, kind, name)
-        for row_target, name, kind, sha, _root in state_rows
-    )
+    """Owned iff state records this target path and it still carries our
+    marker. The marker's recorded sha is deliberately not consulted — a
+    partially-failed update can leave the marker ahead of the state row,
+    and the entry is still ours."""
+    return any(row[0] == str(target) for row in state_rows) and marker_is_ours(target)
 
 
 def install_skill(source: Path, sha: str, name: str, target: Path) -> None:
@@ -432,7 +456,7 @@ def preflight_conflicts(options: Options, skills: list[str]) -> None:
     for root in target_roots(options.home):
         for name in skills:
             target = root / name
-            if target.exists() and not state_owns_target(options, state_rows, target):
+            if target.exists() and not state_owns_target(state_rows, target):
                 conflicts.append(target)
     runtime_root = options.home / ".groundwork"
     if runtime_root.exists() and not (runtime_root / MARKER_NAME).is_file():
@@ -484,7 +508,7 @@ def converge_skills(options: Options, sha: str, skills: list[str]) -> None:
             if skill_is_current(options, state_rows, sha, name, root, desired):
                 continue
             if (
-                state_owns_target(options, state_rows, target)
+                state_owns_target(state_rows, target)
                 and target.is_dir()
                 and tree_payload(target) == desired
             ):

--- a/tooling/install.py
+++ b/tooling/install.py
@@ -81,6 +81,7 @@ def parse_args(argv: list[str], environment: dict[str, str]) -> Options:
 
     source = Path(".")
     home = Path(environment["HOME"]) if environment.get("HOME") else None
+    home_from_argument = False
     state_dir: Path | None = None
     corpus_flags: dict[str, str | bool] = {}
     index = 0
@@ -93,6 +94,7 @@ def parse_args(argv: list[str], environment: dict[str, str]) -> Options:
             index += 2
         elif flag == "--home":
             home = Path(arguments[index + 1])
+            home_from_argument = True
             index += 2
         elif flag == "--state-dir":
             state_dir = Path(arguments[index + 1])
@@ -116,11 +118,13 @@ def parse_args(argv: list[str], environment: dict[str, str]) -> Options:
     corpus_input = parse_corpus_input(corpus_flags)
     home = home.resolve()
     if state_dir is None:
-        xdg_state_home = environment.get("XDG_STATE_HOME")
+        xdg_state_home = None if home_from_argument else environment.get("XDG_STATE_HOME")
         state_root = Path(xdg_state_home) if xdg_state_home else home / ".local" / "state"
         state_dir = state_root / "groundwork"
     config_environment = dict(environment)
-    config_environment.setdefault("HOME", str(home))
+    if home_from_argument:
+        config_environment.pop("XDG_CONFIG_HOME", None)
+    config_environment["HOME"] = str(home)
     return Options(
         mode=mode,
         source=source.resolve(),
@@ -496,7 +500,11 @@ def record_corpus_config(options: Options) -> None:
     if options.corpus_input is None:
         return
     if options.config_path.exists():
-        if load_principles_config(options.config_path) == options.corpus_input:
+        try:
+            existing_config = load_principles_config(options.config_path)
+        except PrinciplesConfigError:
+            existing_config = None
+        if existing_config == options.corpus_input:
             return
     write_principles_config(options.corpus_input, options.config_path)
 
@@ -508,7 +516,11 @@ def stage_corpus(options: Options, config: PrinciplesCorpusConfig) -> Path:
     index-less corpus aborts the run with nothing changed."""
     staging_parent = Path(tempfile.mkdtemp(prefix=".groundwork.corpus.", dir=options.home))
     staged = staging_parent / "corpus"
-    materialize(config, embedded_corpus_path(options.source), staged)
+    try:
+        materialize(config, embedded_corpus_path(options.source), staged)
+    except BaseException:
+        shutil.rmtree(staging_parent, ignore_errors=True)
+        raise
     return staged
 
 

--- a/tooling/install.py
+++ b/tooling/install.py
@@ -1,0 +1,590 @@
+"""Methodology self-install for runtime-driven deployments.
+
+Serves deployments where a protocol runtime executes the methodology
+through the methodology interface contract: protocol instruction content
+is the contract channel's to deliver, so this installer carries none of
+it. It owns exactly what that channel does not deliver:
+
+- **Skills, verbatim** — every ``skills/<name>/`` carrying a ``SKILL.md``
+  installs unmodified into the agent harnesses' native skill-discovery
+  locations. No projection, no transformation of any shipped file.
+- **The methodology runtime** — ``~/.groundwork`` with the
+  ``groundwork-mechanic`` resolver, the ``mechanics/`` set, the
+  forge-operations module, and the manifest.
+- **The principles corpus** — an operator input recorded into the
+  deployment-owned config (ADR-0005) and materialized at
+  ``~/.groundwork/principles`` through the existing resolution layer.
+
+Deliberately stdlib-only, like the rest of ``tooling/``: the install path
+runs in deployments that carry no third-party packages.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+
+if __package__ in (None, ""):  # invoked as a script
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tooling.corpus_resolution import CorpusResolutionError, check_resolvable, materialize
+from tooling.principles_config import (
+    PrinciplesConfigError,
+    PrinciplesCorpusConfig,
+    default_config_path,
+    load_principles_config,
+    parse_principles_config,
+    resolved_corpus_path,
+    write_principles_config,
+)
+
+PROGRAM = "install"
+
+# Ownership identity. Deliberately distinct from the legacy interactive
+# installer (`.groundwork-install`, `managed-by=groundwork-install`) so
+# neither installer can mistake the other's entries for its own.
+MARKER_NAME = ".groundwork-managed"
+MANAGED_BY = "groundwork scripts/install"
+STATE_FILE_NAME = "install.tsv"
+
+# The legacy interactive installer's marker. Entries it placed are never
+# adopted — the operator is directed to its own uninstall instead.
+LEGACY_MARKER_NAME = ".groundwork-install"
+
+
+class InstallError(Exception):
+    """A named, loud installation failure."""
+
+
+@dataclass(frozen=True)
+class Options:
+    mode: str
+    source: Path
+    home: Path
+    state_dir: Path
+    config_path: Path
+    corpus_input: PrinciplesCorpusConfig | None
+
+
+def parse_args(argv: list[str], environment: dict[str, str]) -> Options:
+    mode = "install"
+    arguments = list(argv)
+    if arguments and arguments[0] in ("install", "uninstall"):
+        mode = arguments.pop(0)
+
+    source = Path(".")
+    home = Path(environment["HOME"]) if environment.get("HOME") else None
+    state_dir: Path | None = None
+    corpus_flags: dict[str, str | bool] = {}
+    index = 0
+    while index < len(arguments):
+        flag = arguments[index]
+        if flag.startswith("--") and flag != "--corpus-embedded" and index + 1 >= len(arguments):
+            raise InstallError(f"{flag} requires a value")
+        if flag == "--source":
+            source = Path(arguments[index + 1])
+            index += 2
+        elif flag == "--home":
+            home = Path(arguments[index + 1])
+            index += 2
+        elif flag == "--state-dir":
+            state_dir = Path(arguments[index + 1])
+            index += 2
+        elif flag == "--corpus-git":
+            corpus_flags["git"] = arguments[index + 1]
+            index += 2
+        elif flag == "--corpus-ref":
+            corpus_flags["ref"] = arguments[index + 1]
+            index += 2
+        elif flag == "--corpus-path":
+            corpus_flags["path"] = arguments[index + 1]
+            index += 2
+        elif flag == "--corpus-embedded":
+            corpus_flags["embedded"] = True
+            index += 1
+        else:
+            raise InstallError(f"unknown argument: {flag}")
+    if home is None:
+        raise InstallError("HOME is not set; pass --home")
+    corpus_input = parse_corpus_input(corpus_flags)
+    home = home.resolve()
+    if state_dir is None:
+        xdg_state_home = environment.get("XDG_STATE_HOME")
+        state_root = Path(xdg_state_home) if xdg_state_home else home / ".local" / "state"
+        state_dir = state_root / "groundwork"
+    config_environment = dict(environment)
+    config_environment.setdefault("HOME", str(home))
+    return Options(
+        mode=mode,
+        source=source.resolve(),
+        home=home,
+        state_dir=state_dir.resolve(),
+        config_path=default_config_path(config_environment),
+        corpus_input=corpus_input,
+    )
+
+
+def parse_corpus_input(corpus_flags: dict[str, str | bool]) -> PrinciplesCorpusConfig | None:
+    """Operator corpus input as a validated config — ADR-0005's discriminated
+    union expressed as mutually exclusive flags."""
+    sources = [key for key in ("git", "path", "embedded") if key in corpus_flags]
+    if len(sources) > 1:
+        raise InstallError(
+            "--corpus-git, --corpus-path, and --corpus-embedded are mutually exclusive"
+        )
+    if "ref" in corpus_flags and "git" not in corpus_flags:
+        raise InstallError("--corpus-ref requires --corpus-git")
+    if not sources:
+        return None
+    corpus: dict[str, str] = {"source": sources[0]}
+    if "git" in corpus_flags:
+        corpus["url"] = str(corpus_flags["git"])
+        if "ref" in corpus_flags:
+            corpus["ref"] = str(corpus_flags["ref"])
+    elif "path" in corpus_flags:
+        corpus["path"] = str(corpus_flags["path"])
+    return parse_principles_config({"corpus": corpus})
+
+
+def git(source: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(source), *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise InstallError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def source_sha(source: Path) -> str:
+    return git(source, "rev-parse", "HEAD").strip()
+
+
+def validate_source(source: Path) -> str:
+    """The source must be a clean checkout root carrying skills; content
+    derives from HEAD, so a dirty tree would install bytes the operator is
+    not looking at. Returns the commit the installation derives from."""
+    if not source.is_dir():
+        raise InstallError(f"source not found: {source}")
+    toplevel = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if toplevel.returncode != 0 or Path(toplevel.stdout.strip()).resolve() != source:
+        raise InstallError(f"source must be the groundwork checkout root: {source}")
+    if git(source, "status", "--porcelain").strip():
+        raise InstallError("source checkout is dirty; install from a clean checkout")
+    sha = source_sha(source)
+    probe = subprocess.run(
+        ["git", "-C", str(source), "cat-file", "-e", f"{sha}:skills"],
+        capture_output=True,
+    )
+    if probe.returncode != 0:
+        raise InstallError(f"source has no skills directory at {sha}")
+    return sha
+
+
+def enumerate_skills(source: Path, sha: str) -> list[str]:
+    """Skill names at the commit — enumerated from the tree, never hardcoded."""
+    names = []
+    for name in sorted(git(source, "ls-tree", "-d", "--name-only", f"{sha}:skills").splitlines()):
+        probe = subprocess.run(
+            ["git", "-C", str(source), "cat-file", "-e", f"{sha}:skills/{name}/SKILL.md"],
+            capture_output=True,
+        )
+        if probe.returncode == 0:
+            names.append(name)
+    return names
+
+
+def target_roots(home: Path) -> list[Path]:
+    return [home / ".claude" / "skills", home / ".agents" / "skills"]
+
+
+def extract_tree(source: Path, sha: str, tree_path: str, destination: Path) -> None:
+    """Materialize ``<sha>:<tree_path>`` verbatim into ``destination``."""
+    archive = subprocess.run(
+        ["git", "-C", str(source), "archive", "--format=tar", f"{sha}:{tree_path}"],
+        capture_output=True,
+    )
+    if archive.returncode != 0:
+        raise InstallError(
+            f"cannot read {tree_path} from source commit: {archive.stderr.decode().strip()}"
+        )
+    destination.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(fileobj=BytesIO(archive.stdout)) as tar:
+        tar.extractall(destination, filter="data")
+
+
+# The resolver wrapper the runtime bundle ships: resolves its own root and
+# execs the bundled forge-operations module.
+RESOLVER_WRAPPER = """\
+#!/usr/bin/env sh
+set -eu
+root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)"
+PYTHONPATH="$root/lib${PYTHONPATH:+:$PYTHONPATH}" exec python3 "$root/lib/tooling/forge_operations.py" --root "$root" "$@"
+"""
+
+
+def show_file(source: Path, sha: str, file_path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(source), "show", f"{sha}:{file_path}"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise InstallError(f"cannot read {file_path} from source commit: {result.stderr.decode().strip()}")
+    return result.stdout
+
+
+def project_runtime_bundle(source: Path, sha: str, target: Path) -> None:
+    """Build the methodology runtime bundle into ``target``."""
+    (target / "bin").mkdir(parents=True, exist_ok=True)
+    (target / "lib" / "tooling").mkdir(parents=True, exist_ok=True)
+    (target / "manifest.toml").write_bytes(show_file(source, sha, "manifest.toml"))
+    extract_tree(source, sha, "mechanics", target / "mechanics")
+    (target / "lib" / "tooling" / "forge_operations.py").write_bytes(
+        show_file(source, sha, "tooling/forge_operations.py")
+    )
+    resolver = target / "bin" / "groundwork-mechanic"
+    resolver.write_text(RESOLVER_WRAPPER, encoding="utf-8")
+    resolver.chmod(0o755)
+
+
+# The runtime-bundle children this installer manages under `~/.groundwork`.
+# The resolved corpus (`principles/`) lives beside them and is converged
+# separately — bundle convergence never rebuilds the whole root.
+RUNTIME_BUNDLE_CHILDREN = ("manifest.toml", "mechanics", "lib", "bin", MARKER_NAME)
+
+
+def converge_runtime_bundle(options: Options, sha: str) -> None:
+    runtime_root = options.home / ".groundwork"
+    staging = Path(tempfile.mkdtemp(prefix=".groundwork.bundle.", dir=options.home))
+    try:
+        project_runtime_bundle(options.source, sha, staging)
+        write_marker(staging, options.source, sha, "runtime", "groundwork")
+        if runtime_root.is_dir() and tree_payload(staging, include_marker=True) == bundle_payload(
+            runtime_root
+        ):
+            return
+        runtime_root.mkdir(parents=True, exist_ok=True)
+        for child in RUNTIME_BUNDLE_CHILDREN:
+            current = runtime_root / child
+            if current.is_dir():
+                shutil.rmtree(current)
+            elif current.exists():
+                current.unlink()
+            (staging / child).replace(current)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def bundle_payload(runtime_root: Path) -> dict[str, bytes]:
+    """The installed runtime bundle's payload, managed children only."""
+    payload = {}
+    for child in RUNTIME_BUNDLE_CHILDREN:
+        path = runtime_root / child
+        if path.is_file():
+            payload[child] = path.read_bytes()
+        elif path.is_dir():
+            for rel, content in tree_payload(path, include_marker=True).items():
+                payload[f"{child}/{rel}"] = content
+    return payload
+
+
+def marker_content(source: Path, sha: str, kind: str, name: str) -> str:
+    return (
+        f"managed-by={MANAGED_BY}\n"
+        f"source={source}\n"
+        f"source-sha={sha}\n"
+        f"name={name}\n"
+        f"kind={kind}\n"
+    )
+
+
+def write_marker(target: Path, source: Path, sha: str, kind: str, name: str) -> None:
+    (target / MARKER_NAME).write_text(marker_content(source, sha, kind, name), encoding="utf-8")
+
+
+def marker_matches(target: Path, source: Path, sha: str, kind: str, name: str) -> bool:
+    marker = target / MARKER_NAME
+    if not marker.is_file():
+        return False
+    return marker.read_text(encoding="utf-8") == marker_content(source, sha, kind, name)
+
+
+def tree_payload(directory: Path, *, include_marker: bool = False) -> dict[str, bytes]:
+    """Relative path → bytes for every file under ``directory``; the
+    ownership marker is excluded unless asked for."""
+    payload = {}
+    for path in sorted(directory.rglob("*")):
+        if path.is_file() and (include_marker or path.name != MARKER_NAME):
+            payload[str(path.relative_to(directory))] = path.read_bytes()
+    return payload
+
+
+def source_payload(source: Path, sha: str, tree_path: str) -> dict[str, bytes]:
+    """Relative path → bytes for ``<sha>:<tree_path>`` straight from git."""
+    archive = subprocess.run(
+        ["git", "-C", str(source), "archive", "--format=tar", f"{sha}:{tree_path}"],
+        capture_output=True,
+    )
+    if archive.returncode != 0:
+        raise InstallError(
+            f"cannot read {tree_path} from source commit: {archive.stderr.decode().strip()}"
+        )
+    payload = {}
+    with tarfile.open(fileobj=BytesIO(archive.stdout)) as tar:
+        for member in tar.getmembers():
+            if member.isfile():
+                extracted = tar.extractfile(member)
+                assert extracted is not None
+                payload[member.name] = extracted.read()
+    return payload
+
+
+def read_state(state_file: Path) -> list[tuple[str, str, str, str, str]]:
+    if not state_file.is_file():
+        return []
+    rows = []
+    for line in state_file.read_text(encoding="utf-8").splitlines():
+        target, name, kind, sha, root = line.split("\t")
+        rows.append((target, name, kind, sha, root))
+    return rows
+
+
+def write_state(options: Options, sha: str, skills: list[str]) -> None:
+    """Record the managed skill entries; a byte-identical state file is
+    left untouched."""
+    lines = []
+    for root in target_roots(options.home):
+        for name in skills:
+            lines.append(f"{root / name}\t{name}\tskill\t{sha}\t{root}")
+    content = "".join(f"{line}\n" for line in lines)
+    state_file = options.state_dir / STATE_FILE_NAME
+    if state_file.is_file() and state_file.read_text(encoding="utf-8") == content:
+        return
+    options.state_dir.mkdir(parents=True, exist_ok=True)
+    temporary = state_file.with_name(state_file.name + ".tmp")
+    temporary.write_text(content, encoding="utf-8")
+    temporary.replace(state_file)
+
+
+def state_owns_target(state_rows: list[tuple[str, str, str, str, str]], target: Path) -> bool:
+    return any(row[0] == str(target) for row in state_rows)
+
+
+def install_skill(source: Path, sha: str, name: str, target: Path) -> None:
+    temporary = Path(tempfile.mkdtemp(prefix=f"{target.name}.tmp.", dir=target.parent))
+    extract_tree(source, sha, f"skills/{name}", temporary)
+    write_marker(temporary, source, sha, "skill", name)
+    if target.exists():
+        shutil.rmtree(target)
+    temporary.replace(target)
+
+
+def skill_is_current(
+    options: Options,
+    state_rows: list[tuple[str, str, str, str, str]],
+    sha: str,
+    name: str,
+    root: Path,
+    desired: dict[str, bytes],
+) -> bool:
+    target = root / name
+    row = (str(target), name, "skill", sha, str(root))
+    if row not in state_rows:
+        return False
+    if not target.is_dir():
+        return False
+    if not marker_matches(target, options.source, sha, "skill", name):
+        return False
+    return tree_payload(target) == desired
+
+
+def preflight_conflicts(options: Options, skills: list[str]) -> None:
+    """Every desired target that already exists must be owned by this
+    installer; anything else is an unmanaged conflict named before any
+    mutation happens."""
+    state_rows = read_state(options.state_dir / STATE_FILE_NAME)
+    conflicts = []
+    for root in target_roots(options.home):
+        for name in skills:
+            target = root / name
+            if target.exists() and not state_owns_target(state_rows, target):
+                conflicts.append(target)
+    runtime_root = options.home / ".groundwork"
+    if runtime_root.exists() and not (runtime_root / MARKER_NAME).is_file():
+        conflicts.append(runtime_root)
+    if conflicts:
+        raise InstallError("; ".join(_describe_conflict(target) for target in conflicts))
+
+
+def _describe_conflict(target: Path) -> str:
+    description = f"unmanaged conflict at {target}"
+    if (target / LEGACY_MARKER_NAME).is_file():
+        description += (
+            " (installed by groundwork-install; run `scripts/groundwork-install uninstall` first)"
+        )
+    return description
+
+
+def remove_obsolete_entries(options: Options, skills: list[str]) -> None:
+    """Remove state-recorded entries no longer shipped by the tree.
+
+    Deletion is gated on this installer's own marker: an obsolete entry
+    that lost its marker fails loudly rather than risking content this
+    installer does not own."""
+    state_rows = read_state(options.state_dir / STATE_FILE_NAME)
+    desired = set(skills)
+    obsolete = [Path(row[0]) for row in state_rows if row[1] not in desired]
+    unmarked = [
+        target
+        for target in obsolete
+        if target.exists() and not (target / MARKER_NAME).is_file()
+    ]
+    if unmarked:
+        raise InstallError(
+            "missing marker on obsolete managed entry: "
+            + ", ".join(str(target) for target in unmarked)
+        )
+    for target in obsolete:
+        if target.is_dir():
+            shutil.rmtree(target)
+
+
+def converge_skills(options: Options, sha: str, skills: list[str]) -> None:
+    state_rows = read_state(options.state_dir / STATE_FILE_NAME)
+    for name in skills:
+        desired = source_payload(options.source, sha, f"skills/{name}")
+        for root in target_roots(options.home):
+            root.mkdir(parents=True, exist_ok=True)
+            target = root / name
+            if skill_is_current(options, state_rows, sha, name, root, desired):
+                continue
+            if state_owns_target(state_rows, target) and target.is_dir() and tree_payload(target) == desired:
+                write_marker(target, options.source, sha, "skill", name)
+                continue
+            install_skill(options.source, sha, name, target)
+
+
+def embedded_corpus_path(source: Path) -> Path:
+    return source / "principles"
+
+
+def effective_corpus_config(options: Options) -> PrinciplesCorpusConfig:
+    """The corpus source this run resolves: the operator input when given,
+    else the existing deployment config, else the embedded default."""
+    if options.corpus_input is not None:
+        return options.corpus_input
+    return load_principles_config(options.config_path)
+
+
+def record_corpus_config(options: Options) -> None:
+    """Record the operator corpus input in the deployment-owned config.
+
+    Only an explicit input writes; a semantically equal existing file is
+    left byte-untouched so a hand-written operator config survives."""
+    if options.corpus_input is None:
+        return
+    if options.config_path.exists():
+        if load_principles_config(options.config_path) == options.corpus_input:
+            return
+    write_principles_config(options.corpus_input, options.config_path)
+
+
+def stage_corpus(options: Options, config: PrinciplesCorpusConfig) -> Path:
+    """Materialize the configured corpus into a staging location under home.
+
+    Staging happens before any target mutation: an unreachable remote or an
+    index-less corpus aborts the run with nothing changed."""
+    staging_parent = Path(tempfile.mkdtemp(prefix=".groundwork.corpus.", dir=options.home))
+    staged = staging_parent / "corpus"
+    materialize(config, embedded_corpus_path(options.source), staged)
+    return staged
+
+
+def swap_corpus(options: Options, staged: Path) -> None:
+    """Move the staged corpus into place; a byte-identical resolved corpus
+    is left untouched."""
+    target = resolved_corpus_path(options.home / ".groundwork")
+    if target.is_dir() and tree_payload(target) == tree_payload(staged):
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        shutil.rmtree(target)
+    staged.replace(target)
+
+
+def install(options: Options) -> None:
+    sha = validate_source(options.source)
+    skills = enumerate_skills(options.source, sha)
+    corpus_config = effective_corpus_config(options)
+    check_resolvable(corpus_config, embedded_corpus_path(options.source))
+    preflight_conflicts(options, skills)
+    staged_corpus = stage_corpus(options, corpus_config)
+    try:
+        record_corpus_config(options)
+        remove_obsolete_entries(options, skills)
+        converge_skills(options, sha, skills)
+        converge_runtime_bundle(options, sha)
+        swap_corpus(options, staged_corpus)
+    finally:
+        shutil.rmtree(staged_corpus.parent, ignore_errors=True)
+    write_state(options, sha, skills)
+    print(f"{PROGRAM}: installed {sha}")
+
+
+def uninstall(options: Options) -> None:
+    """Marker-verified removal of every managed entry and the runtime root.
+
+    The resolved corpus is materialized content this installer owns and
+    leaves with the runtime root; the deployment-owned config file is
+    recorded into, never deleted."""
+    state_file = options.state_dir / STATE_FILE_NAME
+    if not state_file.is_file():
+        raise InstallError("not installed")
+    state_rows = read_state(state_file)
+    targets = [Path(row[0]) for row in state_rows]
+    runtime_root = options.home / ".groundwork"
+    if runtime_root.exists():
+        targets.append(runtime_root)
+    unmarked = [
+        target
+        for target in targets
+        if target.exists() and not (target / MARKER_NAME).is_file()
+    ]
+    if unmarked:
+        raise InstallError(
+            "missing marker on managed entry: " + ", ".join(str(target) for target in unmarked)
+        )
+    for target in targets:
+        if target.is_dir():
+            shutil.rmtree(target)
+    state_file.unlink()
+    print(f"{PROGRAM}: uninstalled")
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        options = parse_args(sys.argv[1:] if argv is None else argv, dict(os.environ))
+        if options.mode == "uninstall":
+            uninstall(options)
+        else:
+            install(options)
+    except (InstallError, PrinciplesConfigError, CorpusResolutionError) as error:
+        print(f"{PROGRAM}: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tooling/principles_config.py
+++ b/tooling/principles_config.py
@@ -118,6 +118,39 @@ def load_principles_config(
     return parse_principles_config(document)
 
 
+def render_principles_config(config: PrinciplesCorpusConfig) -> str:
+    """Render a configured source as canonical TOML.
+
+    The recording surface for operator corpus inputs: the self-installer
+    writes what the operator supplied through here, and what this renders
+    always parses back to an equal config (round-trip invariant held by
+    tests/test_principles_config.py).
+    """
+    lines = ["[corpus]", f"source = {_toml_string(config.source)}"]
+    if config.path is not None:
+        lines.append(f"path = {_toml_string(str(config.path))}")
+    if config.url is not None:
+        lines.append(f"url = {_toml_string(config.url)}")
+    if config.ref is not None:
+        lines.append(f"ref = {_toml_string(config.ref)}")
+    return "\n".join(lines) + "\n"
+
+
+def write_principles_config(config: PrinciplesCorpusConfig, path: Path | str) -> None:
+    """Atomically record a configured source at ``path``, creating parents."""
+    config_path = Path(path)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = config_path.with_name(config_path.name + ".tmp")
+    temporary.write_text(render_principles_config(config), encoding="utf-8")
+    temporary.replace(config_path)
+
+
+def _toml_string(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    escaped = "".join(f"\\u{ord(ch):04x}" if ord(ch) < 0x20 or ch == "\x7f" else ch for ch in escaped)
+    return f'"{escaped}"'
+
+
 def parse_principles_config(document: dict[str, Any]) -> PrinciplesCorpusConfig:
     errors = _schema_errors(document)
     if errors:


### PR DESCRIPTION
## Summary

- Adds `scripts/install` (logic in `tooling/install.py`, stdlib-only): the methodology self-install for runtime-driven deployments, owning exactly what the methodology interface contract channel does not deliver — skills verbatim, the `~/.groundwork` methodology runtime, and the principles corpus.
- Carries none of the legacy projection machinery: no PROTOCOL.md→SKILL.md projection, no session-surface handoff insertion, no resolver-reference rewriting. The legacy `scripts/groundwork-install` is untouched; its retirement is #415.
- The corpus source is an operator input (`--corpus-git URL [--corpus-ref REF]` | `--corpus-path PATH` | `--corpus-embedded`), recorded into the deployment-owned `principles.toml` (ADR-0005) and materialized through the existing resolution layer. Absent input → existing config honored; absent both → embedded default.

## Changes

- `tooling/install.py` + `scripts/install` — installer: clean-checkout-root validation (content derives from `HEAD`; recorded `source-sha` is the trace; no pinned-ref gate), tree-enumerated skills into both native discovery roots, runtime bundle with `bin/groundwork-mechanic`, corpus staging before any target mutation (resolution errors surface unmodified), compare-before-swap convergence on every surface, marker-gated pruning and uninstall, marker-verified state-listed skill ownership, and named-path conflict preflight that directs legacy-installed entries to `groundwork-install uninstall` (never adopts).
- `tooling/principles_config.py` — gains `render_principles_config`/`write_principles_config` (canonical TOML with escaping; parse round-trip invariant; atomic write). Recording skips a semantically equal existing file so hand-written operator configs survive byte-untouched.
- Ownership identity disjoint from legacy: `.groundwork-managed` markers, state at `${XDG_STATE_HOME:-~/.local/state}/groundwork/install.tsv`.
- Docs: README "Install for Runtime-Driven Deployments" section + deprecation pointer on the protocols-as-skills section; `docs/principles-corpus.md` recording path; ADR-0006 with register row; CHANGELOG.

## GitHub Issue(s)

Closes #416

## Test plan

- `python -m unittest tests.test_install -v` — 26 behavior tests mapped to the issue's verification bullets: skills byte-identical in both roots, protocols never land, no `groundwork-mechanic` rewriting, resolver executes, operator input recorded + materialized with readable index, existing config honored byte-untouched, embedded zero-config, second run exits 0 with no managed inode/mtime change, stale skill pruned, unmanaged/legacy conflicts named and untouched, state-listed skills without a valid `.groundwork-managed` marker fail loudly and preserve content, intact-marker managed updates still converge, invalid config and unreachable remote halt before any target mutation, dirty source rejected, markers record `managed-by` + source commit, no shell startup file created, uninstall removes only owned entries and preserves `principles.toml`, state namespace distinct from legacy.
- `python -m unittest discover -s tests` (328 OK), `python -m tooling.conformance` (36 PASS), and `git diff --check` — CI parity plus whitespace guard.
- Smoke on this real checkout from an empty `$HOME`: first run installs all three surfaces and the mechanic resolves `close-out`; second run exits 0 with every managed inode/mtime unchanged; uninstall leaves only unmanaged content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
