### PR TITLE
[codex] Consume target project payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Forge operation resolution now consumes runa's structured
+  `RUNA_TARGET_PROJECT` payload. `groundwork-mechanic` resolves
+  deployment-owned values from a selected configured repository or tracker,
+  accepts only selector inputs such as `repository_selector` and
+  `tracker_selector` from agents, and rejects the retired `RUNA_FORGE_*`
+  identity atoms.
 - README hero rewritten for the ecosystem README pass: groundwork positioned
   as software delivery expressed as an enforceable methodology — evidence-
   gated completion, CI-gated documentation coherence, forge-agnostic

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ When `manifest.toml`, `mechanics/`, and the forge-operation resolver are
 present, the installer also projects a managed runtime bundle under
 `~/.groundwork/`. The bundle contains the manifest, mechanic library, resolver
 module, and `bin/groundwork-mechanic`, so installed protocol sessions can
-resolve forge-invariant operations through the active `RUNA_FORGE_TYPE`
-configuration without reaching back into the source checkout. Installed
+resolve forge-invariant operations through the active `RUNA_TARGET_PROJECT`
+payload without reaching back into the source checkout. Installed
 protocol copies reference the managed resolver path directly, so users do not
 need to add `~/.groundwork/bin` to `PATH`.
 
@@ -181,29 +181,27 @@ than from `NAME=VALUE` argv bindings. For example, pass
 from the current process environment without placing the secret value in the
 resolver command line.
 
-Forge deployment identity is also supplied by environment contract, not by
-mechanic call-site bindings. Mechanics mark deployment-resolved parameters with
-`deployment_value`, and `groundwork-mechanic` derives those values from these
-atoms:
+Forge deployment identity is supplied by runa's structured project payload, not
+by mechanic call-site coordinates. Mechanics mark deployment-resolved
+parameters with `deployment_value`, and `groundwork-mechanic` derives those
+values from the selected configured repository or tracker in
+`RUNA_TARGET_PROJECT`:
 
-| Variable | Holds | Example | Forge-assigned? |
+| Source | Holds | Example | Forge-assigned? |
 |---|---|---|---|
-| `RUNA_FORGE_TYPE` | active forge selector, defaulting to `github` | `sourcehut` | no |
-| `RUNA_FORGE_OWNER` | tracker/repo owner handle | `operator` | no |
-| `RUNA_FORGE_NAME` | tracker/repo name | `weforge` | no |
-| `RUNA_FORGE_TRACKER_ID` | tracker integer ID | `4` | yes |
-| `GROUNDWORK_FORGE_ENDPOINT` | deployment host used to derive service hosts | `weforge.build` | no |
+| `RUNA_TARGET_PROJECT.forge_type` | active forge type | `sourcehut` | no |
+| repository selector | configured repo owner/name/host | `repository_selector=groundwork` | no |
+| tracker selector | configured tracker owner/name/host/id | `tracker_selector=weforge` | partly |
 | `GROUNDWORK_FORGE_REPO_ID` | git repo integer ID | `42` | yes |
 
 For SourceHut, the resolver derives `todo_query_url` as
