### PR TITLE
[codex] Move forge mechanics to address payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Forge mechanics now consume runa's `RUNA_PROJECT_FORGE_ADDRESSES` payload and
+  resolve configured resources through selector inputs. `groundwork-mechanic`
+  accepts `--repository` and `--tracker` selectors for repository- and
+  tracker-resolved operations. The retired coordinate-sourcing environment
+  surfaces `GROUNDWORK_FORGE_ENDPOINT` and `GROUNDWORK_FORGE_REPO_ID` are no
+  longer part of the mechanic contract.
 - README hero rewritten for the ecosystem README pass: groundwork positioned
   as software delivery expressed as an enforceable methodology — evidence-
   gated completion, CI-gated documentation coherence, forge-agnostic

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ When `manifest.toml`, `mechanics/`, and the forge-operation resolver are
 present, the installer also projects a managed runtime bundle under
 `~/.groundwork/`. The bundle contains the manifest, mechanic library, resolver
 module, and `bin/groundwork-mechanic`, so installed protocol sessions can
-resolve forge-invariant operations through the active `RUNA_FORGE_TYPE`
-configuration without reaching back into the source checkout. Installed
+resolve forge-invariant operations through runa's configured forge-address
+payload without reaching back into the source checkout. Installed
 protocol copies reference the managed resolver path directly, so users do not
 need to add `~/.groundwork/bin` to `PATH`.
 
@@ -181,29 +181,29 @@ than from `NAME=VALUE` argv bindings. For example, pass
 from the current process environment without placing the secret value in the
 resolver command line.
 
-Forge deployment identity is also supplied by environment contract, not by
-mechanic call-site bindings. Mechanics mark deployment-resolved parameters with
-`deployment_value`, and `groundwork-mechanic` derives those values from these
-atoms:
+Forge coordinates are supplied by runa's `RUNA_PROJECT_FORGE_ADDRESSES`
+payload, not by mechanic call-site bindings. The payload contains the
+configured forge instances, each instance's type and service hosts, and the
+project's repository and tracker resources. Mechanics continue to mark
+deployment-resolved parameters with `deployment_value`; `groundwork-mechanic`
+hydrates those values only after selecting a configured resource from the
+payload.
 
-| Variable | Holds | Example | Forge-assigned? |
-|---|---|---|---|
-| `RUNA_FORGE_TYPE` | active forge selector, defaulting to `github` | `sourcehut` | no |
-| `RUNA_FORGE_OWNER` | tracker/repo owner handle | `operator` | no |
-| `RUNA_FORGE_NAME` | tracker/repo name | `weforge` | no |
-| `RUNA_FORGE_TRACKER_ID` | tracker integer ID | `4` | yes |
-| `GROUNDWORK_FORGE_ENDPOINT` | deployment host used to derive service hosts | `weforge.build` | no |
-| `GROUNDWORK_FORGE_REPO_ID` | git repo integer ID | `42` | yes |
+Repository-resolved operations accept `--repository <selector>`.
+Tracker-resolved operations accept `--tracker <selector>`. The selector may be
+the configured resource id or a full address selector such as
+`<instance>:<owner>/<name>` for a repository or
+`<instance>:<owner>/<name>/<tracker-id>` for a SourceHut tracker. A selector
+that does not name a configured resource is rejected, and omitting a selector is
+accepted only when exactly one configured resource of the required kind exists.
 
-For SourceHut, the resolver derives `todo_query_url` as
-`https://todo.<endpoint>/query`, `git_query_url` as
-`https://git.<endpoint>/query`, and `ssh_remote` as
-`git@git.<endpoint>:~<owner>/<name>`, while `tracker_id` and `repo_id` come
-directly from their atoms. For GitHub, it derives `repository` as
-`<owner>/<name>`. Runa owns the four scoped identity atoms it injects into
-agent and MCP environments; Groundwork still owns endpoint and repo-id atoms
-that are not part of runtime scoped identity. The atoms are the only deployment
-facts; composed endpoints and remotes are not separate configuration values.
+For GitHub, the resolver derives `repository` as `<owner>/<name>` and reads
+the instance host from the selected resource's instance. For SourceHut, tracker
+operations derive tracker endpoints from the instance's tracker host, and
+repository operations derive git endpoints and `ssh_remote` from the instance's
+git host. A mechanic caller may supply only operation data and secrets; owner,
+name, host, endpoint URL, `repository`, `tracker_id`, and `ssh_remote` remain
+deployment-resolved values and are rejected when passed as bindings.
 
 The cross-repo seam for this ticket identity is documented in
 [`docs/architecture/connecting-structure.md`](docs/architecture/connecting-structure.md#phase-2-forge-tagging-seam).

--- a/docs/architecture/decisions/0004-contract-first-scoped-pipeline.md
+++ b/docs/architecture/decisions/0004-contract-first-scoped-pipeline.md
@@ -247,10 +247,10 @@ context to fire passively — with full expositions in references.
   redesign is shaped so the entrypoint slots in front of `take` without
   further methodology change.
 - **Forge identity namespace.** The protocols reference only invariant
-  operations resolved through `groundwork-mechanic`; the resolver reads the
-  runtime-owned `RUNA_FORGE_*` identity atoms (the #389/#390 repair, on
-  which this redesign now sits), with endpoint and repo-id remaining
-  methodology-owned atoms.
+  operations resolved through `groundwork-mechanic`; the resolver reads
+  runa's `RUNA_PROJECT_FORGE_ADDRESSES` payload and the operation's
+  repository or tracker selector, so configured project resources remain the
+  sole source of forge coordinates.
 - **Best-of-field call — verify may repair its own gate failures.** When
   fresh verification fails, verify's instructions route through `debug` and
   permit the minimal fix within the increment (then a fresh full gate)

--- a/docs/architecture/decisions/0005-principles-corpus-configuration.md
+++ b/docs/architecture/decisions/0005-principles-corpus-configuration.md
@@ -50,10 +50,11 @@ in the shipped manifest crosses that boundary.
 
 ### Why not environment atoms
 
-Post-#389, env atoms are runtime-owned session identity (`RUNA_FORGE_*`)
-or narrowly-scoped forge deployment values. The corpus is methodology
-content resolved once at setup, not per-session identity. Env vars also
-offer no structural validation; the repo's established
+Forge addressing is now delivered as the runtime-owned
+`RUNA_PROJECT_FORGE_ADDRESSES` payload, selected by configured resource
+selectors, while the corpus is methodology content resolved once at setup,
+not per-session identity. Env vars also offer no structural validation; the
+repo's established
 structural-impossibility tier (TOML + JSON Schema, the C-2/C-3 prior art)
 is available to a file and not to an environment.
 

--- a/skills/acquire/SKILL.md
+++ b/skills/acquire/SKILL.md
@@ -42,12 +42,13 @@ session that entrypoint opens.
    returns:
 
    ```
-   groundwork-mechanic run read-ticket ticket_number=<N> [--secret-env token=<ENV>]
+   groundwork-mechanic run read-ticket --tracker <selector> ticket_number=<N> [--secret-env token=<ENV>]
    ```
 
-   Deployment identity (owner, name, tracker, repository) comes from the
-   runtime-owned `RUNA_FORGE_*` atoms — do not pass it. The mechanic emits
-   `{handle, title, body, state}` for either forge.
+   Tracker coordinates come from runa's `RUNA_PROJECT_FORGE_ADDRESSES`
+   payload and the selected configured tracker — do not pass owner, name,
+   host, repository, endpoint URL, or tracker identity as bindings. The
+   mechanic emits `{handle, title, body, state}` for either forge.
 
 2. **Materialize the artifact body.** Pipe the read-ticket output through
    the materializer:

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -41,6 +41,44 @@ SOURCEHUT_TICKET_BODY = (
 )
 
 
+def forge_payload(
+    *,
+    github_repository: bool = False,
+    sourcehut_tracker: bool = False,
+) -> str:
+    instances = {}
+    repositories = []
+    trackers = []
+    if github_repository:
+        instances["github"] = {"type": "github", "host": "github.com"}
+        repositories.append(
+            {"id": "github-repo", "instance": "github", "owner": "tesserine", "name": "runa"}
+        )
+    if sourcehut_tracker:
+        instances["weforge"] = {
+            "type": "sourcehut",
+            "git_host": "git.weforge.build",
+            "tracker_host": "todo.weforge.build",
+        }
+        trackers.append(
+            {
+                "id": "sourcehut-tracker",
+                "instance": "weforge",
+                "owner": "operator",
+                "name": "weforge",
+                "tracker_id": "4",
+            }
+        )
+    return json.dumps(
+        {
+            "version": 1,
+            "instances": instances,
+            "repositories": repositories,
+            "trackers": trackers,
+        }
+    )
+
+
 def materialize(read_ticket_stdout: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(MATERIALIZE)],
@@ -79,8 +117,7 @@ class MaterializeTicketTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "runa",
+                    "RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(github_repository=True),
                 },
             ):
                 read = run_invocation(mechanic, {"ticket_number": "188"}, cwd=root)