-`https://todo.<endpoint>/query`, `git_query_url` as
-`https://git.<endpoint>/query`, and `ssh_remote` as
-`git@git.<endpoint>:~<owner>/<name>`, while `tracker_id` and `repo_id` come
-directly from their atoms. For GitHub, it derives `repository` as
-`<owner>/<name>`. Runa owns the four scoped identity atoms it injects into
-agent and MCP environments; Groundwork still owns endpoint and repo-id atoms
-that are not part of runtime scoped identity. The atoms are the only deployment
-facts; composed endpoints and remotes are not separate configuration values.
+`https://todo.<tracker-host>/query`, `git_query_url` as
+`https://git.<repo-host>/query`, and `ssh_remote` as
+`git@git.<repo-host>:~<owner>/<name>`, while `tracker_id` comes from the
+configured tracker and `repo_id` remains the forge-assigned Groundwork value.
+For GitHub, it derives `repository` as `<owner>/<name>`. The agent may provide
+`repository_selector` or `tracker_selector`; it must never provide owner/name
+coordinates or deployment-resolved parameter values.
 
 The cross-repo seam for this ticket identity is documented in
 [`docs/architecture/connecting-structure.md`](docs/architecture/connecting-structure.md#phase-2-forge-tagging-seam).

--- a/docs/architecture/decisions/0004-contract-first-scoped-pipeline.md
+++ b/docs/architecture/decisions/0004-contract-first-scoped-pipeline.md
@@ -248,9 +248,9 @@ context to fire passively — with full expositions in references.
   further methodology change.
 - **Forge identity namespace.** The protocols reference only invariant
   operations resolved through `groundwork-mechanic`; the resolver reads the
-  runtime-owned `RUNA_FORGE_*` identity atoms (the #389/#390 repair, on
-  which this redesign now sits), with endpoint and repo-id remaining
-  methodology-owned atoms.
+  runtime-owned `RUNA_TARGET_PROJECT` payload and selector inputs (successor
+  to the #389/#390 identity repair), with forge-assigned repo-id remaining
+  methodology-owned where needed.
 - **Best-of-field call — verify may repair its own gate failures.** When
   fresh verification fails, verify's instructions route through `debug` and
   permit the minimal fix within the increment (then a fresh full gate)

--- a/docs/architecture/decisions/0005-principles-corpus-configuration.md
+++ b/docs/architecture/decisions/0005-principles-corpus-configuration.md
@@ -50,10 +50,10 @@ in the shipped manifest crosses that boundary.
 
 ### Why not environment atoms
 
-Post-#389, env atoms are runtime-owned session identity (`RUNA_FORGE_*`)
-or narrowly-scoped forge deployment values. The corpus is methodology
-content resolved once at setup, not per-session identity. Env vars also
-offer no structural validation; the repo's established
+Post-#418, runtime session identity is the structured `RUNA_TARGET_PROJECT`
+payload, with mechanics resolving configured repositories and trackers by
+selector. The corpus is methodology content resolved once at setup, not
+per-session identity. Env vars also offer no structural validation; the repo's established
 structural-impossibility tier (TOML + JSON Schema, the C-2/C-3 prior art)
 is available to a file and not to an environment.
 

--- a/skills/acquire/SKILL.md
+++ b/skills/acquire/SKILL.md
@@ -46,7 +46,9 @@ session that entrypoint opens.
    ```
 
    Deployment identity (owner, name, tracker, repository) comes from the
-   runtime-owned `RUNA_FORGE_*` atoms — do not pass it. The mechanic emits
+   runtime-owned `RUNA_TARGET_PROJECT` payload. Pass only configured selectors
+   such as `repository_selector` or `tracker_selector` when the project has
+   more than one matching configured entry; do not pass coordinates. The mechanic emits
    `{handle, title, body, state}` for either forge.
 
 2. **Materialize the artifact body.** Pipe the read-ticket output through

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -55,6 +55,62 @@ def write_fake_command(path: Path, body: str) -> None:
     path.chmod(0o755)
 
 
+def target_project_payload(
+    forge_type: str = "github",
+    *,
+    owner: str = "tesserine",
+    name: str = "runa",
+) -> str:
+    repositories = [
+        {
+            "selector": name,
+            "owner": owner,
+            "name": name,
+            "host": "github.com" if forge_type == "github" else "weforge.build",
+        }
+    ]
+    trackers = []
+    if forge_type == "sourcehut":
+        trackers = [
+            {
+                "selector": name,
+                "repository": name,
+                "owner": owner,
+                "name": name,
+                "host": "weforge.build",
+                "tracker_id": "4",
+            }
+        ]
+    return json.dumps(
+        {
+            "version": 1,
+            "forge_type": forge_type,
+            "repositories": repositories,
+            "trackers": trackers,
+        }
+    )
+
+
+def append_github_target_project(project: Path, *, owner: str, name: str) -> None:
+    project_file = project / ".runa" / "project.toml"
+    content = project_file.read_text(encoding="utf-8")
+    project_file.write_text(
+        content
+        + f"""
+
+[target_project]
+forge_type = "github"
+
+[[target_project.repositories]]
+selector = "{name}"
+owner = "{owner}"
+name = "{name}"
+host = "github.com"
+""",
+        encoding="utf-8",
+    )
+
+
 class MaterializeTicketTests(unittest.TestCase):
     def test_github_ticket_materializes_to_schema_valid_adopted_work_unit(self) -> None:
         mechanic = resolve_operation(ROOT, "read-ticket", forge_type="github")
@@ -79,8 +135,7 @@ class MaterializeTicketTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "runa",
+                    "RUNA_TARGET_PROJECT": target_project_payload(owner="tesserine", name="runa"),
                 },
             ):
                 read = run_invocation(mechanic, {"ticket_number": "188"}, cwd=root)
@@ -149,10 +204,7 @@ class MaterializeTicketTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "RUNA_FORGE_TRACKER_ID": "4",
+                    "RUNA_TARGET_PROJECT": target_project_payload("sourcehut", owner="operator", name="weforge"),
                 },
             ):
                 read = run_invocation(
@@ -255,19 +307,17 @@ class AcquisitionEntryEndToEndTests(unittest.TestCase):
                 cwd=project, capture_output=True, text=True,
             )
             self.assertEqual(init.returncode, 0, f"{init.stdout}\n{init.stderr}")
+            append_github_target_project(project, owner="tesserine", name="runa")
 
             forge_env = {
                 **os.environ,
                 "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                "RUNA_FORGE_OWNER": "tesserine",
-                "RUNA_FORGE_NAME": "runa",
             }
             with mock.patch.dict(
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "runa",
+                    "RUNA_TARGET_PROJECT": target_project_payload(owner="tesserine", name="runa"),
                 },
             ):
                 read = run_invocation(mechanic, {"ticket_number": "188"}, cwd=root)

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -36,14 +36,14 @@ def target_project_payload(
     trackers: list[dict[str, str]] | None = None,
 ) -> str:
     if repositories is None:
-        repositories = [
-            {
-                "selector": "default",
-                "owner": "tesserine",
-                "name": "groundwork",
-                "host": "github.com" if forge_type == "github" else "weforge.build",
-            }
-        ]
+        repository = {
+            "selector": "default",
+            "owner": "tesserine",
+            "name": "groundwork",
+        }
+        if forge_type == "sourcehut":
+            repository["host"] = "weforge.build"
+        repositories = [repository]
     return json.dumps(
         {
             "version": 1,
@@ -616,6 +616,50 @@ cat "{response}"
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual(["https://todo.weforge.build/query", "4"], result.stdout.strip().splitlines())
 
+    def test_cli_rejects_sourcehut_host_deployment_value_without_configured_host(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_sourcehut_tracker_probe_methodology(root)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "run",
+                    "probe",
+                ],
+                env=forge_cli_environment(
+                    RUNA_TARGET_PROJECT=target_project_payload(
+                        "sourcehut",
+                        repositories=[
+                            {
+                                "selector": "weforge",
+                                "owner": "operator",
+                                "name": "weforge",
+                            }
+                        ],
+                        trackers=[
+                            {
+                                "selector": "weforge",
+                                "repository": "weforge",
+                                "owner": "operator",
+                                "name": "weforge",
+                                "tracker_id": "4",
+                            }
+                        ],
+                    ),
+                ),
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("configured tracker is missing required field `host`", result.stderr)
+        self.assertNotIn("github.com", result.stderr)
+
     def test_cli_resolves_sourcehut_repo_only_values_without_tracker_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -775,13 +819,11 @@ cat "{response}"
                         "selector": "runa",
                         "owner": "tesserine",
                         "name": "runa",
-                        "host": "github.com",
                     },
                     {
                         "selector": "groundwork",
                         "owner": "tesserine",
                         "name": "groundwork",
-                        "host": "github.com",
                     },
                 ]
             )
@@ -815,13 +857,11 @@ cat "{response}"
                         "selector": "runa",
                         "owner": "tesserine",
                         "name": "runa",
-                        "host": "github.com",
                     },
                     {
                         "selector": "groundwork",
                         "owner": "tesserine",
                         "name": "groundwork",
-                        "host": "github.com",
                     },
                 ]
             )

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -20,7 +20,8 @@ from tooling.forge_operations import (
 
 ROOT = Path(__file__).resolve().parents[1]
 EARLY_ARC_OPERATIONS = ["create-ticket", "read-ticket", "claim-work-unit", "record-progress"]
-RUNA_FORGE_ENVIRONMENT_ATOMS = (
+RUNA_PROJECT_ENVIRONMENT_ATOMS = (
+    "RUNA_TARGET_PROJECT",
     "RUNA_FORGE_TYPE",
     "RUNA_FORGE_OWNER",
     "RUNA_FORGE_NAME",
@@ -28,10 +29,60 @@ RUNA_FORGE_ENVIRONMENT_ATOMS = (
 )
 
 
+def target_project_payload(
+    forge_type: str = "github",
+    *,
+    repositories: list[dict[str, str]] | None = None,
+    trackers: list[dict[str, str]] | None = None,
+) -> str:
+    if repositories is None:
+        repositories = [
+            {
+                "selector": "default",
+                "owner": "tesserine",
+                "name": "groundwork",
+                "host": "github.com" if forge_type == "github" else "weforge.build",
+            }
+        ]
+    return json.dumps(
+        {
+            "version": 1,
+            "forge_type": forge_type,
+            "repositories": repositories,
+            "trackers": trackers or [],
+        }
+    )
+
+
+def sourcehut_target_project() -> str:
+    return target_project_payload(
+        "sourcehut",
+        repositories=[
+            {
+                "selector": "weforge",
+                "owner": "operator",
+                "name": "weforge",
+                "host": "weforge.build",
+            }
+        ],
+        trackers=[
+            {
+                "selector": "weforge",
+                "repository": "weforge",
+                "owner": "operator",
+                "name": "weforge",
+                "host": "weforge.build",
+                "tracker_id": "4",
+            }
+        ],
+    )
+
+
 def forge_cli_environment(**values: str) -> dict[str, str]:
     environment = os.environ.copy()
-    for atom in RUNA_FORGE_ENVIRONMENT_ATOMS:
+    for atom in RUNA_PROJECT_ENVIRONMENT_ATOMS:
         environment.pop(atom, None)
+    environment["RUNA_TARGET_PROJECT"] = target_project_payload()
     environment.update(values)
     return environment
 
@@ -83,17 +134,29 @@ class ForgeOperationTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-    def test_active_forge_type_defaults_to_github_when_no_env_or_override_exists(self) -> None:
-        self.assertEqual("github", active_forge_type({}, None))
+    def test_active_forge_type_requires_target_project_payload(self) -> None:
+        with self.assertRaises(ForgeOperationError) as context:
+            active_forge_type({}, None)
 
-    def test_active_forge_type_uses_explicit_override_before_environment(self) -> None:
-        self.assertEqual("sourcehut", active_forge_type({"RUNA_FORGE_TYPE": "github"}, "sourcehut"))
+        self.assertIn("RUNA_TARGET_PROJECT", str(context.exception))
 
-    def test_active_forge_type_uses_runa_forge_type_environment(self) -> None:
-        self.assertEqual("sourcehut", active_forge_type({"RUNA_FORGE_TYPE": "sourcehut"}, None))
+    def test_active_forge_type_uses_explicit_override_before_project_payload(self) -> None:
+        self.assertEqual("sourcehut", active_forge_type({"RUNA_TARGET_PROJECT": target_project_payload()}, "sourcehut"))
+
+    def test_active_forge_type_uses_runa_target_project_environment(self) -> None:
+        self.assertEqual("sourcehut", active_forge_type({"RUNA_TARGET_PROJECT": sourcehut_target_project()}, None))
 
     def test_active_forge_type_does_not_fall_back_to_groundwork_forge_type_environment(self) -> None:
-        self.assertEqual("github", active_forge_type({"GROUNDWORK_FORGE_TYPE": "sourcehut"}, None))
+        self.assertEqual(
+            "github",
+            active_forge_type({"RUNA_TARGET_PROJECT": target_project_payload(), "GROUNDWORK_FORGE_TYPE": "sourcehut"}, None),
+        )
+
+    def test_active_forge_type_rejects_retired_runa_forge_atoms(self) -> None:
+        with self.assertRaises(ForgeOperationError) as context:
+            active_forge_type({"RUNA_TARGET_PROJECT": target_project_payload(), "RUNA_FORGE_TYPE": "github"}, None)
+
+        self.assertIn("retired runa forge environment atom", str(context.exception))
 
     def test_resolve_operation_returns_exact_active_forge_mechanic(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -105,7 +168,7 @@ class ForgeOperationTests(unittest.TestCase):
         self.assertEqual("close-out", mechanic["name"])
         self.assertEqual("sourcehut", mechanic["forge_tag"])
 
-    def test_cli_resolve_accepts_forge_type_override(self) -> None:
+    def test_cli_resolve_uses_target_project_forge_type(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_methodology(root)
@@ -116,12 +179,10 @@ class ForgeOperationTests(unittest.TestCase):
                     str(ROOT / "tooling" / "forge_operations.py"),
                     "--root",
                     str(root),
-                    "--forge-type",
-                    "sourcehut",
                     "resolve",
                     "close-out",
                 ],
-                env=forge_cli_environment(),
+                env=forge_cli_environment(RUNA_TARGET_PROJECT=sourcehut_target_project()),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -176,8 +237,7 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "groundwork",
+                    "RUNA_TARGET_PROJECT": target_project_payload(),
                 },
             ):
                 result = run_invocation(
@@ -198,8 +258,7 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "groundwork",
+                    "RUNA_TARGET_PROJECT": target_project_payload(),
                 },
             ):
                 result = run_invocation(
@@ -229,8 +288,7 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_TRACKER_ID": "4",
+                    "RUNA_TARGET_PROJECT": sourcehut_target_project(),
                 },
             ):
                 result = run_invocation(
@@ -248,8 +306,7 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_TRACKER_ID": "4",
+                    "RUNA_TARGET_PROJECT": sourcehut_target_project(),
                 },
             ):
                 result = run_invocation(
@@ -290,10 +347,7 @@ cat "{response}"
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "RUNA_FORGE_TRACKER_ID": "4",
+                    "RUNA_TARGET_PROJECT": sourcehut_target_project(),
                 },
             ):
                 result = run_invocation(
@@ -308,10 +362,7 @@ cat "{response}"
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "RUNA_FORGE_TRACKER_ID": "4",
+                    "RUNA_TARGET_PROJECT": sourcehut_target_project(),
                 },
             ):
                 error_result = run_invocation(
@@ -488,16 +539,11 @@ cat "{response}"
                     str(ROOT / "tooling" / "forge_operations.py"),
                     "--root",
                     str(root),
-                    "--forge-type",
-                    "sourcehut",
                     "run",
                     "probe",
                 ],
                 env=forge_cli_environment(
-                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                    RUNA_FORGE_OWNER="operator",
-                    RUNA_FORGE_NAME="weforge",
-                    RUNA_FORGE_TRACKER_ID="4",
+                    RUNA_TARGET_PROJECT=sourcehut_target_project(),
                     GROUNDWORK_FORGE_REPO_ID="42",
                 ),
                 text=True,
@@ -508,7 +554,7 @@ cat "{response}"
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual("42\n", result.stdout)
 
-    def test_cli_resolves_sourcehut_deployment_values_from_runtime_and_groundwork_atoms(self) -> None:
+    def test_cli_resolves_sourcehut_deployment_values_from_target_project_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_sourcehut_deployment_probe_methodology(root)
@@ -519,16 +565,11 @@ cat "{response}"
                     str(ROOT / "tooling" / "forge_operations.py"),
                     "--root",
                     str(root),
-                    "--forge-type",
-                    "sourcehut",
                     "run",
                     "probe",
                 ],
                 env=forge_cli_environment(
-                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                    RUNA_FORGE_OWNER="operator",
-                    RUNA_FORGE_NAME="weforge",
-                    RUNA_FORGE_TRACKER_ID="4",
+                    RUNA_TARGET_PROJECT=sourcehut_target_project(),
                     GROUNDWORK_FORGE_REPO_ID="42",
                 ),
                 text=True,
@@ -553,11 +594,7 @@ cat "{response}"
             root = Path(directory)
             self.write_sourcehut_tracker_probe_methodology(root)
             environment = forge_cli_environment(
-                RUNA_FORGE_TYPE="sourcehut",
-                GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                RUNA_FORGE_OWNER="operator",
-                RUNA_FORGE_NAME="weforge",
-                RUNA_FORGE_TRACKER_ID="4",
+                RUNA_TARGET_PROJECT=sourcehut_target_project(),
             )
             environment.pop("GROUNDWORK_FORGE_REPO_ID", None)
 
@@ -579,7 +616,7 @@ cat "{response}"
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual(["https://todo.weforge.build/query", "4"], result.stdout.strip().splitlines())
 
-    def test_cli_names_missing_sourcehut_deployment_atom(self) -> None:
+    def test_cli_names_missing_sourcehut_tracker_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_sourcehut_deployment_probe_methodology(root)
@@ -590,15 +627,22 @@ cat "{response}"
                     str(ROOT / "tooling" / "forge_operations.py"),
                     "--root",
                     str(root),
-                    "--forge-type",
-                    "sourcehut",
                     "run",
                     "probe",
                 ],
                 env=forge_cli_environment(
-                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                    RUNA_FORGE_OWNER="operator",
-                    RUNA_FORGE_NAME="weforge",
+                    RUNA_TARGET_PROJECT=target_project_payload(
+                        "sourcehut",
+                        repositories=[
+                            {
+                                "selector": "weforge",
+                                "owner": "operator",
+                                "name": "weforge",
+                                "host": "weforge.build",
+                            }
+                        ],
+                        trackers=[],
+                    ),
                     GROUNDWORK_FORGE_REPO_ID="42",
                 ),
                 text=True,
@@ -607,9 +651,9 @@ cat "{response}"
             )
 
         self.assertNotEqual(0, result.returncode)
-        self.assertIn("RUNA_FORGE_TRACKER_ID", result.stderr)
+        self.assertIn("does not declare a tracker", result.stderr)
 
-    def test_cli_resolves_github_repository_from_runtime_atoms_with_default_forge_type(self) -> None:
+    def test_cli_resolves_github_repository_from_single_repository_project_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_github_deployment_probe_methodology(root)
@@ -623,10 +667,7 @@ cat "{response}"
                     "run",
                     "probe",
                 ],
-                env=forge_cli_environment(
-                    RUNA_FORGE_OWNER="tesserine",
-                    RUNA_FORGE_NAME="groundwork",
-                ),
+                env=forge_cli_environment(),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -634,6 +675,109 @@ cat "{response}"
 
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual("tesserine/groundwork\n", result.stdout)
+
+    def test_cli_resolves_github_repository_from_selector_in_multi_repository_project_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_github_deployment_probe_methodology(root)
+            project = target_project_payload(
+                repositories=[
+                    {
+                        "selector": "runa",
+                        "owner": "tesserine",
+                        "name": "runa",
+                        "host": "github.com",
+                    },
+                    {
+                        "selector": "groundwork",
+                        "owner": "tesserine",
+                        "name": "groundwork",
+                        "host": "github.com",
+                    },
+                ]
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "run",
+                    "probe",
+                    "repository_selector=groundwork",
+                ],
+                env=forge_cli_environment(RUNA_TARGET_PROJECT=project),
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("tesserine/groundwork\n", result.stdout)
+
+    def test_cli_requires_repository_selector_for_multi_repository_project_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_github_deployment_probe_methodology(root)
+            project = target_project_payload(
+                repositories=[
+                    {
+                        "selector": "runa",
+                        "owner": "tesserine",
+                        "name": "runa",
+                        "host": "github.com",
+                    },
+                    {
+                        "selector": "groundwork",
+                        "owner": "tesserine",
+                        "name": "groundwork",
+                        "host": "github.com",
+                    },
+                ]
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "run",
+                    "probe",
+                ],
+                env=forge_cli_environment(RUNA_TARGET_PROJECT=project),
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("repository_selector is required", result.stderr)
+
+    def test_cli_rejects_unknown_repository_selector(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_github_deployment_probe_methodology(root)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "run",
+                    "probe",
+                    "repository_selector=missing",
+                ],
+                env=forge_cli_environment(),
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("repository selector `missing`", result.stderr)
 
     def test_cli_rejects_caller_supplied_deployment_value(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -650,10 +794,7 @@ cat "{response}"
                     "probe",
                     "repository=attacker/repo",
                 ],
-                env=forge_cli_environment(
-                    RUNA_FORGE_OWNER="tesserine",
-                    RUNA_FORGE_NAME="groundwork",
-                ),
+                env=forge_cli_environment(),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -616,6 +616,95 @@ cat "{response}"
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual(["https://todo.weforge.build/query", "4"], result.stdout.strip().splitlines())
 
+    def test_cli_resolves_sourcehut_repo_only_values_without_tracker_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_sourcehut_repository_probe_methodology(root)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "run",
+                    "probe",
+                ],
+                env=forge_cli_environment(
+                    RUNA_TARGET_PROJECT=target_project_payload(
+                        "sourcehut",
+                        repositories=[
+                            {
+                                "selector": "weforge",
+                                "owner": "operator",
+                                "name": "weforge",
+                                "host": "weforge.build",
+                            }
+                        ],
+                        trackers=[],
+                    ),
+                ),
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            [
+                "operator/weforge",
+                "https://git.weforge.build/query",
+                "git@git.weforge.build:~operator/weforge",
+            ],
+            result.stdout.strip().splitlines(),
+        )
+
+    def test_cli_resolves_sourcehut_repo_only_values_with_ambiguous_trackers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_sourcehut_repository_probe_methodology(root)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "run",
+                    "probe",
+                ],
+                env=forge_cli_environment(
+                    RUNA_TARGET_PROJECT=target_project_payload(
+                        "sourcehut",
+                        repositories=[
+                            {
+                                "selector": "weforge",
+                                "owner": "operator",
+                                "name": "weforge",
+                                "host": "weforge.build",
+                            }
+                        ],
+                        trackers=[
+                            {"selector": "todo", "host": "todo.sr.ht", "tracker_id": "4"},
+                            {"selector": "bugs", "host": "todo.sr.ht", "tracker_id": "5"},
+                        ],
+                    ),
+                ),
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            [
+                "operator/weforge",
+                "https://git.weforge.build/query",
+                "git@git.weforge.build:~operator/weforge",
+            ],
+            result.stdout.strip().splitlines(),
+        )
+
     def test_cli_names_missing_sourcehut_tracker_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -1002,6 +1091,55 @@ cat "{response}"
                 purpose = "Tracker ID."
                 required = true
                 deployment_value = "tracker_id"
+
+                [outcome]
+                description = "Printed."
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+
+    def write_sourcehut_repository_probe_methodology(self, root: Path) -> None:
+        (root / "manifest.toml").write_text(
+            textwrap.dedent(
+                """
+                [[forge_tags]]
+                name = "sourcehut"
+
+                [[mechanics]]
+                name = "probe"
+                forge_tags = ["sourcehut"]
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+        (root / "mechanics" / "sourcehut").mkdir(parents=True, exist_ok=True)
+        (root / "mechanics" / "sourcehut" / "probe.toml").write_text(
+            textwrap.dedent(
+                """
+                name = "probe"
+                purpose = "Probe repository-only SourceHut deployment-value resolution."
+                forge_tag = "sourcehut"
+                default_invocation = 'printf "%s\\n%s\\n%s\\n" "$repository" "$git_url" "$remote"'
+                examples = ['printf "%s\\n" "$remote"']
+
+                [[parameters]]
+                name = "repository"
+                purpose = "Repository owner/name."
+                required = true
+                deployment_value = "repository"
+
+                [[parameters]]
+                name = "git_url"
+                purpose = "Git query URL."
+                required = true
+                deployment_value = "git_query_url"
+
+                [[parameters]]
+                name = "remote"
+                purpose = "Git SSH remote."
+                required = true
+                deployment_value = "ssh_remote"
 
                 [outcome]
                 description = "Printed."

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import shlex
@@ -49,6 +50,39 @@ def assert_failure_contains(
 ) -> None:
     test.assertNotEqual(result.returncode, 0, "command unexpectedly succeeded")
     test.assertIn(expected, result.stderr)
+
+
+def sourcehut_project_environment(**values: str) -> dict[str, str]:
+    environment = {
+        **os.environ,
+        "PATH": "/usr/bin:/bin",
+        "RUNA_TARGET_PROJECT": json.dumps(
+            {
+                "version": 1,
+                "forge_type": "sourcehut",
+                "repositories": [
+                    {
+                        "selector": "weforge",
+                        "owner": "operator",
+                        "name": "weforge",
+                        "host": "weforge.build",
+                    }
+                ],
+                "trackers": [
+                    {
+                        "selector": "weforge",
+                        "repository": "weforge",
+                        "owner": "operator",
+                        "name": "weforge",
+                        "host": "weforge.build",
+                        "tracker_id": "4",
+                    }
+                ],
+            }
+        ),
+    }
+    environment.update(values)
+    return environment
 
 
 class MethodologyFixture:
@@ -247,7 +281,7 @@ class GroundworkInstallTests(unittest.TestCase):
         resolved = run(
             [str(resolver), "resolve", "close-out"],
             install.runtime_root(),
-            env={**os.environ, "RUNA_FORGE_TYPE": "sourcehut"},
+            env=sourcehut_project_environment(),
         )
         assert_success(self, resolved)
         self.assertEqual("close-out[sourcehut]\n", resolved.stdout)
@@ -294,7 +328,7 @@ class GroundworkInstallTests(unittest.TestCase):
             resolved = run(
                 argv,
                 install.runtime_root(),
-                env={**os.environ, "RUNA_FORGE_TYPE": "sourcehut", "PATH": "/usr/bin:/bin"},
+                env=sourcehut_project_environment(),
             )
             assert_success(self, resolved)
             self.assertEqual("close-out[sourcehut]\n", resolved.stdout)
@@ -331,7 +365,7 @@ class GroundworkInstallTests(unittest.TestCase):
         resolved = run(
             argv,
             install.runtime_root(),
-            env={**os.environ, "RUNA_FORGE_TYPE": "sourcehut", "PATH": "/usr/bin:/bin"},
+            env=sourcehut_project_environment(),
         )
         assert_success(self, resolved)
         self.assertEqual("close-out[sourcehut]\n", resolved.stdout)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6,6 +6,7 @@ runtime bundle, and principles-corpus recording + materialization. It never
 delivers protocol content — that is the runtime's channel.
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -56,6 +57,38 @@ def assert_failure_contains(
 ) -> None:
     test.assertNotEqual(result.returncode, 0, "command unexpectedly succeeded")
     test.assertIn(expected, result.stderr)
+
+
+def sourcehut_project_environment(**values: str) -> dict[str, str]:
+    environment = {
+        "PATH": "/usr/bin:/bin",
+        "RUNA_TARGET_PROJECT": json.dumps(
+            {
+                "version": 1,
+                "forge_type": "sourcehut",
+                "repositories": [
+                    {
+                        "selector": "weforge",
+                        "owner": "operator",
+                        "name": "weforge",
+                        "host": "weforge.build",
+                    }
+                ],
+                "trackers": [
+                    {
+                        "selector": "weforge",
+                        "repository": "weforge",
+                        "owner": "operator",
+                        "name": "weforge",
+                        "host": "weforge.build",
+                        "tracker_id": "4",
+                    }
+                ],
+            }
+        ),
+    }
+    environment.update(values)
+    return environment
 
 
 def tree_payload(directory: Path, *, exclude: frozenset[str] = frozenset({MARKER_NAME})) -> dict[str, bytes]:
@@ -256,7 +289,7 @@ class SelfInstallTests(unittest.TestCase):
         resolved = run(
             [str(resolver), "resolve", "close-out"],
             install.runtime_root(),
-            env={"PATH": "/usr/bin:/bin", "RUNA_FORGE_TYPE": "sourcehut"},
+            env=sourcehut_project_environment(),
         )
         assert_success(self, resolved)
         self.assertEqual("close-out[sourcehut]\n", resolved.stdout)

--- a/tests/test_interactive_session_surface.py
+++ b/tests/test_interactive_session_surface.py
@@ -52,19 +52,31 @@ def write_executable(path: Path, body: str) -> None:
     path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def append_agent_command_config(project_dir: Path, command: list[Path]) -> None:
-    config_path = project_dir / ".runa" / "config.toml"
-    config = config_path.read_text(encoding="utf-8")
+def write_project_surface(project_dir: Path, command: list[Path]) -> None:
+    config_path = project_dir / ".runa" / "project.toml"
     quoted = ", ".join(json.dumps(str(part)) for part in command)
-    config_path.write_text(f"{config}\n[agent]\ncommand = [{quoted}]\n", encoding="utf-8")
+    config_path.write_text(
+        f"""
+[launch]
+command = [{quoted}]
+
+[target_project]
+forge_type = "github"
+
+[[target_project.repositories]]
+selector = "groundwork"
+owner = "tesserine"
+name = "groundwork"
+host = "github.com"
+""".lstrip(),
+        encoding="utf-8",
+    )
 
 
 def groundwork_env() -> dict[str, str]:
     env = os.environ.copy()
-    env.pop("RUNA_FORGE_TYPE", None)
-    env.pop("RUNA_FORGE_TRACKER_ID", None)
-    env["RUNA_FORGE_OWNER"] = "tesserine"
-    env["RUNA_FORGE_NAME"] = "groundwork"
+    for atom in ["RUNA_FORGE_TYPE", "RUNA_FORGE_TRACKER_ID", "RUNA_FORGE_OWNER", "RUNA_FORGE_NAME"]:
+        env.pop(atom, None)
     return env
 
 
@@ -131,7 +143,7 @@ class InteractiveSessionSurfaceTests(unittest.TestCase):
                 fi
                 """,
             )
-            append_agent_command_config(
+            write_project_surface(
                 project_dir,
                 [agent_path, prompt_path, config_capture_path, runa_mcp, mcp_log_path],
             )

--- a/tooling/forge_operations.py
+++ b/tooling/forge_operations.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import tomllib
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -263,27 +263,48 @@ def _resolve_deployment_value(
             f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
         )
     if forge_type == "sourcehut":
-        tracker = _selected_tracker(target_project, selectors.get("tracker_selector"))
-        repository = _selected_sourcehut_repository(target_project, tracker, selectors.get("repository_selector"))
+        tracker: Mapping[str, Any] | None = None
+        repository: Mapping[str, Any] | None = None
+
+        def selected_tracker() -> Mapping[str, Any]:
+            nonlocal tracker
+            if tracker is None:
+                tracker = _selected_tracker(target_project, selectors.get("tracker_selector"))
+            return tracker
+
+        def selected_repository() -> Mapping[str, Any]:
+            nonlocal repository
+            if repository is None:
+                repository = _selected_sourcehut_repository(
+                    target_project,
+                    selectors.get("repository_selector"),
+                    selectors.get("tracker_selector"),
+                )
+            return repository
+
         if deployment_value == "owner":
-            return _required_string_field(tracker, "owner", "tracker")
+            return _required_string_field(selected_tracker(), "owner", "tracker")
         if deployment_value == "name":
-            return _required_string_field(tracker, "name", "tracker")
+            return _required_string_field(selected_tracker(), "name", "tracker")
         if deployment_value == "repository":
+            repository = selected_repository()
             owner = _required_string_field(repository, "owner", "repository")
             name = _required_string_field(repository, "name", "repository")
             return f"{owner}/{name}"
         if deployment_value == "todo_query_url":
-            return f"https://todo.{_required_host(tracker, repository, 'tracker')}/query"
+            endpoint = _required_sourcehut_host(selected_tracker(), selected_repository, "tracker")
+            return f"https://todo.{endpoint}/query"
         if deployment_value == "git_query_url":
-            return f"https://git.{_required_host(repository, tracker, 'repository')}/query"
+            endpoint = _required_sourcehut_host(selected_repository(), selected_tracker, "repository")
+            return f"https://git.{endpoint}/query"
         if deployment_value == "ssh_remote":
-            endpoint = _required_host(repository, tracker, "repository")
+            repository = selected_repository()
+            endpoint = _required_sourcehut_host(repository, selected_tracker, "repository")
             owner = _required_string_field(repository, "owner", "repository")
             name = _required_string_field(repository, "name", "repository")
             return f"git@git.{endpoint}:~{owner}/{name}"
         if deployment_value == "tracker_id":
-            return _required_string_field(tracker, "tracker_id", "tracker")
+            return _required_string_field(selected_tracker(), "tracker_id", "tracker")
         if deployment_value == "repo_id":
             return _required_environment(environment, "GROUNDWORK_FORGE_REPO_ID")
         raise ForgeOperationError(
@@ -366,15 +387,24 @@ def _selected_tracker(target_project: Mapping[str, Any], selector: str | None) -
 
 def _selected_sourcehut_repository(
     target_project: Mapping[str, Any],
-    tracker: Mapping[str, Any],
     selector: str | None,
+    tracker_selector: str | None,
 ) -> Mapping[str, Any]:
     if selector:
         return _selected_repository(target_project, selector)
+    repositories = _target_project_items(target_project, "repositories", "repository")
+    if len(repositories) == 1:
+        return repositories[0]
+    if not repositories:
+        raise ForgeOperationError(f"{RUNA_TARGET_PROJECT} does not declare a repository")
+    tracker = _selected_tracker(target_project, tracker_selector)
     tracker_repository = tracker.get("repository")
     if isinstance(tracker_repository, str) and tracker_repository:
         return _selected_repository(target_project, tracker_repository)
-    return _selected_repository(target_project, None)
+    raise ForgeOperationError(
+        "repository_selector is required when the configured project declares multiple repositories: "
+        + ", ".join(_selectors(repositories))
+    )
 
 
 def _target_project_items(target_project: Mapping[str, Any], key: str, item_name: str) -> list[Mapping[str, Any]]:
@@ -400,11 +430,16 @@ def _required_string_field(item: Mapping[str, Any], key: str, item_name: str) ->
     return value
 
 
-def _required_host(primary: Mapping[str, Any], fallback: Mapping[str, Any], item_name: str) -> str:
+def _required_sourcehut_host(
+    primary: Mapping[str, Any],
+    fallback: Callable[[], Mapping[str, Any]],
+    item_name: str,
+) -> str:
     value = primary.get("host")
     if isinstance(value, str) and value:
         return value
-    fallback_value = fallback.get("host")
+    fallback_item = fallback()
+    fallback_value = fallback_item.get("host")
     if isinstance(fallback_value, str) and fallback_value:
         return fallback_value
     raise ForgeOperationError(f"configured {item_name} is missing required field `host`")

--- a/tooling/forge_operations.py
+++ b/tooling/forge_operations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import tomllib
@@ -9,10 +10,15 @@ from typing import Any, Mapping
 
 
 ROOT = Path(__file__).resolve().parents[1]
-RUNA_FORGE_TYPE = "RUNA_FORGE_TYPE"
-RUNA_FORGE_OWNER = "RUNA_FORGE_OWNER"
-RUNA_FORGE_NAME = "RUNA_FORGE_NAME"
-RUNA_FORGE_TRACKER_ID = "RUNA_FORGE_TRACKER_ID"
+RUNA_TARGET_PROJECT = "RUNA_TARGET_PROJECT"
+RETIRED_RUNA_FORGE_ENVIRONMENT_ATOMS = (
+    "RUNA_FORGE_TYPE",
+    "RUNA_FORGE_OWNER",
+    "RUNA_FORGE_NAME",
+    "RUNA_FORGE_TRACKER_ID",
+)
+RESERVED_SELECTOR_PARAMETERS = {"repository_selector", "tracker_selector"}
+SUPPORTED_FORGE_TYPES = {"github", "sourcehut"}
 
 
 class ForgeOperationError(ValueError):
@@ -20,9 +26,10 @@ class ForgeOperationError(ValueError):
 
 
 def active_forge_type(environment: Mapping[str, str], override: str | None) -> str:
+    _reject_retired_runa_forge_environment_atoms(environment)
     if override:
         return override
-    return environment.get(RUNA_FORGE_TYPE) or "github"
+    return _target_project_forge_type(_target_project(environment))
 
 
 def resolve_operation(root: Path | str, operation: str, *, forge_type: str | None = None) -> dict[str, Any]:
@@ -51,7 +58,7 @@ def resolve_operation(root: Path | str, operation: str, *, forge_type: str | Non
 
 
 def inspect_invocation(mechanic: Mapping[str, Any], values: Mapping[str, str]) -> str:
-    unknown = sorted(set(values) - set(_parameters(mechanic)))
+    unknown = sorted(set(values) - set(_parameters(mechanic)) - RESERVED_SELECTOR_PARAMETERS)
     if unknown:
         raise ForgeOperationError(f"unknown parameter(s): {', '.join(unknown)}")
     return _invocation_body(mechanic)
@@ -59,14 +66,15 @@ def inspect_invocation(mechanic: Mapping[str, Any], values: Mapping[str, str]) -
 
 def render_shell_invocation(mechanic: Mapping[str, Any], values: Mapping[str, str]) -> tuple[str, dict[str, str]]:
     parameters = _parameters(mechanic)
+    call_values, selector_values = _split_selector_values(values)
     deployment_parameters = _deployment_parameters(mechanic)
-    provided_deployment_values = sorted(set(values) & set(deployment_parameters))
+    provided_deployment_values = sorted(set(call_values) & set(deployment_parameters))
     if provided_deployment_values:
         raise ForgeOperationError(
-            f"deployment-resolved parameter(s) must come from the configured forge environment: {', '.join(provided_deployment_values)}"
+            f"deployment-resolved parameter(s) must come from the configured project: {', '.join(provided_deployment_values)}"
         )
-    deployment_values = _deployment_parameter_values(mechanic, os.environ)
-    resolved_values = {**values, **deployment_values}
+    deployment_values = _deployment_parameter_values(mechanic, os.environ, selector_values)
+    resolved_values = {**call_values, **deployment_values}
     missing = [name for name, parameter in parameters.items() if parameter.get("required") and name not in resolved_values]
     if missing:
         raise ForgeOperationError(f"missing required parameter(s): {', '.join(sorted(missing))}")
@@ -100,7 +108,6 @@ def run_invocation(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Resolve and invoke Groundwork forge operations.")
     parser.add_argument("--root", default=str(ROOT), help="Groundwork methodology root. Defaults to this checkout.")
-    parser.add_argument("--forge-type", help="Active forge type override. Defaults to RUNA_FORGE_TYPE, then github.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     resolve_parser = subparsers.add_parser("resolve", help="Print the resolved mechanic path-equivalent name.")
@@ -122,7 +129,7 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
     try:
-        mechanic = resolve_operation(args.root, args.operation, forge_type=args.forge_type)
+        mechanic = resolve_operation(args.root, args.operation)
         if args.command == "resolve":
             print(f"{mechanic['name']}[{mechanic['forge_tag']}]")
             return 0
@@ -201,6 +208,7 @@ def _deployment_parameters(mechanic: Mapping[str, Any]) -> dict[str, str]:
 def _deployment_parameter_values(
     mechanic: Mapping[str, Any],
     environment: Mapping[str, str],
+    selectors: Mapping[str, str],
 ) -> dict[str, str]:
     deployments = _deployment_parameters(mechanic)
     if not deployments:
@@ -208,7 +216,7 @@ def _deployment_parameter_values(
     forge_type = mechanic.get("forge_tag")
     if not isinstance(forge_type, str):
         raise ForgeOperationError("deployment-resolved parameters require mechanic forge_tag")
-    resolved = _resolved_deployment_values(forge_type, set(deployments.values()), environment)
+    resolved = _resolved_deployment_values(forge_type, set(deployments.values()), environment, selectors)
     values: dict[str, str] = {}
     for name, deployment_value in deployments.items():
         values[name] = resolved[deployment_value]
@@ -219,9 +227,17 @@ def _resolved_deployment_values(
     forge_type: str,
     deployment_values: set[str],
     environment: Mapping[str, str],
+    selectors: Mapping[str, str],
 ) -> dict[str, str]:
+    _reject_retired_runa_forge_environment_atoms(environment)
+    target_project = _target_project(environment)
+    project_forge_type = _target_project_forge_type(target_project)
+    if project_forge_type != forge_type:
+        raise ForgeOperationError(
+            f"mechanic forge type `{forge_type}` does not match configured project forge type `{project_forge_type}`"
+        )
     return {
-        deployment_value: _resolve_deployment_value(forge_type, deployment_value, environment)
+        deployment_value: _resolve_deployment_value(forge_type, deployment_value, environment, target_project, selectors)
         for deployment_value in deployment_values
     }
 
@@ -230,41 +246,44 @@ def _resolve_deployment_value(
     forge_type: str,
     deployment_value: str,
     environment: Mapping[str, str],
+    target_project: Mapping[str, Any],
+    selectors: Mapping[str, str],
 ) -> str:
     if forge_type == "github":
+        repository = _selected_repository(target_project, selectors.get("repository_selector"))
         if deployment_value == "owner":
-            return _required_environment(environment, RUNA_FORGE_OWNER)
+            return _required_string_field(repository, "owner", "repository")
         if deployment_value == "name":
-            return _required_environment(environment, RUNA_FORGE_NAME)
+            return _required_string_field(repository, "name", "repository")
         if deployment_value == "repository":
-            owner = _required_environment(environment, RUNA_FORGE_OWNER)
-            name = _required_environment(environment, RUNA_FORGE_NAME)
+            owner = _required_string_field(repository, "owner", "repository")
+            name = _required_string_field(repository, "name", "repository")
             return f"{owner}/{name}"
         raise ForgeOperationError(
             f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
         )
     if forge_type == "sourcehut":
+        tracker = _selected_tracker(target_project, selectors.get("tracker_selector"))
+        repository = _selected_sourcehut_repository(target_project, tracker, selectors.get("repository_selector"))
         if deployment_value == "owner":
-            return _required_environment(environment, RUNA_FORGE_OWNER)
+            return _required_string_field(tracker, "owner", "tracker")
         if deployment_value == "name":
-            return _required_environment(environment, RUNA_FORGE_NAME)
+            return _required_string_field(tracker, "name", "tracker")
         if deployment_value == "repository":
-            owner = _required_environment(environment, RUNA_FORGE_OWNER)
-            name = _required_environment(environment, RUNA_FORGE_NAME)
+            owner = _required_string_field(repository, "owner", "repository")
+            name = _required_string_field(repository, "name", "repository")
             return f"{owner}/{name}"
         if deployment_value == "todo_query_url":
-            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
-            return f"https://todo.{endpoint}/query"
+            return f"https://todo.{_required_host(tracker, repository, 'tracker')}/query"
         if deployment_value == "git_query_url":
-            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
-            return f"https://git.{endpoint}/query"
+            return f"https://git.{_required_host(repository, tracker, 'repository')}/query"
         if deployment_value == "ssh_remote":
-            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
-            owner = _required_environment(environment, RUNA_FORGE_OWNER)
-            name = _required_environment(environment, RUNA_FORGE_NAME)
+            endpoint = _required_host(repository, tracker, "repository")
+            owner = _required_string_field(repository, "owner", "repository")
+            name = _required_string_field(repository, "name", "repository")
             return f"git@git.{endpoint}:~{owner}/{name}"
         if deployment_value == "tracker_id":
-            return _required_environment(environment, RUNA_FORGE_TRACKER_ID)
+            return _required_string_field(tracker, "tracker_id", "tracker")
         if deployment_value == "repo_id":
             return _required_environment(environment, "GROUNDWORK_FORGE_REPO_ID")
         raise ForgeOperationError(
@@ -273,10 +292,128 @@ def _resolve_deployment_value(
     raise ForgeOperationError(f"forge type `{forge_type}` does not support deployment identity")
 
 
+def _split_selector_values(values: Mapping[str, str]) -> tuple[dict[str, str], dict[str, str]]:
+    call_values: dict[str, str] = {}
+    selector_values: dict[str, str] = {}
+    for name, value in values.items():
+        if name in RESERVED_SELECTOR_PARAMETERS:
+            selector_values[name] = str(value)
+        else:
+            call_values[name] = str(value)
+    return call_values, selector_values
+
+
+def _reject_retired_runa_forge_environment_atoms(environment: Mapping[str, str]) -> None:
+    present = sorted(atom for atom in RETIRED_RUNA_FORGE_ENVIRONMENT_ATOMS if environment.get(atom))
+    if present:
+        raise ForgeOperationError(
+            "retired runa forge environment atom(s) are not supported; use "
+            f"{RUNA_TARGET_PROJECT}: {', '.join(present)}"
+        )
+
+
+def _target_project(environment: Mapping[str, str]) -> Mapping[str, Any]:
+    raw_payload = _required_environment(environment, RUNA_TARGET_PROJECT)
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as error:
+        raise ForgeOperationError(f"{RUNA_TARGET_PROJECT} must contain a JSON project payload: {error}") from error
+    if not isinstance(payload, dict):
+        raise ForgeOperationError(f"{RUNA_TARGET_PROJECT} must contain a JSON object")
+    return payload
+
+
+def _target_project_forge_type(target_project: Mapping[str, Any]) -> str:
+    forge_type = target_project.get("forge_type")
+    if not isinstance(forge_type, str) or forge_type not in SUPPORTED_FORGE_TYPES:
+        raise ForgeOperationError(f"{RUNA_TARGET_PROJECT} must name a supported forge_type")
+    return forge_type
+
+
+def _selected_repository(target_project: Mapping[str, Any], selector: str | None) -> Mapping[str, Any]:
+    repositories = _target_project_items(target_project, "repositories", "repository")
+    if selector:
+        for repository in repositories:
+            if repository.get("selector") == selector:
+                return repository
+        raise ForgeOperationError(f"repository selector `{selector}` does not resolve in {RUNA_TARGET_PROJECT}")
+    if len(repositories) == 1:
+        return repositories[0]
+    if not repositories:
+        raise ForgeOperationError(f"{RUNA_TARGET_PROJECT} does not declare a repository")
+    raise ForgeOperationError(
+        "repository_selector is required when the configured project declares multiple repositories: "
+        + ", ".join(_selectors(repositories))
+    )
+
+
+def _selected_tracker(target_project: Mapping[str, Any], selector: str | None) -> Mapping[str, Any]:
+    trackers = _target_project_items(target_project, "trackers", "tracker")
+    if selector:
+        for tracker in trackers:
+            if tracker.get("selector") == selector:
+                return tracker
+        raise ForgeOperationError(f"tracker selector `{selector}` does not resolve in {RUNA_TARGET_PROJECT}")
+    if len(trackers) == 1:
+        return trackers[0]
+    if not trackers:
+        raise ForgeOperationError(f"{RUNA_TARGET_PROJECT} does not declare a tracker")
+    raise ForgeOperationError(
+        "tracker_selector is required when the configured project declares multiple trackers: "
+        + ", ".join(_selectors(trackers))
+    )
+
+
+def _selected_sourcehut_repository(
+    target_project: Mapping[str, Any],
+    tracker: Mapping[str, Any],
+    selector: str | None,
+) -> Mapping[str, Any]:
+    if selector:
+        return _selected_repository(target_project, selector)
+    tracker_repository = tracker.get("repository")
+    if isinstance(tracker_repository, str) and tracker_repository:
+        return _selected_repository(target_project, tracker_repository)
+    return _selected_repository(target_project, None)
+
+
+def _target_project_items(target_project: Mapping[str, Any], key: str, item_name: str) -> list[Mapping[str, Any]]:
+    raw_items = target_project.get(key, [])
+    if not isinstance(raw_items, list):
+        raise ForgeOperationError(f"{RUNA_TARGET_PROJECT}.{key} must be a list")
+    items: list[Mapping[str, Any]] = []
+    for index, item in enumerate(raw_items):
+        if not isinstance(item, dict):
+            raise ForgeOperationError(f"{RUNA_TARGET_PROJECT}.{key}[{index}] must be a {item_name} object")
+        items.append(item)
+    return items
+
+
+def _selectors(items: list[Mapping[str, Any]]) -> list[str]:
+    return [str(item.get("selector")) for item in items if isinstance(item.get("selector"), str)]
+
+
+def _required_string_field(item: Mapping[str, Any], key: str, item_name: str) -> str:
+    value = item.get(key)
+    if not isinstance(value, str) or not value:
+        raise ForgeOperationError(f"configured {item_name} is missing required field `{key}`")
+    return value
+
+
+def _required_host(primary: Mapping[str, Any], fallback: Mapping[str, Any], item_name: str) -> str:
+    value = primary.get("host")
+    if isinstance(value, str) and value:
+        return value
+    fallback_value = fallback.get("host")
+    if isinstance(fallback_value, str) and fallback_value:
+        return fallback_value
+    raise ForgeOperationError(f"configured {item_name} is missing required field `host`")
+
+
 def _required_environment(environment: Mapping[str, str], name: str) -> str:
     value = environment.get(name)
     if value is None or value == "":
-        raise ForgeOperationError(f"missing required deployment identity atom `{name}`")
+        raise ForgeOperationError(f"missing required environment variable `{name}`")
     return value
 
 


### PR DESCRIPTION
## Coupled landing

This PR is one half of the coupled runa#196 + groundwork#418 change. It must land together with tesserine/runa#198; neither side should be merged alone.

Closes #418.

## Summary

- Resolve forge operation deployment coordinates from `RUNA_TARGET_PROJECT` instead of the retired single-repository `RUNA_FORGE_*` env atoms.
- Preserve the guard that agents supply selectors only, never coordinates, with explicit repository/tracker selector handling.
- Support the single-repository one-element case while requiring selectors for ambiguous multi-repository payloads.
- Update acquisition/install/session tests, docs, and changelog for the consumer-side surface reset.

## Validation

- `python -m unittest discover -s tests`

## Coupling note

The matching runa PR publishes the project payload and retires the old forge env atoms. Merging this without tesserine/runa#198 leaves the producer surface absent.