@@ -149,10 +186,7 @@ class MaterializeTicketTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "RUNA_FORGE_TRACKER_ID": "4",
+                    "RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(sourcehut_tracker=True),
                 },
             ):
                 read = run_invocation(
@@ -259,15 +293,13 @@ class AcquisitionEntryEndToEndTests(unittest.TestCase):
             forge_env = {
                 **os.environ,
                 "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                "RUNA_FORGE_OWNER": "tesserine",
-                "RUNA_FORGE_NAME": "runa",
+                "RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(github_repository=True),
             }
             with mock.patch.dict(
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "runa",
+                    "RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(github_repository=True),
                 },
             ):
                 read = run_invocation(mechanic, {"ticket_number": "188"}, cwd=root)

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -20,20 +20,53 @@ from tooling.forge_operations import (
 
 ROOT = Path(__file__).resolve().parents[1]
 EARLY_ARC_OPERATIONS = ["create-ticket", "read-ticket", "claim-work-unit", "record-progress"]
-RUNA_FORGE_ENVIRONMENT_ATOMS = (
-    "RUNA_FORGE_TYPE",
-    "RUNA_FORGE_OWNER",
-    "RUNA_FORGE_NAME",
-    "RUNA_FORGE_TRACKER_ID",
-)
 
 
 def forge_cli_environment(**values: str) -> dict[str, str]:
     environment = os.environ.copy()
-    for atom in RUNA_FORGE_ENVIRONMENT_ATOMS:
-        environment.pop(atom, None)
+    environment.pop("RUNA_PROJECT_FORGE_ADDRESSES", None)
     environment.update(values)
     return environment
+
+
+def forge_payload(
+    *,
+    github_repository: bool = False,
+    sourcehut_repository: bool = False,
+    sourcehut_tracker: bool = False,
+    sourcehut_tracker_id: str | None = "4",
+) -> str:
+    instances = {}
+    repositories = []
+    trackers = []
+    if github_repository:
+        instances["github"] = {"type": "github", "host": "github.com"}
+        repositories.append(
+            {"id": "github-repo", "instance": "github", "owner": "tesserine", "name": "groundwork"}
+        )
+    if sourcehut_repository or sourcehut_tracker:
+        instances["weforge"] = {
+            "type": "sourcehut",
+            "git_host": "git.weforge.build",
+            "tracker_host": "todo.weforge.build",
+        }
+    if sourcehut_repository:
+        repositories.append(
+            {"id": "sourcehut-repo", "instance": "weforge", "owner": "operator", "name": "weforge"}
+        )
+    if sourcehut_tracker:
+        tracker = {"id": "sourcehut-tracker", "instance": "weforge", "owner": "operator", "name": "weforge"}
+        if sourcehut_tracker_id is not None:
+            tracker["tracker_id"] = sourcehut_tracker_id
+        trackers.append(tracker)
+    return json.dumps(
+        {
+            "version": 1,
+            "instances": instances,
+            "repositories": repositories,
+            "trackers": trackers,
+        }
+    )
 
 
 class ForgeOperationTests(unittest.TestCase):
@@ -86,14 +119,46 @@ class ForgeOperationTests(unittest.TestCase):
     def test_active_forge_type_defaults_to_github_when_no_env_or_override_exists(self) -> None:
         self.assertEqual("github", active_forge_type({}, None))
 
-    def test_active_forge_type_uses_explicit_override_before_environment(self) -> None:
-        self.assertEqual("sourcehut", active_forge_type({"RUNA_FORGE_TYPE": "github"}, "sourcehut"))
+    def test_active_forge_type_uses_explicit_override_before_payload(self) -> None:
+        self.assertEqual(
+            "sourcehut",
+            active_forge_type(
+                {"RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(github_repository=True)},
+                "sourcehut",
+            ),
+        )
 
-    def test_active_forge_type_uses_runa_forge_type_environment(self) -> None:
-        self.assertEqual("sourcehut", active_forge_type({"RUNA_FORGE_TYPE": "sourcehut"}, None))
+    def test_active_forge_type_uses_single_resource_payload(self) -> None:
+        self.assertEqual(
+            "sourcehut",
+            active_forge_type(
+                {"RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(sourcehut_tracker=True)},
+                None,
+            ),
+        )
 
-    def test_active_forge_type_does_not_fall_back_to_groundwork_forge_type_environment(self) -> None:
+    def test_active_forge_type_does_not_fall_back_to_retired_environment(self) -> None:
         self.assertEqual("github", active_forge_type({"GROUNDWORK_FORGE_TYPE": "sourcehut"}, None))
+
+    def test_durable_forge_docs_and_resolver_do_not_name_retired_repo_id_surface(self) -> None:
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        resolver = (ROOT / "tooling" / "forge_operations.py").read_text(encoding="utf-8")
+
+        for retired in ["GROUNDWORK_FORGE_REPO_ID", "repo_id"]:
+            self.assertNotIn(retired, readme)
+            self.assertNotIn(retired, resolver)
+        for required in ["RUNA_PROJECT_FORGE_ADDRESSES", "--repository", "--tracker"]:
+            self.assertIn(required, readme)
+
+        changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        unreleased = changelog.split("## [Unreleased]", 1)[1].split("\n## [", 1)[0]
+        for required in [
+            "GROUNDWORK_FORGE_ENDPOINT",
+            "GROUNDWORK_FORGE_REPO_ID",
+            "--repository",
+            "--tracker",
+        ]:
+            self.assertIn(required, unreleased)
 
     def test_resolve_operation_returns_exact_active_forge_mechanic(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -176,8 +241,7 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "groundwork",
+                    "RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(github_repository=True),
                 },
             ):
                 result = run_invocation(
@@ -198,8 +262,7 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "groundwork",
+                    "RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(github_repository=True),
                 },
             ):
                 result = run_invocation(
@@ -229,8 +292,7 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_TRACKER_ID": "4",
+                    "RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(sourcehut_tracker=True),
                 },
             ):
                 result = run_invocation(
@@ -248,8 +310,7 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_TRACKER_ID": "4",
+                    "RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(sourcehut_tracker=True),
                 },
             ):
                 result = run_invocation(
@@ -290,10 +351,7 @@ cat "{response}"
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "RUNA_FORGE_TRACKER_ID": "4",
+                    "RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(sourcehut_tracker=True),
                 },
             ):
                 result = run_invocation(
@@ -308,10 +366,7 @@ cat "{response}"
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "RUNA_FORGE_TRACKER_ID": "4",
+                    "RUNA_PROJECT_FORGE_ADDRESSES": forge_payload(sourcehut_tracker=True),
                 },
             ):
                 error_result = run_invocation(
@@ -494,11 +549,7 @@ cat "{response}"
                     "probe",
                 ],
                 env=forge_cli_environment(
-                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                    RUNA_FORGE_OWNER="operator",
-                    RUNA_FORGE_NAME="weforge",
-                    RUNA_FORGE_TRACKER_ID="4",
-                    GROUNDWORK_FORGE_REPO_ID="42",
+                    RUNA_PROJECT_FORGE_ADDRESSES=forge_payload(sourcehut_tracker=True),
                 ),
                 text=True,
                 stdout=subprocess.PIPE,
@@ -506,9 +557,9 @@ cat "{response}"
             )
 
         self.assertEqual(0, result.returncode, result.stderr)
-        self.assertEqual("42\n", result.stdout)
+        self.assertEqual("4\n", result.stdout)
 
-    def test_cli_resolves_sourcehut_deployment_values_from_runtime_and_groundwork_atoms(self) -> None:
+    def test_cli_resolves_sourcehut_deployment_values_from_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_sourcehut_deployment_probe_methodology(root)
@@ -525,11 +576,7 @@ cat "{response}"
                     "probe",
                 ],
                 env=forge_cli_environment(
-                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                    RUNA_FORGE_OWNER="operator",
-                    RUNA_FORGE_NAME="weforge",
-                    RUNA_FORGE_TRACKER_ID="4",
-                    GROUNDWORK_FORGE_REPO_ID="42",
+                    RUNA_PROJECT_FORGE_ADDRESSES=forge_payload(sourcehut_tracker=True),
                 ),
                 text=True,
                 stdout=subprocess.PIPE,
@@ -543,7 +590,6 @@ cat "{response}"
                 "https://git.weforge.build/query",
                 "git@git.weforge.build:~operator/weforge",
                 "4",
-                "42",
             ],
             result.stdout.strip().splitlines(),
         )
@@ -553,13 +599,8 @@ cat "{response}"
             root = Path(directory)
             self.write_sourcehut_tracker_probe_methodology(root)
             environment = forge_cli_environment(
-                RUNA_FORGE_TYPE="sourcehut",
-                GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                RUNA_FORGE_OWNER="operator",
-                RUNA_FORGE_NAME="weforge",
-                RUNA_FORGE_TRACKER_ID="4",
+                RUNA_PROJECT_FORGE_ADDRESSES=forge_payload(sourcehut_tracker=True),
             )
-            environment.pop("GROUNDWORK_FORGE_REPO_ID", None)
 
             result = subprocess.run(
                 [
@@ -579,7 +620,7 @@ cat "{response}"
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual(["https://todo.weforge.build/query", "4"], result.stdout.strip().splitlines())
 
-    def test_cli_names_missing_sourcehut_deployment_atom(self) -> None:
+    def test_cli_names_missing_sourcehut_payload_coordinate(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_sourcehut_deployment_probe_methodology(root)
@@ -596,10 +637,10 @@ cat "{response}"
                     "probe",
                 ],
                 env=forge_cli_environment(
-                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                    RUNA_FORGE_OWNER="operator",
-                    RUNA_FORGE_NAME="weforge",
-                    GROUNDWORK_FORGE_REPO_ID="42",
+                    RUNA_PROJECT_FORGE_ADDRESSES=forge_payload(
+                        sourcehut_tracker=True,
+                        sourcehut_tracker_id=None,
+                    ),
                 ),
                 text=True,
                 stdout=subprocess.PIPE,
@@ -607,9 +648,9 @@ cat "{response}"
             )
 
         self.assertNotEqual(0, result.returncode)
-        self.assertIn("RUNA_FORGE_TRACKER_ID", result.stderr)
+        self.assertIn("tracker_id", result.stderr)
 
-    def test_cli_resolves_github_repository_from_runtime_atoms_with_default_forge_type(self) -> None:
+    def test_cli_resolves_github_repository_from_payload_with_default_forge_type(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_github_deployment_probe_methodology(root)
@@ -624,8 +665,7 @@ cat "{response}"
                     "probe",
                 ],
                 env=forge_cli_environment(
-                    RUNA_FORGE_OWNER="tesserine",
-                    RUNA_FORGE_NAME="groundwork",
+                    RUNA_PROJECT_FORGE_ADDRESSES=forge_payload(github_repository=True),
                 ),
                 text=True,
                 stdout=subprocess.PIPE,
@@ -651,8 +691,7 @@ cat "{response}"
                     "repository=attacker/repo",
                 ],
                 env=forge_cli_environment(
-                    RUNA_FORGE_OWNER="tesserine",
-                    RUNA_FORGE_NAME="groundwork",
+                    RUNA_PROJECT_FORGE_ADDRESSES=forge_payload(github_repository=True),
                 ),
                 text=True,
                 stdout=subprocess.PIPE,
@@ -746,14 +785,14 @@ cat "{response}"
                 name = "probe"
                 purpose = "Probe deployment-value resolution."
                 forge_tag = "sourcehut"
-                default_invocation = 'printf "%s\\n" "$upload_repo_number"'
-                examples = ['printf "%s\\n" "$upload_repo_number"']
+                default_invocation = 'printf "%s\\n" "$upload_tracker_number"'
+                examples = ['printf "%s\\n" "$upload_tracker_number"']
 
                 [[parameters]]
-                name = "upload_repo_number"
-                purpose = "Repo ID under a deliberately non-canonical parameter name."
+                name = "upload_tracker_number"
+                purpose = "Tracker ID under a deliberately non-canonical parameter name."
                 required = true
-                deployment_value = "repo_id"
+                deployment_value = "tracker_id"
 
                 [outcome]
                 description = "Printed."
@@ -786,7 +825,7 @@ cat "{response}"
                 name = "probe"
                 purpose = "Probe SourceHut deployment-value resolution."
                 forge_tag = "sourcehut"
-                default_invocation = 'printf "%s\\n%s\\n%s\\n%s\\n%s\\n" "$todo_url" "$git_url" "$remote" "$tracker" "$repo"'
+                default_invocation = 'printf "%s\\n%s\\n%s\\n%s\\n" "$todo_url" "$git_url" "$remote" "$tracker"'
                 examples = ['printf "%s\\n" "$remote"']
 
                 [[parameters]]
@@ -812,12 +851,6 @@ cat "{response}"
                 purpose = "Tracker ID."
                 required = true
                 deployment_value = "tracker_id"
-
-                [[parameters]]
-                name = "repo"
-                purpose = "Repo ID."
-                required = true
-                deployment_value = "repo_id"
 
                 [outcome]
                 description = "Printed."

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -53,14 +53,14 @@ class MechanicTests(unittest.TestCase):
         mechanic = {
             "name": "sourcehut-upload",
             "purpose": "Upload to a configured forge repository.",
-            "default_invocation": 'printf "%s\\n" "$repo_number"',
-            "examples": ['printf "%s\\n" "$repo_number"'],
+            "default_invocation": 'printf "%s\\n" "$tracker_number"',
+            "examples": ['printf "%s\\n" "$tracker_number"'],
             "parameters": [
                 {
-                    "name": "repo_number",
-                    "purpose": "Configured forge repository ID.",
+                    "name": "tracker_number",
+                    "purpose": "Configured forge tracker ID.",
                     "required": True,
-                    "deployment_value": "repo_id",
+                    "deployment_value": "tracker_id",
                 }
             ],
             "outcome": {"description": "Printed."},
@@ -72,15 +72,15 @@ class MechanicTests(unittest.TestCase):
         mechanic = {
             "name": "sourcehut-upload",
             "purpose": "Upload to a configured forge repository.",
-            "default_invocation": 'printf "%s\\n" "$repo_number"',
-            "examples": ['printf "%s\\n" "$repo_number"'],
+            "default_invocation": 'printf "%s\\n" "$tracker_number"',
+            "examples": ['printf "%s\\n" "$tracker_number"'],
             "parameters": [
                 {
-                    "name": "repo_number",
-                    "purpose": "Configured forge repository ID.",
+                    "name": "tracker_number",
+                    "purpose": "Configured forge tracker ID.",
                     "required": True,
                     "secret": True,
-                    "deployment_value": "repo_id",
+                    "deployment_value": "tracker_id",
                 }
             ],
             "outcome": {"description": "Printed."},

--- a/tooling/forge_operations.py
+++ b/tooling/forge_operations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import tomllib
@@ -9,10 +10,7 @@ from typing import Any, Mapping
 
 
 ROOT = Path(__file__).resolve().parents[1]
-RUNA_FORGE_TYPE = "RUNA_FORGE_TYPE"
-RUNA_FORGE_OWNER = "RUNA_FORGE_OWNER"
-RUNA_FORGE_NAME = "RUNA_FORGE_NAME"
-RUNA_FORGE_TRACKER_ID = "RUNA_FORGE_TRACKER_ID"
+FORGE_ADDRESSES_ENV = "RUNA_PROJECT_FORGE_ADDRESSES"
 
 
 class ForgeOperationError(ValueError):
@@ -22,13 +20,35 @@ class ForgeOperationError(ValueError):
 def active_forge_type(environment: Mapping[str, str], override: str | None) -> str:
     if override:
         return override
-    return environment.get(RUNA_FORGE_TYPE) or "github"
+    payload = _forge_address_payload(environment)
+    resources = [*_resource_entries(payload, "repositories"), *_resource_entries(payload, "trackers")]
+    forge_types = {
+        str(instance.get("type"))
+        for resource in resources
+        if isinstance(instance := _resource_instance(payload, resource), Mapping)
+        and isinstance(instance.get("type"), str)
+    }
+    if len(forge_types) == 1:
+        return forge_types.pop()
+    return "github"
 
 
-def resolve_operation(root: Path | str, operation: str, *, forge_type: str | None = None) -> dict[str, Any]:
+def resolve_operation(
+    root: Path | str,
+    operation: str,
+    *,
+    forge_type: str | None = None,
+    repository_selector: str | None = None,
+    tracker_selector: str | None = None,
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
     root_path = Path(root)
     manifest = _load_toml(root_path / "manifest.toml")
-    selected_forge_type = active_forge_type(os.environ, forge_type)
+    selected_forge_type = forge_type or _selected_forge_type(
+        environment or os.environ,
+        repository_selector=repository_selector,
+        tracker_selector=tracker_selector,
+    )
     forge_tags = _manifest_names(manifest, "forge_tags")
     if selected_forge_type not in forge_tags:
         raise ForgeOperationError(f"forge type `{selected_forge_type}` does not resolve in forge_tags")
@@ -57,15 +77,26 @@ def inspect_invocation(mechanic: Mapping[str, Any], values: Mapping[str, str]) -
     return _invocation_body(mechanic)
 
 
-def render_shell_invocation(mechanic: Mapping[str, Any], values: Mapping[str, str]) -> tuple[str, dict[str, str]]:
+def render_shell_invocation(
+    mechanic: Mapping[str, Any],
+    values: Mapping[str, str],
+    *,
+    repository_selector: str | None = None,
+    tracker_selector: str | None = None,
+) -> tuple[str, dict[str, str]]:
     parameters = _parameters(mechanic)
     deployment_parameters = _deployment_parameters(mechanic)
     provided_deployment_values = sorted(set(values) & set(deployment_parameters))
     if provided_deployment_values:
         raise ForgeOperationError(
-            f"deployment-resolved parameter(s) must come from the configured forge environment: {', '.join(provided_deployment_values)}"
+            f"deployment-resolved parameter(s) must come from the configured forge address payload: {', '.join(provided_deployment_values)}"
         )
-    deployment_values = _deployment_parameter_values(mechanic, os.environ)
+    deployment_values = _deployment_parameter_values(
+        mechanic,
+        os.environ,
+        repository_selector=repository_selector,
+        tracker_selector=tracker_selector,
+    )
     resolved_values = {**values, **deployment_values}
     missing = [name for name, parameter in parameters.items() if parameter.get("required") and name not in resolved_values]
     if missing:
@@ -81,8 +112,15 @@ def run_invocation(
     values: Mapping[str, str],
     *,
     cwd: Path | str,
+    repository_selector: str | None = None,
+    tracker_selector: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    command, invocation_environment = render_shell_invocation(mechanic, values)
+    command, invocation_environment = render_shell_invocation(
+        mechanic,
+        values,
+        repository_selector=repository_selector,
+        tracker_selector=tracker_selector,
+    )
     environment = os.environ.copy()
     environment.update(invocation_environment)
     return subprocess.run(
@@ -100,17 +138,23 @@ def run_invocation(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Resolve and invoke Groundwork forge operations.")
     parser.add_argument("--root", default=str(ROOT), help="Groundwork methodology root. Defaults to this checkout.")
-    parser.add_argument("--forge-type", help="Active forge type override. Defaults to RUNA_FORGE_TYPE, then github.")
+    parser.add_argument("--forge-type", help="Active forge type override for compatibility; selectors normally determine the type.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     resolve_parser = subparsers.add_parser("resolve", help="Print the resolved mechanic path-equivalent name.")
     resolve_parser.add_argument("operation")
+    resolve_parser.add_argument("--repository", help="Configured repository selector for repository operations.")
+    resolve_parser.add_argument("--tracker", help="Configured tracker selector for tracker operations.")
 
     inspect_parser = subparsers.add_parser("inspect", help="Print the constant shell invocation body.")
     inspect_parser.add_argument("operation")
+    inspect_parser.add_argument("--repository", help="Configured repository selector for repository operations.")
+    inspect_parser.add_argument("--tracker", help="Configured tracker selector for tracker operations.")
 
     run_parser = subparsers.add_parser("run", help="Run the resolved mechanic with parameter bindings.")
     run_parser.add_argument("operation")
+    run_parser.add_argument("--repository", help="Configured repository selector for repository operations.")
+    run_parser.add_argument("--tracker", help="Configured tracker selector for tracker operations.")
     run_parser.add_argument(
         "--secret-env",
         action="append",
@@ -122,7 +166,13 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
     try:
-        mechanic = resolve_operation(args.root, args.operation, forge_type=args.forge_type)
+        mechanic = resolve_operation(
+            args.root,
+            args.operation,
+            forge_type=args.forge_type,
+            repository_selector=args.repository,
+            tracker_selector=args.tracker,
+        )
         if args.command == "resolve":
             print(f"{mechanic['name']}[{mechanic['forge_tag']}]")
             return 0
@@ -132,7 +182,13 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "run":
             values = _parse_bindings(args.bindings, mechanic)
             values.update(_parse_secret_env_bindings(args.secret_env, mechanic, os.environ))
-            result = run_invocation(mechanic, values, cwd=Path.cwd())
+            result = run_invocation(
+                mechanic,
+                values,
+                cwd=Path.cwd(),
+                repository_selector=args.repository,
+                tracker_selector=args.tracker,
+            )
             if result.stdout:
                 print(result.stdout, end="")
             if result.stderr:
@@ -201,6 +257,9 @@ def _deployment_parameters(mechanic: Mapping[str, Any]) -> dict[str, str]:
 def _deployment_parameter_values(
     mechanic: Mapping[str, Any],
     environment: Mapping[str, str],
+    *,
+    repository_selector: str | None = None,
+    tracker_selector: str | None = None,
 ) -> dict[str, str]:
     deployments = _deployment_parameters(mechanic)
     if not deployments:
@@ -208,7 +267,13 @@ def _deployment_parameter_values(
     forge_type = mechanic.get("forge_tag")
     if not isinstance(forge_type, str):
         raise ForgeOperationError("deployment-resolved parameters require mechanic forge_tag")
-    resolved = _resolved_deployment_values(forge_type, set(deployments.values()), environment)
+    resolved = _resolved_deployment_values(
+        forge_type,
+        set(deployments.values()),
+        environment,
+        repository_selector=repository_selector,
+        tracker_selector=tracker_selector,
+    )
     values: dict[str, str] = {}
     for name, deployment_value in deployments.items():
         values[name] = resolved[deployment_value]
@@ -219,9 +284,25 @@ def _resolved_deployment_values(
     forge_type: str,
     deployment_values: set[str],
     environment: Mapping[str, str],
+    *,
+    repository_selector: str | None = None,
+    tracker_selector: str | None = None,
 ) -> dict[str, str]:
+    payload = _forge_address_payload(environment, required=True)
+    resource = _selected_resource(
+        payload,
+        deployment_values,
+        repository_selector=repository_selector,
+        tracker_selector=tracker_selector,
+    )
+    instance = _resource_instance(payload, resource)
     return {
-        deployment_value: _resolve_deployment_value(forge_type, deployment_value, environment)
+        deployment_value: _resolve_deployment_value(
+            forge_type,
+            deployment_value,
+            resource,
+            instance,
+        )
         for deployment_value in deployment_values
     }
 
@@ -229,55 +310,191 @@ def _resolved_deployment_values(
 def _resolve_deployment_value(
     forge_type: str,
     deployment_value: str,
-    environment: Mapping[str, str],
+    resource: Mapping[str, Any],
+    instance: Mapping[str, Any],
 ) -> str:
     if forge_type == "github":
         if deployment_value == "owner":
-            return _required_environment(environment, RUNA_FORGE_OWNER)
+            return _required_resource_value(resource, "owner")
         if deployment_value == "name":
-            return _required_environment(environment, RUNA_FORGE_NAME)
+            return _required_resource_value(resource, "name")
         if deployment_value == "repository":
-            owner = _required_environment(environment, RUNA_FORGE_OWNER)
-            name = _required_environment(environment, RUNA_FORGE_NAME)
+            owner = _required_resource_value(resource, "owner")
+            name = _required_resource_value(resource, "name")
             return f"{owner}/{name}"
         raise ForgeOperationError(
             f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
         )
     if forge_type == "sourcehut":
         if deployment_value == "owner":
-            return _required_environment(environment, RUNA_FORGE_OWNER)
+            return _required_resource_value(resource, "owner")
         if deployment_value == "name":
-            return _required_environment(environment, RUNA_FORGE_NAME)
+            return _required_resource_value(resource, "name")
         if deployment_value == "repository":
-            owner = _required_environment(environment, RUNA_FORGE_OWNER)
-            name = _required_environment(environment, RUNA_FORGE_NAME)
+            owner = _required_resource_value(resource, "owner")
+            name = _required_resource_value(resource, "name")
             return f"{owner}/{name}"
         if deployment_value == "todo_query_url":
-            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
-            return f"https://todo.{endpoint}/query"
+            host = _service_host(instance, "tracker")
+            return f"https://{host}/query"
         if deployment_value == "git_query_url":
-            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
-            return f"https://git.{endpoint}/query"
+            host = _service_host(instance, "git")
+            return f"https://{host}/query"
         if deployment_value == "ssh_remote":
-            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
-            owner = _required_environment(environment, RUNA_FORGE_OWNER)
-            name = _required_environment(environment, RUNA_FORGE_NAME)
-            return f"git@git.{endpoint}:~{owner}/{name}"
+            host = _service_host(instance, "git")
+            owner = _required_resource_value(resource, "owner")
+            name = _required_resource_value(resource, "name")
+            return f"git@{host}:~{owner}/{name}"
         if deployment_value == "tracker_id":
-            return _required_environment(environment, RUNA_FORGE_TRACKER_ID)
-        if deployment_value == "repo_id":
-            return _required_environment(environment, "GROUNDWORK_FORGE_REPO_ID")
+            return _required_resource_value(resource, "tracker_id")
         raise ForgeOperationError(
             f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
         )
     raise ForgeOperationError(f"forge type `{forge_type}` does not support deployment identity")
 
 
-def _required_environment(environment: Mapping[str, str], name: str) -> str:
-    value = environment.get(name)
+def _required_resource_value(resource: Mapping[str, Any], name: str) -> str:
+    value = resource.get(name)
     if value is None or value == "":
-        raise ForgeOperationError(f"missing required deployment identity atom `{name}`")
-    return value
+        raise ForgeOperationError(f"selected forge resource is missing required coordinate `{name}`")
+    return str(value)
+
+
+def _forge_address_payload(
+    environment: Mapping[str, str],
+    *,
+    required: bool = False,
+) -> Mapping[str, Any]:
+    raw = environment.get(FORGE_ADDRESSES_ENV)
+    if not raw:
+        if required:
+            raise ForgeOperationError(f"missing required forge address payload `{FORGE_ADDRESSES_ENV}`")
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ForgeOperationError(f"{FORGE_ADDRESSES_ENV} is not valid JSON: {error}") from error
+    if not isinstance(payload, dict):
+        raise ForgeOperationError(f"{FORGE_ADDRESSES_ENV} must be a JSON object")
+    return payload
+
+
+def _resource_entries(payload: Mapping[str, Any], key: str) -> list[Mapping[str, Any]]:
+    collection = payload.get(key, [])
+    if isinstance(collection, list):
+        return [entry for entry in collection if isinstance(entry, Mapping)]
+    if isinstance(collection, Mapping):
+        entries = []
+        for resource_id, entry in collection.items():
+            if isinstance(entry, Mapping):
+                merged = dict(entry)
+                merged.setdefault("id", resource_id)
+                entries.append(merged)
+        return entries
+    return []
+
+
+def _resource_instance(payload: Mapping[str, Any], resource: Mapping[str, Any]) -> Mapping[str, Any]:
+    instance_id = resource.get("instance")
+    instances = payload.get("instances", {})
+    if isinstance(instances, Mapping) and instance_id in instances and isinstance(instances[instance_id], Mapping):
+        instance = dict(instances[instance_id])
+        instance.setdefault("id", instance_id)
+        return instance
+    for instance in _resource_entries(payload, "instances"):
+        if instance.get("id") == instance_id:
+            return instance
+    raise ForgeOperationError(f"configured resource references unknown forge instance `{instance_id}`")
+
+
+def _selected_forge_type(
+    environment: Mapping[str, str],
+    *,
+    repository_selector: str | None,
+    tracker_selector: str | None,
+) -> str:
+    payload = _forge_address_payload(environment)
+    if not payload:
+        return "github"
+    resource = _selected_resource(
+        payload,
+        set(),
+        repository_selector=repository_selector,
+        tracker_selector=tracker_selector,
+    )
+    instance = _resource_instance(payload, resource)
+    forge_type = instance.get("type")
+    if not isinstance(forge_type, str) or not forge_type:
+        raise ForgeOperationError("selected forge instance is missing required type")
+    return forge_type
+
+
+def _selected_resource(
+    payload: Mapping[str, Any],
+    deployment_values: set[str],
+    *,
+    repository_selector: str | None,
+    tracker_selector: str | None,
+) -> Mapping[str, Any]:
+    if tracker_selector:
+        return _select_resource(payload, "trackers", tracker_selector)
+    if repository_selector:
+        return _select_resource(payload, "repositories", repository_selector)
+    if deployment_values & {"tracker_id", "todo_query_url"}:
+        return _single_resource(payload, "trackers")
+    if deployment_values & {"ssh_remote", "git_query_url"}:
+        return _single_resource(payload, "repositories")
+    repositories = _resource_entries(payload, "repositories")
+    trackers = _resource_entries(payload, "trackers")
+    candidates = [*repositories, *trackers]
+    if len(candidates) == 1:
+        return candidates[0]
+    raise ForgeOperationError("forge operation requires --repository or --tracker to select a configured resource")
+
+
+def _single_resource(payload: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    resources = _resource_entries(payload, key)
+    if len(resources) != 1:
+        selector = "--repository" if key == "repositories" else "--tracker"
+        raise ForgeOperationError(f"forge operation requires {selector} to select one configured resource")
+    return resources[0]
+
+
+def _select_resource(payload: Mapping[str, Any], key: str, selector: str) -> Mapping[str, Any]:
+    matches = [resource for resource in _resource_entries(payload, key) if _resource_matches(resource, selector)]
+    if len(matches) != 1:
+        raise ForgeOperationError(f"selector `{selector}` resolved to {len(matches)} configured resources; expected exactly 1")
+    return matches[0]
+
+
+def _resource_matches(resource: Mapping[str, Any], selector: str) -> bool:
+    if resource.get("id") == selector:
+        return True
+    instance = resource.get("instance")
+    owner = resource.get("owner")
+    name = resource.get("name")
+    if not all(isinstance(value, str) and value for value in [instance, owner, name]):
+        return False
+    if selector == f"{instance}:{owner}/{name}":
+        return True
+    tracker_id = resource.get("tracker_id")
+    return tracker_id is not None and selector == f"{instance}:{owner}/{name}/{tracker_id}"
+
+
+def _service_host(instance: Mapping[str, Any], service: str) -> str:
+    direct_name = f"{service}_host"
+    value = instance.get(direct_name)
+    if isinstance(value, str) and value:
+        return value
+    services = instance.get("services")
+    if isinstance(services, Mapping):
+        value = services.get(service)
+        if isinstance(value, str) and value:
+            return value
+    value = instance.get("host")
+    if service in {"git", "tracker"} and instance.get("type") == "github" and isinstance(value, str) and value:
+        return value
+    raise ForgeOperationError(f"selected forge instance is missing required `{service}` service host")
 
 
 def _invocation_body(mechanic: Mapping[str, Any]) -> str:


### PR DESCRIPTION
## Summary

This is the groundwork side of the coupled runa#199 / groundwork#420 change. Forge mechanics now consume runa’s `RUNA_PROJECT_FORGE_ADDRESSES` payload and use `--repository` / `--tracker` selectors instead of retired environment coordinate sourcing.

The README, ADRs, acquire skill, resolver, and tests were updated to remove the stale `repo_id` / `GROUNDWORK_FORGE_REPO_ID` path and document the selector/payload model.

## Validation

- `python -m unittest tests.test_forge_operations tests.test_acquisition tests.test_mechanics`
- `python -m py_compile tooling/forge_operations.py`
- Swept README/docs/skills/protocols/resolver for retired forge surfaces: `GROUNDWORK_FORGE_ENDPOINT`, `GROUNDWORK_FORGE_REPO_ID`, `repo_id`, `RUNA_FORGE_*`

## Coupling

Must land with tesserine/runa#199 contract update so the delivered payload exists before these mechanics depend on it.