### PR TITLE
Consume runa forge-address contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ When `manifest.toml`, `mechanics/`, and the forge-operation resolver are
 present, the installer also projects a managed runtime bundle under
 `~/.groundwork/`. The bundle contains the manifest, mechanic library, resolver
 module, and `bin/groundwork-mechanic`, so installed protocol sessions can
-resolve forge-invariant operations through the active `RUNA_FORGE_TYPE`
-configuration without reaching back into the source checkout. Installed
+resolve forge-invariant operations through runa's `RUNA_FORGE_ADDRESSES`
+payload without reaching back into the source checkout. Installed
 protocol copies reference the managed resolver path directly, so users do not
 need to add `~/.groundwork/bin` to `PATH`.
 
@@ -168,12 +168,11 @@ The early-arc tracker operations are forge-invariant at the call site and
 forge-tagged in the mechanic library: `create-ticket`, `read-ticket`,
 `claim-work-unit`, and `record-progress` resolve to either GitHub issue
 mechanics or SourceHut ticket mechanics. Ticket creation emits the
-forge-assigned identity needed for a `work-unit.handle`: GitHub emits
-`forge_tag`, issue `url`, and issue `number`; SourceHut emits `forge_tag`,
-`tracker_id`, and ticket `number`. The mechanics validate the expected API or
-GraphQL result field before accepting a response, so an HTTP- or CLI-successful
-response that contains application errors or omits the expected operation
-result is rejected.
+forge-address work-unit handle needed for `work-unit.handle`: `tracker`,
+`tracker_identity`, `work_unit_identity`, and `number`. The mechanics validate
+the expected API or GraphQL result field before accepting a response, so an
+HTTP- or CLI-successful response that contains application errors or omits the
+expected operation result is rejected.
 
 Secret mechanic parameters must be bound from an environment variable rather
 than from `NAME=VALUE` argv bindings. For example, pass
@@ -183,36 +182,31 @@ resolver command line.
 
 Forge deployment identity is also supplied by environment contract, not by
 mechanic call-site bindings. Mechanics mark deployment-resolved parameters with
-`deployment_value`, and `groundwork-mechanic` derives those values from these
-atoms:
+`deployment_value`, and `groundwork-mechanic` derives those values from the
+validated `RUNA_FORGE_ADDRESSES` payload:
 
-| Variable | Holds | Example | Forge-assigned? |
+| Payload field | Holds | Example | Forge-assigned? |
 |---|---|---|---|
-| `RUNA_FORGE_TYPE` | active forge selector, defaulting to `github` | `sourcehut` | no |
-| `RUNA_FORGE_OWNER` | tracker/repo owner handle | `operator` | no |
-| `RUNA_FORGE_NAME` | tracker/repo name | `weforge` | no |
-| `RUNA_FORGE_TRACKER_ID` | tracker integer ID | `4` | yes |
-| `GROUNDWORK_FORGE_ENDPOINT` | deployment host used to derive service hosts | `weforge.build` | no |
-| `GROUNDWORK_FORGE_REPO_ID` | git repo integer ID | `42` | yes |
+| `repositories[].identity` | repository identity | `github:github.com/tesserine/groundwork` | no |
+| `trackers[].identity` | tracker identity | `sourcehut:todo.weforge.build/~operator/weforge:4` | partly |
+| `trackers[].tracker_id` | SourceHut tracker integer ID | `4` | yes |
 
-For SourceHut, the resolver derives `todo_query_url` as
-`https://todo.<endpoint>/query`, `git_query_url` as
-`https://git.<endpoint>/query`, and `ssh_remote` as
-`git@git.<endpoint>:~<owner>/<name>`, while `tracker_id` and `repo_id` come
-directly from their atoms. For GitHub, it derives `repository` as
-`<owner>/<name>`. Runa owns the four scoped identity atoms it injects into
-agent and MCP environments; Groundwork still owns endpoint and repo-id atoms
-that are not part of runtime scoped identity. The atoms are the only deployment
-facts; composed endpoints and remotes are not separate configuration values.
+For SourceHut, the resolver derives `todo_query_url` from the tracker host,
+`git_query_url` and `ssh_remote` from the git host, owner, and repository, and
+uses the tracker id from the payload. For GitHub, it derives `repository` as
+`<owner>/<repository>`. Runa owns the scoped identity payload it injects into
+agent and MCP environments. The payload is the only deployment facts source;
+composed endpoints and remotes are not separate configuration values.
 
 The cross-repo seam for this ticket identity is documented in
 [`docs/architecture/connecting-structure.md`](docs/architecture/connecting-structure.md#phase-2-forge-tagging-seam).
-Groundwork owns the schema-as-contract shape of `work-unit.handle`, the
-mechanics that produce handles from active deployment identity, and the
-decompose delivery rules. runa owns scoped runtime enforcement: exact recorded
-`--work-unit` ids, tracker-handle consistency, duplicate-root rejection, and
-active deployment agreement. Cross-deployment work is composed from separate
-sessions; a handle never overrides the active deployment.
+runa owns the `work-unit.handle` format in the forge-address contract.
+Groundwork owns the mechanics that produce handles from runa's validated
+deployment payload, the derived schema copy, and the decompose delivery rules.
+runa owns scoped runtime enforcement: exact recorded `--work-unit` ids,
+tracker-handle consistency, duplicate-root rejection, and active deployment
+agreement. Cross-deployment work is composed from separate sessions; a handle
+never overrides the active deployment.
 
 The source checkout must be clean and pinned at a tag or full commit SHA. The
 command refuses branch checkouts because a branch is a moving source. To update

--- a/mechanics/github/claim-work-unit.toml
+++ b/mechanics/github/claim-work-unit.toml
@@ -1,7 +1,7 @@
 name = "claim-work-unit"
 purpose = "Claim a GitHub work-unit issue by assigning it in the active repository."
 forge_tag = "github"
-default_invocation = '''response=$(mktemp) && trap 'rm -f "$response"' EXIT && gh api "repos/${repository}/issues/${ticket_number}" --method PATCH -F "assignees[]=${assignee}" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); url=payload.get("html_url"); number=payload.get("number"); sys.exit("GitHub claim-work-unit API response contained errors or omitted html_url/number") if "errors" in payload or not isinstance(url, str) or not url or not isinstance(number, int) else print(json.dumps({"handle":{"forge_tag":"github","url":url,"number":number}}, separators=(",", ":")))' "$response"'''
+default_invocation = '''response=$(mktemp) && trap 'rm -f "$response"' EXIT && gh api "repos/${repository}/issues/${ticket_number}" --method PATCH -F "assignees[]=${assignee}" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker=sys.argv[2]; tracker_identity=sys.argv[3]; number=payload.get("number"); sys.exit("GitHub claim-work-unit API response contained errors or omitted issue number") if "errors" in payload or not isinstance(number, int) else print(json.dumps({"handle":{"tracker":tracker,"tracker_identity":tracker_identity,"work_unit_identity":f"{tracker_identity}#{number}","number":number}}, separators=(",", ":")))' "$response" "$tracker" "$tracker_identity"'''
 examples = [
   'gh api repos/tesserine/groundwork/issues/369 --method PATCH -F assignees[]=operator',
 ]
@@ -11,6 +11,18 @@ name = "repository"
 purpose = "GitHub repository in OWNER/REPO form."
 required = true
 deployment_value = "repository"
+
+[[parameters]]
+name = "tracker"
+purpose = "Authoritative tracker selector name backing the GitHub repository."
+required = true
+deployment_value = "tracker"
+
+[[parameters]]
+name = "tracker_identity"
+purpose = "Authoritative runa tracker identity backing the GitHub repository."
+required = true
+deployment_value = "tracker_identity"
 
 [[parameters]]
 name = "ticket_number"

--- a/mechanics/github/create-ticket.toml
+++ b/mechanics/github/create-ticket.toml
@@ -1,7 +1,7 @@
 name = "create-ticket"
-purpose = "Create a GitHub issue in the active repository and emit the forge-tagged work-unit handle identity."
+purpose = "Create a GitHub issue in the active repository and emit the forge-address work-unit handle identity."
 forge_tag = "github"
-default_invocation = '''response=$(mktemp) && trap 'rm -f "$response"' EXIT && gh api "repos/${repository}/issues" --method POST -f "title=${title}" -F "body=@${body_file}" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); url=payload.get("html_url"); number=payload.get("number"); sys.exit("GitHub create-ticket API response contained errors or omitted html_url/number") if "errors" in payload or not isinstance(url, str) or not url or not isinstance(number, int) else print(json.dumps({"forge_tag":"github","url":url,"number":number}, separators=(",", ":")))' "$response"'''
+default_invocation = '''response=$(mktemp) && trap 'rm -f "$response"' EXIT && gh api "repos/${repository}/issues" --method POST -f "title=${title}" -F "body=@${body_file}" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker=sys.argv[2]; tracker_identity=sys.argv[3]; number=payload.get("number"); sys.exit("GitHub create-ticket API response contained errors or omitted issue number") if "errors" in payload or not isinstance(number, int) else print(json.dumps({"tracker":tracker,"tracker_identity":tracker_identity,"work_unit_identity":f"{tracker_identity}#{number}","number":number}, separators=(",", ":")))' "$response" "$tracker" "$tracker_identity"'''
 examples = [
   '''gh api repos/tesserine/groundwork/issues --method POST -f title='Add work unit' -F body=@/tmp/work-unit.md''',
 ]
@@ -11,6 +11,18 @@ name = "repository"
 purpose = "GitHub repository in OWNER/REPO form."
 required = true
 deployment_value = "repository"
+
+[[parameters]]
+name = "tracker"
+purpose = "Authoritative tracker selector name backing the GitHub repository."
+required = true
+deployment_value = "tracker"
+
+[[parameters]]
+name = "tracker_identity"
+purpose = "Authoritative runa tracker identity backing the GitHub repository."
+required = true
+deployment_value = "tracker_identity"
 
 [[parameters]]
 name = "title"
@@ -23,4 +35,4 @@ purpose = "Path to a file containing the issue body."
 required = true
 
 [outcome]
-description = "A GitHub issue exists in the active repository and stdout contains a work-unit handle with forge_tag, url, and number."
+description = "A GitHub issue exists in the active repository and stdout contains a forge-address work-unit handle."

--- a/mechanics/github/read-ticket.toml
+++ b/mechanics/github/read-ticket.toml
@@ -1,7 +1,7 @@
 name = "read-ticket"
 purpose = "Read a GitHub issue from the active repository and emit its ticket state with a work-unit handle."
 forge_tag = "github"
-default_invocation = '''response=$(mktemp) && trap 'rm -f "$response"' EXIT && gh api "repos/${repository}/issues/${ticket_number}" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); url=payload.get("html_url"); number=payload.get("number"); title=payload.get("title"); body=payload.get("body"); state=payload.get("state"); sys.exit("GitHub read-ticket API response contained errors or omitted issue fields") if "errors" in payload or not isinstance(url, str) or not url or not isinstance(number, int) or not isinstance(title, str) or not isinstance(state, str) or body is not None and not isinstance(body, str) else print(json.dumps({"handle":{"forge_tag":"github","url":url,"number":number},"title":title,"body":body,"state":state}, separators=(",", ":")))' "$response"'''
+default_invocation = '''response=$(mktemp) && trap 'rm -f "$response"' EXIT && gh api "repos/${repository}/issues/${ticket_number}" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker=sys.argv[2]; tracker_identity=sys.argv[3]; number=payload.get("number"); title=payload.get("title"); body=payload.get("body"); state=payload.get("state"); sys.exit("GitHub read-ticket API response contained errors or omitted issue fields") if "errors" in payload or not isinstance(number, int) or not isinstance(title, str) or not isinstance(state, str) or body is not None and not isinstance(body, str) else print(json.dumps({"handle":{"tracker":tracker,"tracker_identity":tracker_identity,"work_unit_identity":f"{tracker_identity}#{number}","number":number},"title":title,"body":body,"state":state}, separators=(",", ":")))' "$response" "$tracker" "$tracker_identity"'''
 examples = [
   'gh api repos/tesserine/groundwork/issues/369',
 ]
@@ -11,6 +11,18 @@ name = "repository"
 purpose = "GitHub repository in OWNER/REPO form."
 required = true
 deployment_value = "repository"
+
+[[parameters]]
+name = "tracker"
+purpose = "Authoritative tracker selector name backing the GitHub repository."
+required = true
+deployment_value = "tracker"
+
+[[parameters]]
+name = "tracker_identity"
+purpose = "Authoritative runa tracker identity backing the GitHub repository."
+required = true
+deployment_value = "tracker_identity"
 
 [[parameters]]
 name = "ticket_number"

--- a/mechanics/sourcehut/claim-work-unit.toml
+++ b/mechanics/sourcehut/claim-work-unit.toml
@@ -1,7 +1,7 @@
 name = "claim-work-unit"
 purpose = "Claim a SourceHut work-unit ticket by assigning a user in the active tracker."
 forge_tag = "sourcehut"
-default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; tracker_id=int(sys.argv[1]); ticket_number=int(sys.argv[2]); user_id=int(sys.argv[3]); print(json.dumps({"query":"mutation assignUser($trackerId: Int!, $ticketId: Int!, $userId: Int!) { assignUser(trackerId: $trackerId, ticketId: $ticketId, userId: $userId) { id ticket { id ref subject } } }","variables":{"trackerId":tracker_id,"ticketId":ticket_number,"userId":user_id}}))' "$tracker_id" "$ticket_number" "$assignee_user_id" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker_id=int(sys.argv[2]); data=payload.get("data"); event=data.get("assignUser") if isinstance(data, dict) else None; ticket=event.get("ticket") if isinstance(event, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; sys.exit("SourceHut assignUser GraphQL response contained errors or omitted data.assignUser.ticket.id") if "errors" in payload or not isinstance(number, int) else print(json.dumps({"handle":{"forge_tag":"sourcehut","tracker_id":tracker_id,"number":number}}, separators=(",", ":")))' "$response" "$tracker_id"'''
+default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; tracker_id=int(sys.argv[1]); ticket_number=int(sys.argv[2]); user_id=int(sys.argv[3]); print(json.dumps({"query":"mutation assignUser($trackerId: Int!, $ticketId: Int!, $userId: Int!) { assignUser(trackerId: $trackerId, ticketId: $ticketId, userId: $userId) { id ticket { id ref subject } } }","variables":{"trackerId":tracker_id,"ticketId":ticket_number,"userId":user_id}}))' "$tracker_id" "$ticket_number" "$assignee_user_id" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker=sys.argv[2]; tracker_identity=sys.argv[3]; data=payload.get("data"); event=data.get("assignUser") if isinstance(data, dict) else None; ticket=event.get("ticket") if isinstance(event, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; sys.exit("SourceHut assignUser GraphQL response contained errors or omitted data.assignUser.ticket.id") if "errors" in payload or not isinstance(number, int) else print(json.dumps({"handle":{"tracker":tracker,"tracker_identity":tracker_identity,"work_unit_identity":f"{tracker_identity}#{number}","number":number}}, separators=(",", ":")))' "$response" "$tracker" "$tracker_identity"'''
 examples = [
   '''curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-claim-ticket.json https://todo.sr.ht/query''',
 ]
@@ -11,6 +11,18 @@ name = "tracker_id"
 purpose = "todo.sr.ht tracker ID containing work-unit tickets."
 required = true
 deployment_value = "tracker_id"
+
+[[parameters]]
+name = "tracker"
+purpose = "Authoritative tracker selector name."
+required = true
+deployment_value = "tracker"
+
+[[parameters]]
+name = "tracker_identity"
+purpose = "Authoritative runa tracker identity."
+required = true
+deployment_value = "tracker_identity"
 
 [[parameters]]
 name = "todo_query_url"

--- a/mechanics/sourcehut/create-ticket.toml
+++ b/mechanics/sourcehut/create-ticket.toml
@@ -1,7 +1,7 @@
 name = "create-ticket"
-purpose = "Create a SourceHut ticket in the active tracker and emit the forge-tagged work-unit handle identity."
+purpose = "Create a SourceHut ticket in the active tracker and emit the forge-address work-unit handle identity."
 forge_tag = "sourcehut"
-default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; title=sys.argv[1]; body=open(sys.argv[2], encoding="utf-8").read(); tracker_id=int(sys.argv[3]); print(json.dumps({"query":"mutation submitTicket($trackerId: Int!, $input: SubmitTicketInput!) { submitTicket(trackerId: $trackerId, input: $input) { id ref subject } }","variables":{"trackerId":tracker_id,"input":{"subject":title,"body":body}}}))' "$title" "$body_file" "$tracker_id" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker_id=int(sys.argv[2]); data=payload.get("data"); ticket=data.get("submitTicket") if isinstance(data, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; sys.exit("SourceHut submitTicket GraphQL response contained errors or omitted data.submitTicket.id") if "errors" in payload or not isinstance(number, int) else print(json.dumps({"forge_tag":"sourcehut","tracker_id":tracker_id,"number":number}, separators=(",", ":")))' "$response" "$tracker_id"'''
+default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; title=sys.argv[1]; body=open(sys.argv[2], encoding="utf-8").read(); tracker_id=int(sys.argv[3]); print(json.dumps({"query":"mutation submitTicket($trackerId: Int!, $input: SubmitTicketInput!) { submitTicket(trackerId: $trackerId, input: $input) { id ref subject } }","variables":{"trackerId":tracker_id,"input":{"subject":title,"body":body}}}))' "$title" "$body_file" "$tracker_id" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker=sys.argv[2]; tracker_identity=sys.argv[3]; data=payload.get("data"); ticket=data.get("submitTicket") if isinstance(data, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; sys.exit("SourceHut submitTicket GraphQL response contained errors or omitted data.submitTicket.id") if "errors" in payload or not isinstance(number, int) else print(json.dumps({"tracker":tracker,"tracker_identity":tracker_identity,"work_unit_identity":f"{tracker_identity}#{number}","number":number}, separators=(",", ":")))' "$response" "$tracker" "$tracker_identity"'''
 examples = [
   '''curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-create-ticket.json https://todo.sr.ht/query''',
 ]
@@ -11,6 +11,18 @@ name = "tracker_id"
 purpose = "todo.sr.ht tracker ID containing work-unit tickets."
 required = true
 deployment_value = "tracker_id"
+
+[[parameters]]
+name = "tracker"
+purpose = "Authoritative tracker selector name."
+required = true
+deployment_value = "tracker"
+
+[[parameters]]
+name = "tracker_identity"
+purpose = "Authoritative runa tracker identity."
+required = true
+deployment_value = "tracker_identity"
 
 [[parameters]]
 name = "todo_query_url"
@@ -35,4 +47,4 @@ required = true
 secret = true
 
 [outcome]
-description = "A SourceHut ticket exists in the active tracker and stdout contains a work-unit handle with forge_tag, tracker_id, and number."
+description = "A SourceHut ticket exists in the active tracker and stdout contains a forge-address work-unit handle."

--- a/mechanics/sourcehut/read-ticket.toml
+++ b/mechanics/sourcehut/read-ticket.toml
@@ -1,7 +1,7 @@
 name = "read-ticket"
 purpose = "Read a SourceHut ticket from the active tracker and emit its ticket state with a work-unit handle."
 forge_tag = "sourcehut"
-default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; tracker_owner=sys.argv[1]; tracker_name=sys.argv[2]; ticket_number=int(sys.argv[3]); print(json.dumps({"query":"query readTicket($trackerOwner: String!, $trackerName: String!, $ticketId: Int!) { user(username: $trackerOwner) { tracker(name: $trackerName) { id ticket(id: $ticketId) { id ref subject body status resolution } } } }","variables":{"trackerOwner":tracker_owner,"trackerName":tracker_name,"ticketId":ticket_number}}))' "$tracker_owner" "$tracker_name" "$ticket_number" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker_id=int(sys.argv[2]); data=payload.get("data"); user=data.get("user") if isinstance(data, dict) else None; tracker=user.get("tracker") if isinstance(user, dict) else None; ticket=tracker.get("ticket") if isinstance(tracker, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; subject=ticket.get("subject") if isinstance(ticket, dict) else None; body=ticket.get("body") if isinstance(ticket, dict) else None; status=ticket.get("status") if isinstance(ticket, dict) else None; sys.exit("SourceHut read-ticket GraphQL response contained errors or omitted data.user.tracker.ticket fields") if "errors" in payload or not isinstance(number, int) or not isinstance(subject, str) or body is not None and not isinstance(body, str) or not isinstance(status, str) else print(json.dumps({"handle":{"forge_tag":"sourcehut","tracker_id":tracker_id,"number":number},"title":subject,"body":body,"state":status}, separators=(",", ":")))' "$response" "$tracker_id"'''
+default_invocation = '''payload_file=$(mktemp) && response=$(mktemp) && trap 'rm -f "$payload_file" "$response"' EXIT && python3 -c 'import json, sys; tracker_owner=sys.argv[1]; tracker_name=sys.argv[2]; ticket_number=int(sys.argv[3]); print(json.dumps({"query":"query readTicket($trackerOwner: String!, $trackerName: String!, $ticketId: Int!) { user(username: $trackerOwner) { tracker(name: $trackerName) { id ticket(id: $ticketId) { id ref subject body status resolution } } } }","variables":{"trackerOwner":tracker_owner,"trackerName":tracker_name,"ticketId":ticket_number}}))' "$tracker_owner" "$tracker_name" "$ticket_number" > "$payload_file" && curl --fail --silent --show-error --header "Authorization: Bearer ${token}" --header 'Content-Type: application/json' --data "@${payload_file}" "$todo_query_url" > "$response" && python3 -c 'import json, sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); tracker=sys.argv[2]; tracker_identity=sys.argv[3]; data=payload.get("data"); user=data.get("user") if isinstance(data, dict) else None; tracker_result=user.get("tracker") if isinstance(user, dict) else None; ticket=tracker_result.get("ticket") if isinstance(tracker_result, dict) else None; number=ticket.get("id") if isinstance(ticket, dict) else None; subject=ticket.get("subject") if isinstance(ticket, dict) else None; body=ticket.get("body") if isinstance(ticket, dict) else None; status=ticket.get("status") if isinstance(ticket, dict) else None; sys.exit("SourceHut read-ticket GraphQL response contained errors or omitted data.user.tracker.ticket fields") if "errors" in payload or not isinstance(number, int) or not isinstance(subject, str) or body is not None and not isinstance(body, str) or not isinstance(status, str) else print(json.dumps({"handle":{"tracker":tracker,"tracker_identity":tracker_identity,"work_unit_identity":f"{tracker_identity}#{number}","number":number},"title":subject,"body":body,"state":status}, separators=(",", ":")))' "$response" "$tracker" "$tracker_identity"'''
 examples = [
   '''curl --fail --silent --show-error --header "Authorization: Bearer $WEFORGE_OPERATOR_PAT" --header 'Content-Type: application/json' --data @/tmp/sourcehut-read-ticket.json https://todo.sr.ht/query''',
 ]
@@ -19,10 +19,16 @@ required = true
 deployment_value = "name"
 
 [[parameters]]
-name = "tracker_id"
-purpose = "todo.sr.ht tracker ID containing work-unit tickets."
+name = "tracker"
+purpose = "Authoritative tracker selector name."
 required = true
-deployment_value = "tracker_id"
+deployment_value = "tracker"
+
+[[parameters]]
+name = "tracker_identity"
+purpose = "Authoritative runa tracker identity."
+required = true
+deployment_value = "tracker_identity"
 
 [[parameters]]
 name = "todo_query_url"

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -31,16 +31,16 @@ mechanics use `git check-ref-format` as the authoritative ref-name boundary.
 
 `work-unit.schema.json` is the planning-to-execution bridge. It remains
 forge-neutral and unpartitioned: tracker-backed units may carry an optional
-forge-tagged ticket `handle`, while non-tracker units omit `handle`, and
+forge-address ticket `handle`, while non-tracker units omit `handle`, and
 planning-phase work-unit bodies do not carry a top-level `work_unit` field.
-Supported ticket handles are GitHub issue handles
-`{ forge_tag, url, number }` and SourceHut ticket handles
-`{ forge_tag, tracker_id, number }`; Groundwork artifact validation enforces
-registry membership and GitHub URL/number agreement.
+The handle schema is not authored here; it is a `$ref` to
+`forge-address.schema.json#/$defs/work_unit_handle`, a derived copy pinned to
+runa's authoritative forge-address contract. Groundwork artifact validation
+also checks that `work_unit_identity` is derived from `tracker_identity` and
+`number`.
 
-Change-proposal and work-unit handle forge tags, plus mechanic-authored
-`forge_tag` values, resolve against the declarative `[[forge_tags]]` registry
-in `manifest.toml`.
+Change-proposal handle forge tags plus mechanic-authored `forge_tag` values
+resolve against the declarative `[[forge_tags]]` registry in `manifest.toml`.
 Manifest `[[mechanics]]` entries may declare `forge_tags = [...]` to bind an
 operation handle to forge-specific C-3 mechanics; conformance requires exactly
 one matching `mechanics/**/*.toml` file for each declared operation/tag pair.

--- a/schemas/forge-address.schema.json
+++ b/schemas/forge-address.schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Forge Address Contract",
+  "description": "Authoritative language-neutral schema for runa forge address payloads and work-unit handles.",
+  "$comment": "Groundwork vendors this runtime copy from runa's authoritative forge-address schema; do not edit the format here.",
+  "x-tesserine-canonical": {
+    "source": "tesserine/runa",
+    "commit": "4334e53aed9826ed250eabeec8c1a423dcebdf8a",
+    "schema_url": "https://raw.githubusercontent.com/tesserine/runa/4334e53aed9826ed250eabeec8c1a423dcebdf8a/contracts/forge-address/forge-address.schema.json"
+  },
+  "type": "object",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/address_payload"
+    },
+    {
+      "$ref": "#/$defs/work_unit_handle"
+    }
+  ],
+  "$defs": {
+    "address_payload": {
+      "type": "object",
+      "required": ["schema_version", "instances", "repositories", "trackers"],
+      "additionalProperties": false,
+      "properties": {
+        "schema_version": {
+          "const": "1.0.0"
+        },
+        "instances": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/instance"
+          }
+        },
+        "repositories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/repository"
+          }
+        },
+        "trackers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/tracker"
+          }
+        }
+      }
+    },
+    "instance": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/github_instance"
+        },
+        {
+          "$ref": "#/$defs/sourcehut_instance"
+        }
+      ]
+    },
+    "github_instance": {
+      "type": "object",
+      "required": ["name", "type", "host"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "type": {
+          "const": "github"
+        },
+        "host": {
+          "$ref": "#/$defs/host"
+        }
+      }
+    },
+    "sourcehut_instance": {
+      "type": "object",
+      "required": ["name", "type", "git_host", "tracker_host"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "type": {
+          "const": "sourcehut"
+        },
+        "git_host": {
+          "$ref": "#/$defs/host"
+        },
+        "tracker_host": {
+          "$ref": "#/$defs/host"
+        }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "required": ["name", "instance", "owner", "repository", "identity"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "instance": {
+          "$ref": "#/$defs/name"
+        },
+        "owner": {
+          "$ref": "#/$defs/owner"
+        },
+        "repository": {
+          "$ref": "#/$defs/name"
+        },
+        "identity": {
+          "$ref": "#/$defs/identity"
+        }
+      }
+    },
+    "tracker": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/github_tracker"
+        },
+        {
+          "$ref": "#/$defs/sourcehut_tracker"
+        }
+      ]
+    },
+    "github_tracker": {
+      "type": "object",
+      "required": ["name", "type", "instance", "repository", "identity"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "type": {
+          "const": "github"
+        },
+        "instance": {
+          "$ref": "#/$defs/name"
+        },
+        "repository": {
+          "$ref": "#/$defs/name"
+        },
+        "identity": {
+          "$ref": "#/$defs/identity"
+        }
+      }
+    },
+    "sourcehut_tracker": {
+      "type": "object",
+      "required": ["name", "type", "instance", "owner", "tracker", "tracker_id", "identity"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name"
+        },
+        "type": {
+          "const": "sourcehut"
+        },
+        "instance": {
+          "$ref": "#/$defs/name"
+        },
+        "owner": {
+          "$ref": "#/$defs/sourcehut_owner"
+        },
+        "tracker": {
+          "$ref": "#/$defs/name"
+        },
+        "tracker_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "identity": {
+          "$ref": "#/$defs/identity"
+        }
+      }
+    },
+    "work_unit_handle": {
+      "type": "object",
+      "required": ["tracker", "tracker_identity", "work_unit_identity", "number"],
+      "additionalProperties": false,
+      "properties": {
+        "tracker": {
+          "$ref": "#/$defs/name"
+        },
+        "tracker_identity": {
+          "$ref": "#/$defs/identity"
+        },
+        "work_unit_identity": {
+          "$ref": "#/$defs/identity"
+        },
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]*$"
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sourcehut_owner": {
+      "type": "string",
+      "pattern": "^~?[A-Za-z0-9][A-Za-z0-9_.-]*$"
+    },
+    "host": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9.-]+$"
+    },
+    "identity": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/schemas/forge-address.schema.json
+++ b/schemas/forge-address.schema.json
@@ -5,8 +5,8 @@
   "$comment": "Groundwork vendors this runtime copy from runa's authoritative forge-address schema; do not edit the format here.",
   "x-tesserine-canonical": {
     "source": "tesserine/runa",
-    "commit": "bfd75a503f2907512c76f445b6662e067b916acb",
-    "schema_url": "https://raw.githubusercontent.com/tesserine/runa/bfd75a503f2907512c76f445b6662e067b916acb/contracts/forge-address/forge-address.schema.json"
+    "commit": "c645d420c55e8d75166ff895691057614d8219ef",
+    "schema_url": "https://raw.githubusercontent.com/tesserine/runa/c645d420c55e8d75166ff895691057614d8219ef/contracts/forge-address/forge-address.schema.json"
   },
   "type": "object",
   "oneOf": [

--- a/schemas/forge-address.schema.json
+++ b/schemas/forge-address.schema.json
@@ -5,8 +5,8 @@
   "$comment": "Groundwork vendors this runtime copy from runa's authoritative forge-address schema; do not edit the format here.",
   "x-tesserine-canonical": {
     "source": "tesserine/runa",
-    "commit": "89627d9a315b4e7dabc4fb7ee2183c982d0d2dca",
-    "schema_url": "https://raw.githubusercontent.com/tesserine/runa/89627d9a315b4e7dabc4fb7ee2183c982d0d2dca/contracts/forge-address/forge-address.schema.json"
+    "commit": "bfd75a503f2907512c76f445b6662e067b916acb",
+    "schema_url": "https://raw.githubusercontent.com/tesserine/runa/bfd75a503f2907512c76f445b6662e067b916acb/contracts/forge-address/forge-address.schema.json"
   },
   "type": "object",
   "oneOf": [

--- a/schemas/forge-address.schema.json
+++ b/schemas/forge-address.schema.json
@@ -5,8 +5,8 @@
   "$comment": "Groundwork vendors this runtime copy from runa's authoritative forge-address schema; do not edit the format here.",
   "x-tesserine-canonical": {
     "source": "tesserine/runa",
-    "commit": "4334e53aed9826ed250eabeec8c1a423dcebdf8a",
-    "schema_url": "https://raw.githubusercontent.com/tesserine/runa/4334e53aed9826ed250eabeec8c1a423dcebdf8a/contracts/forge-address/forge-address.schema.json"
+    "commit": "89627d9a315b4e7dabc4fb7ee2183c982d0d2dca",
+    "schema_url": "https://raw.githubusercontent.com/tesserine/runa/89627d9a315b4e7dabc4fb7ee2183c982d0d2dca/contracts/forge-address/forge-address.schema.json"
   },
   "type": "object",
   "oneOf": [

--- a/schemas/mechanic.schema.json
+++ b/schemas/mechanic.schema.json
@@ -80,6 +80,8 @@
             "todo_query_url",
             "git_query_url",
             "ssh_remote",
+            "tracker",
+            "tracker_identity",
             "tracker_id",
             "repo_id"
           ]

--- a/schemas/work-unit.schema.json
+++ b/schemas/work-unit.schema.json
@@ -26,15 +26,8 @@
       }
     },
     "handle": {
-      "description": "Optional forge-specific reference to the tracker ticket backing this work unit.",
-      "oneOf": [
-        {
-          "$ref": "#/$defs/github-handle"
-        },
-        {
-          "$ref": "#/$defs/sourcehut-handle"
-        }
-      ]
+      "$ref": "forge-address.schema.json#/$defs/work_unit_handle",
+      "description": "Optional runa forge-address work-unit handle for the tracker ticket backing this work unit."
     },
     "scope": {
       "type": "array",
@@ -60,48 +53,6 @@
       "items": {
         "type": "string",
         "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
-      }
-    }
-  },
-  "$defs": {
-    "github-handle": {
-      "type": "object",
-      "required": ["forge_tag", "url", "number"],
-      "additionalProperties": false,
-      "properties": {
-        "forge_tag": {
-          "const": "github"
-        },
-        "url": {
-          "type": "string",
-          "description": "GitHub issue URL.",
-          "pattern": "^https://github\\.com/[^/]+/[^/]+/issues/[0-9]+$"
-        },
-        "number": {
-          "type": "integer",
-          "description": "GitHub issue number.",
-          "minimum": 1
-        }
-      }
-    },
-    "sourcehut-handle": {
-      "type": "object",
-      "required": ["forge_tag", "tracker_id", "number"],
-      "additionalProperties": false,
-      "properties": {
-        "forge_tag": {
-          "const": "sourcehut"
-        },
-        "tracker_id": {
-          "type": "integer",
-          "description": "SourceHut tracker ID assigned by the deployment.",
-          "minimum": 1
-        },
-        "number": {
-          "type": "integer",
-          "description": "SourceHut ticket number.",
-          "minimum": 1
-        }
       }
     }
   }

--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -140,7 +140,10 @@ runtime_available() {
   sha="$(source_sha)"
   git -C "$source_path" cat-file -e "$sha:manifest.toml" 2>/dev/null &&
     git -C "$source_path" cat-file -e "$sha:mechanics" 2>/dev/null &&
-    git -C "$source_path" cat-file -e "$sha:tooling/forge_operations.py" 2>/dev/null
+    git -C "$source_path" cat-file -e "$sha:tooling/forge_operations.py" 2>/dev/null &&
+    git -C "$source_path" cat-file -e "$sha:tooling/forge_address.py" 2>/dev/null &&
+    git -C "$source_path" cat-file -e "$sha:schemas/mechanic.schema.json" 2>/dev/null &&
+    git -C "$source_path" cat-file -e "$sha:schemas/forge-address.schema.json" 2>/dev/null
 }
 
 principles_available() {
@@ -267,10 +270,13 @@ project_runtime_bundle() {
   runtime_available || return 0
   local target="$1"
   local sha="$2"
-  mkdir -p "$target/bin" "$target/lib/tooling" "$target/mechanics" || return 1
+  mkdir -p "$target/bin" "$target/lib/tooling" "$target/mechanics" "$target/schemas" || return 1
   git -C "$source_path" show "$sha:manifest.toml" > "$target/manifest.toml" || return 1
   git -C "$source_path" archive --format=tar "$sha:mechanics" | tar -xf - -C "$target/mechanics" || return 1
   git -C "$source_path" show "$sha:tooling/forge_operations.py" > "$target/lib/tooling/forge_operations.py" || return 1
+  git -C "$source_path" show "$sha:tooling/forge_address.py" > "$target/lib/tooling/forge_address.py" || return 1
+  git -C "$source_path" show "$sha:schemas/mechanic.schema.json" > "$target/schemas/mechanic.schema.json" || return 1
+  git -C "$source_path" show "$sha:schemas/forge-address.schema.json" > "$target/schemas/forge-address.schema.json" || return 1
   cat > "$target/bin/groundwork-mechanic" <<'EOF'
 #!/usr/bin/env sh
 set -eu

--- a/skills/acquire/SKILL.md
+++ b/skills/acquire/SKILL.md
@@ -85,7 +85,12 @@ session that entrypoint opens.
      title: "<from the ticket>",
      description: "<from the ticket>",
      acceptance_criteria: ["<from the ticket>"],
-     handle: { forge_tag: "<github|sourcehut>", "...": "<ticket identity>" }
+     handle: {
+       tracker: "<tracker name>",
+       tracker_identity: "<tracker identity>",
+       work_unit_identity: "<tracker identity>#<N>",
+       number: <N>
+     }
    })
    ```
 

--- a/skills/acquire/scripts/materialize.py
+++ b/skills/acquire/scripts/materialize.py
@@ -72,10 +72,16 @@ def extract_acceptance_criteria(body: str) -> list[str]:
 
 def materialize(ticket: dict) -> dict:
     handle = ticket.get("handle")
-    if not isinstance(handle, dict) or "forge_tag" not in handle or "number" not in handle:
+    if (
+        not isinstance(handle, dict)
+        or "tracker" not in handle
+        or "tracker_identity" not in handle
+        or "work_unit_identity" not in handle
+        or "number" not in handle
+    ):
         raise MaterializeError(
             "ticket payload is missing a forge handle; read-ticket must emit "
-            "handle.forge_tag and handle.number"
+            "handle.tracker, handle.tracker_identity, handle.work_unit_identity, and handle.number"
         )
     number = handle["number"]
 

--- a/tests/fixtures/artifacts/invalid-work-unit-github-url-number-mismatch.json
+++ b/tests/fixtures/artifacts/invalid-work-unit-github-url-number-mismatch.json
@@ -1,12 +1,13 @@
 {
-  "title": "Reject mismatched GitHub work-unit handle",
-  "description": "GitHub work-unit handle URL and number must agree",
+  "title": "Reject mismatched work-unit handle identity",
+  "description": "Work-unit handle identity must be derived from tracker identity and number",
   "acceptance_criteria": [
-    "GitHub URL and number mismatches are rejected"
+    "Derived work-unit identity mismatches are rejected"
   ],
   "handle": {
-    "forge_tag": "github",
-    "url": "https://github.com/tesserine/groundwork/issues/367",
+    "tracker": "groundwork",
+    "tracker_identity": "github:github.com/tesserine/groundwork",
+    "work_unit_identity": "github:github.com/tesserine/groundwork#367",
     "number": 368
   }
 }

--- a/tests/fixtures/artifacts/invalid-work-unit-malformed-handle.json
+++ b/tests/fixtures/artifacts/invalid-work-unit-malformed-handle.json
@@ -1,12 +1,12 @@
 {
   "title": "Reject malformed work-unit handle",
-  "description": "Work-unit handles must use the declared forge tag variants",
+  "description": "Work-unit handles must match the runa forge-address contract",
   "acceptance_criteria": [
     "Malformed handles are rejected"
   ],
   "handle": {
-    "forge_tag": "GitHub",
-    "url": "https://github.com/tesserine/groundwork/issues/368",
+    "tracker": "groundwork",
+    "tracker_identity": "github:github.com/tesserine/groundwork",
     "number": 368
   }
 }

--- a/tests/fixtures/artifacts/invalid-work-unit-wrong-handle-variant.json
+++ b/tests/fixtures/artifacts/invalid-work-unit-wrong-handle-variant.json
@@ -1,12 +1,13 @@
 {
   "title": "Reject wrong work-unit handle variant",
-  "description": "GitHub work-unit handles must not carry SourceHut fields",
+  "description": "Work-unit handles must not carry legacy forge-specific fields",
   "acceptance_criteria": [
     "Wrong forge handle variants are rejected"
   ],
   "handle": {
     "forge_tag": "github",
-    "tracker_id": 4,
+    "tracker_identity": "github:github.com/tesserine/groundwork",
+    "work_unit_identity": "github:github.com/tesserine/groundwork#368",
     "number": 368
   }
 }

--- a/tests/fixtures/artifacts/valid-work-unit-github-handle.json
+++ b/tests/fixtures/artifacts/valid-work-unit-github-handle.json
@@ -2,11 +2,12 @@
   "title": "Add work-unit handle contract",
   "description": "Add a schema contract for tracker-backed work-unit handles",
   "acceptance_criteria": [
-    "GitHub tracker-backed work-units carry a forge-tagged issue handle"
+    "Tracker-backed work-units carry a runa forge-address handle"
   ],
   "handle": {
-    "forge_tag": "github",
-    "url": "https://github.com/tesserine/groundwork/issues/368",
+    "tracker": "groundwork",
+    "tracker_identity": "github:github.com/tesserine/groundwork",
+    "work_unit_identity": "github:github.com/tesserine/groundwork#368",
     "number": 368
   }
 }

--- a/tests/fixtures/artifacts/valid-work-unit-sourcehut-handle.json
+++ b/tests/fixtures/artifacts/valid-work-unit-sourcehut-handle.json
@@ -2,11 +2,12 @@
   "title": "Add SourceHut work-unit handle contract",
   "description": "Add a schema contract for SourceHut tracker-backed work-unit handles",
   "acceptance_criteria": [
-    "SourceHut tracker-backed work-units carry a forge-tagged ticket handle"
+    "SourceHut tracker-backed work-units carry a runa forge-address handle"
   ],
   "handle": {
-    "forge_tag": "sourcehut",
-    "tracker_id": 4,
+    "tracker": "groundwork",
+    "tracker_identity": "sourcehut:todo.weforge.build/~operator/groundwork:4",
+    "work_unit_identity": "sourcehut:todo.weforge.build/~operator/groundwork:4#368",
     "number": 368
   }
 }

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -39,6 +39,65 @@ SOURCEHUT_TICKET_BODY = (
     "## Acceptance criteria\n\n"
     "- [ ] Materialize the work-unit from the ticket\n"
 )
+FORGE_ADDRESS_PAYLOAD = {
+    "schema_version": "1.0.0",
+    "instances": [
+        {"name": "github", "type": "github", "host": "github.com"},
+        {"name": "sourcehut", "type": "sourcehut", "git_host": "git.weforge.build", "tracker_host": "todo.weforge.build"},
+    ],
+    "repositories": [
+        {
+            "name": "runa",
+            "instance": "github",
+            "owner": "tesserine",
+            "repository": "runa",
+            "identity": "github:github.com/tesserine/runa",
+        }
+    ],
+    "trackers": [
+        {
+            "name": "runa",
+            "type": "github",
+            "instance": "github",
+            "repository": "runa",
+            "identity": "github:github.com/tesserine/runa",
+        },
+        {
+            "name": "weforge",
+            "type": "sourcehut",
+            "instance": "sourcehut",
+            "owner": "~operator",
+            "tracker": "weforge",
+            "tracker_id": 4,
+            "identity": "sourcehut:todo.weforge.build/~operator/weforge:4",
+        },
+    ],
+}
+FORGE_ADDRESS_ENV = json.dumps(FORGE_ADDRESS_PAYLOAD, separators=(",", ":"))
+
+
+def write_runa_project_topology(project: Path) -> None:
+    (project / ".runa" / "project.toml").write_text(
+        """
+[[forge.instances]]
+name = "github"
+type = "github"
+host = "github.com"
+
+[[forge.repositories]]
+name = "runa"
+instance = "github"
+owner = "tesserine"
+repository = "runa"
+
+[[forge.trackers]]
+name = "runa"
+type = "github"
+instance = "github"
+repository = "runa"
+""".lstrip(),
+        encoding="utf-8",
+    )
 
 
 def materialize(read_ticket_stdout: str) -> subprocess.CompletedProcess[str]:
@@ -57,7 +116,8 @@ def write_fake_command(path: Path, body: str) -> None:
 
 class MaterializeTicketTests(unittest.TestCase):
     def test_github_ticket_materializes_to_schema_valid_adopted_work_unit(self) -> None:
-        mechanic = resolve_operation(ROOT, "read-ticket", forge_type="github")
+        with mock.patch.dict(os.environ, {"RUNA_FORGE_ADDRESSES": FORGE_ADDRESS_ENV}):
+            mechanic = resolve_operation(ROOT, "read-ticket", repository="runa")
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             bin_dir = root / "bin"
@@ -79,8 +139,6 @@ class MaterializeTicketTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "runa",
                 },
             ):
                 read = run_invocation(mechanic, {"ticket_number": "188"}, cwd=root)
@@ -94,7 +152,12 @@ class MaterializeTicketTests(unittest.TestCase):
                 "work-unit", payload["artifact"], registry=registry_from_manifest()
             )
             self.assertEqual(
-                {"forge_tag": "github", "url": issue["html_url"], "number": 188},
+                {
+                    "tracker": "runa",
+                    "tracker_identity": "github:github.com/tesserine/runa",
+                    "work_unit_identity": "github:github.com/tesserine/runa#188",
+                    "number": 188,
+                },
                 payload["artifact"]["handle"],
             )
             self.assertEqual(
@@ -117,7 +180,8 @@ class MaterializeTicketTests(unittest.TestCase):
                 self.assertNotIn(mutating, gh_calls)
 
     def test_sourcehut_ticket_materializes_to_schema_valid_adopted_work_unit(self) -> None:
-        mechanic = resolve_operation(ROOT, "read-ticket", forge_type="sourcehut")
+        with mock.patch.dict(os.environ, {"RUNA_FORGE_ADDRESSES": FORGE_ADDRESS_ENV}):
+            mechanic = resolve_operation(ROOT, "read-ticket", tracker="weforge")
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             bin_dir = root / "bin"
@@ -149,10 +213,6 @@ class MaterializeTicketTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "RUNA_FORGE_TRACKER_ID": "4",
                 },
             ):
                 read = run_invocation(
@@ -168,7 +228,12 @@ class MaterializeTicketTests(unittest.TestCase):
                 "work-unit", payload["artifact"], registry=registry_from_manifest()
             )
             self.assertEqual(
-                {"forge_tag": "sourcehut", "tracker_id": 4, "number": 188},
+                {
+                    "tracker": "weforge",
+                    "tracker_identity": "sourcehut:todo.weforge.build/~operator/weforge:4",
+                    "work_unit_identity": "sourcehut:todo.weforge.build/~operator/weforge:4#188",
+                    "number": 188,
+                },
                 payload["artifact"]["handle"],
             )
             self.assertTrue(payload["instance_id"].startswith("work-unit-188-"))
@@ -183,7 +248,12 @@ class MaterializeTicketTests(unittest.TestCase):
             self.assertNotIn("mutation", graphql["query"])
 
     def test_materializer_routes_quality_gaps_to_refinement(self) -> None:
-        base_handle = {"forge_tag": "github", "url": "https://github.com/o/r/issues/3", "number": 3}
+        base_handle = {
+            "tracker": "runa",
+            "tracker_identity": "github:github.com/tesserine/runa",
+            "work_unit_identity": "github:github.com/tesserine/runa#3",
+            "number": 3,
+        }
 
         no_criteria = json.dumps(
             {"handle": base_handle, "title": "T", "body": "A description, no list.", "state": "open"}
@@ -240,7 +310,8 @@ class AcquisitionEntryEndToEndTests(unittest.TestCase):
             "body": GITHUB_TICKET_BODY,
             "state": "open",
         }
-        mechanic = resolve_operation(ROOT, "read-ticket", forge_type="github")
+        with mock.patch.dict(os.environ, {"RUNA_FORGE_ADDRESSES": FORGE_ADDRESS_ENV}):
+            mechanic = resolve_operation(ROOT, "read-ticket", repository="runa")
 
         with tempfile.TemporaryDirectory(prefix="groundwork-acquire-") as tmp:
             root = Path(tmp)
@@ -255,19 +326,17 @@ class AcquisitionEntryEndToEndTests(unittest.TestCase):
                 cwd=project, capture_output=True, text=True,
             )
             self.assertEqual(init.returncode, 0, f"{init.stdout}\n{init.stderr}")
+            write_runa_project_topology(project)
 
             forge_env = {
                 **os.environ,
                 "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                "RUNA_FORGE_OWNER": "tesserine",
-                "RUNA_FORGE_NAME": "runa",
+                "RUNA_FORGE_ADDRESSES": FORGE_ADDRESS_ENV,
             }
             with mock.patch.dict(
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "RUNA_FORGE_OWNER": "tesserine",
-                    "RUNA_FORGE_NAME": "runa",
                 },
             ):
                 read = run_invocation(mechanic, {"ticket_number": "188"}, cwd=root)
@@ -302,7 +371,7 @@ class AcquisitionEntryEndToEndTests(unittest.TestCase):
             self.assertTrue(recorded.is_file(), f"artifact not persisted:\n{delivery.stdout}")
             body = json.loads(recorded.read_text(encoding="utf-8"))
             self.assertEqual(188, body["handle"]["number"])
-            self.assertEqual("github", body["handle"]["forge_tag"])
+            self.assertEqual("github:github.com/tesserine/runa#188", body["handle"]["work_unit_identity"])
 
             # The cascade now computes take as the next READY station for the
             # acquired work-unit — entry from an existing ticket reached take.

--- a/tests/test_artifact_schemas.py
+++ b/tests/test_artifact_schemas.py
@@ -191,7 +191,10 @@ class ArtifactSchemaTests(unittest.TestCase):
                 artifact = load_artifact("work-unit", self.fixture(name), registry=registry_from_manifest())
 
                 if "handle" in artifact:
-                    self.assertIn(artifact["handle"]["forge_tag"], {"github", "sourcehut"})
+                    self.assertEqual(
+                        artifact["handle"]["work_unit_identity"],
+                        f"{artifact['handle']['tracker_identity']}#{artifact['handle']['number']}",
+                    )
 
     def test_work_unit_schema_rejects_top_level_work_unit_field(self) -> None:
         with self.assertRaises(ArtifactSchemaError) as context:
@@ -199,7 +202,7 @@ class ArtifactSchemaTests(unittest.TestCase):
 
         self.assertIn("<root>", context.exception.paths)
 
-    def test_work_unit_schema_rejects_wrong_handle_variant_for_tag(self) -> None:
+    def test_work_unit_schema_rejects_legacy_handle_variant(self) -> None:
         with self.assertRaises(ArtifactSchemaError) as context:
             load_artifact("work-unit", self.fixture("invalid-work-unit-wrong-handle-variant.json"))
 
@@ -209,23 +212,14 @@ class ArtifactSchemaTests(unittest.TestCase):
         with self.assertRaises(ArtifactSchemaError) as context:
             load_artifact("work-unit", self.fixture("invalid-work-unit-malformed-handle.json"))
 
-        self.assertIn("handle", context.exception.paths)
+        self.assertIn("handle/work_unit_identity", context.exception.paths)
 
-    def test_work_unit_schema_rejects_github_url_number_mismatch(self) -> None:
+    def test_work_unit_schema_rejects_derived_identity_mismatch(self) -> None:
         with self.assertRaises(ArtifactSchemaError) as context:
             load_artifact("work-unit", self.fixture("invalid-work-unit-github-url-number-mismatch.json"))
 
-        self.assertIn("handle/url", context.exception.paths)
-        self.assertIn("does not agree with handle number", str(context.exception))
-
-    def test_work_unit_forge_tag_rejects_unknown_registry_value(self) -> None:
-        registry = MechanicRegistry(forge_tags={"github"})
-
-        with self.assertRaises(ArtifactSchemaError) as context:
-            load_artifact("work-unit", self.fixture("valid-work-unit-sourcehut-handle.json"), registry=registry)
-
-        self.assertIn("handle/forge_tag", context.exception.paths)
-        self.assertIn("forge tag `sourcehut` does not resolve in registry", str(context.exception))
+        self.assertIn("handle", context.exception.paths)
+        self.assertIn("work_unit_identity must be derived", str(context.exception))
 
     def test_change_needs_revision_schema_accepts_structured_findings(self) -> None:
         artifact = load_artifact("change-needs-revision", self.fixture("valid-change-needs-revision.json"))

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -103,7 +103,7 @@ name = "successor"
         self.assertTrue(results[0].passed)
         self.assertTrue(results[1].passed)
         self.assertFalse(results[2].passed)
-        self.assertIn("handle/url", " ".join(results[2].errors))
+        self.assertIn("work_unit_identity", " ".join(results[2].errors))
 
     def test_invalid_units_return_failures_without_raising(self) -> None:
         results = run_conformance(

--- a/tests/test_forge_address_schema_vendoring.py
+++ b/tests/test_forge_address_schema_vendoring.py
@@ -1,0 +1,41 @@
+import json
+import unittest
+from pathlib import Path
+
+from tooling.forge_address import assert_derived_schema_matches_authority
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FORGE_ADDRESS_SCHEMA = ROOT / "schemas" / "forge-address.schema.json"
+WORK_UNIT_SCHEMA = ROOT / "schemas" / "work-unit.schema.json"
+
+
+class ForgeAddressSchemaVendoringTests(unittest.TestCase):
+    def test_forge_address_schema_declares_immutable_runa_provenance(self) -> None:
+        schema = json.loads(FORGE_ADDRESS_SCHEMA.read_text(encoding="utf-8"))
+        canonical = schema["x-tesserine-canonical"]
+
+        self.assertNotIn("$id", schema)
+        self.assertEqual("tesserine/runa", canonical["source"])
+        self.assertRegex(canonical["commit"], r"^[0-9a-f]{40}$")
+        self.assertIn(canonical["commit"], canonical["schema_url"])
+        self.assertNotIn("/main/", canonical["schema_url"])
+
+    def test_derived_schema_matches_pinned_runa_authority(self) -> None:
+        assert_derived_schema_matches_authority()
+
+    def test_work_unit_handle_refs_authoritative_schema_without_local_defs(self) -> None:
+        schema = json.loads(WORK_UNIT_SCHEMA.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            "forge-address.schema.json#/$defs/work_unit_handle",
+            schema["properties"]["handle"]["$ref"],
+        )
+        self.assertNotIn("$defs", schema)
+        serialized = json.dumps(schema)
+        self.assertNotIn("github-handle", serialized)
+        self.assertNotIn("sourcehut-handle", serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -667,6 +667,40 @@ cat "{response}"
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual("tesserine/groundwork\n", result.stdout)
 
+    def test_cli_resolves_github_repository_only_operation_without_tracker(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_github_deployment_probe_methodology(root)
+            payload = dict(FORGE_ADDRESS_PAYLOAD)
+            payload["trackers"] = [
+                tracker
+                for tracker in FORGE_ADDRESS_PAYLOAD["trackers"]
+                if tracker.get("type") != "github"
+            ]
+            environment = forge_cli_environment(
+                RUNA_FORGE_ADDRESSES=json.dumps(payload, separators=(",", ":"))
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tooling" / "forge_operations.py"),
+                    "--root",
+                    str(root),
+                    "--repository",
+                    "groundwork",
+                    "run",
+                    "probe",
+                ],
+                env=environment,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("tesserine/groundwork\n", result.stdout)
+
     def test_cli_rejects_caller_supplied_deployment_value(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_forge_operations.py
+++ b/tests/test_forge_operations.py
@@ -20,11 +20,54 @@ from tooling.forge_operations import (
 
 ROOT = Path(__file__).resolve().parents[1]
 EARLY_ARC_OPERATIONS = ["create-ticket", "read-ticket", "claim-work-unit", "record-progress"]
+FORGE_ADDRESS_PAYLOAD = {
+    "schema_version": "1.0.0",
+    "instances": [
+        {"name": "github", "type": "github", "host": "github.com"},
+        {"name": "sourcehut", "type": "sourcehut", "git_host": "git.weforge.build", "tracker_host": "todo.weforge.build"},
+    ],
+    "repositories": [
+        {
+            "name": "groundwork",
+            "instance": "github",
+            "owner": "tesserine",
+            "repository": "groundwork",
+            "identity": "github:github.com/tesserine/groundwork",
+        },
+        {
+            "name": "weforge",
+            "instance": "sourcehut",
+            "owner": "~operator",
+            "repository": "weforge",
+            "identity": "sourcehut:git.weforge.build/~operator/weforge",
+        },
+    ],
+    "trackers": [
+        {
+            "name": "groundwork",
+            "type": "github",
+            "instance": "github",
+            "repository": "groundwork",
+            "identity": "github:github.com/tesserine/groundwork",
+        },
+        {
+            "name": "weforge",
+            "type": "sourcehut",
+            "instance": "sourcehut",
+            "owner": "~operator",
+            "tracker": "weforge",
+            "tracker_id": 4,
+            "identity": "sourcehut:todo.weforge.build/~operator/weforge:4",
+        },
+    ],
+}
+FORGE_ADDRESS_ENV = json.dumps(FORGE_ADDRESS_PAYLOAD, separators=(",", ":"))
 RUNA_FORGE_ENVIRONMENT_ATOMS = (
     "RUNA_FORGE_TYPE",
     "RUNA_FORGE_OWNER",
     "RUNA_FORGE_NAME",
     "RUNA_FORGE_TRACKER_ID",
+    "RUNA_FORGE_ADDRESSES",
 )
 
 
@@ -32,6 +75,7 @@ def forge_cli_environment(**values: str) -> dict[str, str]:
     environment = os.environ.copy()
     for atom in RUNA_FORGE_ENVIRONMENT_ATOMS:
         environment.pop(atom, None)
+    environment["RUNA_FORGE_ADDRESSES"] = FORGE_ADDRESS_ENV
     environment.update(values)
     return environment
 
@@ -89,8 +133,8 @@ class ForgeOperationTests(unittest.TestCase):
     def test_active_forge_type_uses_explicit_override_before_environment(self) -> None:
         self.assertEqual("sourcehut", active_forge_type({"RUNA_FORGE_TYPE": "github"}, "sourcehut"))
 
-    def test_active_forge_type_uses_runa_forge_type_environment(self) -> None:
-        self.assertEqual("sourcehut", active_forge_type({"RUNA_FORGE_TYPE": "sourcehut"}, None))
+    def test_active_forge_type_ignores_legacy_runa_forge_type_environment(self) -> None:
+        self.assertEqual("github", active_forge_type({"RUNA_FORGE_TYPE": "sourcehut"}, None))
 
     def test_active_forge_type_does_not_fall_back_to_groundwork_forge_type_environment(self) -> None:
         self.assertEqual("github", active_forge_type({"GROUNDWORK_FORGE_TYPE": "sourcehut"}, None))
@@ -159,7 +203,8 @@ class ForgeOperationTests(unittest.TestCase):
                     self.assertEqual(forge_type, mechanic["forge_tag"])
 
     def test_github_create_ticket_emits_work_unit_handle_and_rejects_missing_result(self) -> None:
-        mechanic = resolve_operation(ROOT, "create-ticket", forge_type="github")
+        with mock.patch.dict(os.environ, forge_cli_environment()):
+            mechanic = resolve_operation(ROOT, "create-ticket", repository="groundwork")
 
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -188,7 +233,12 @@ class ForgeOperationTests(unittest.TestCase):
 
             self.assertEqual(0, result.returncode, result.stderr)
             self.assertEqual(
-                {"forge_tag": "github", "url": "https://github.com/tesserine/groundwork/issues/381", "number": 381},
+                {
+                    "tracker": "groundwork",
+                    "tracker_identity": "github:github.com/tesserine/groundwork",
+                    "work_unit_identity": "github:github.com/tesserine/groundwork#381",
+                    "number": 381,
+                },
                 json.loads(result.stdout),
             )
             self.assertIn("repos/tesserine/groundwork/issues", args.read_text(encoding="utf-8"))
@@ -212,7 +262,8 @@ class ForgeOperationTests(unittest.TestCase):
         self.assertIn("GitHub create-ticket API response", result.stderr)
 
     def test_sourcehut_create_ticket_emits_work_unit_handle_and_rejects_graphql_errors(self) -> None:
-        mechanic = resolve_operation(ROOT, "create-ticket", forge_type="sourcehut")
+        with mock.patch.dict(os.environ, forge_cli_environment()):
+            mechanic = resolve_operation(ROOT, "create-ticket", tracker="weforge")
 
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -229,8 +280,6 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_TRACKER_ID": "4",
                 },
             ):
                 result = run_invocation(
@@ -240,7 +289,15 @@ class ForgeOperationTests(unittest.TestCase):
                 )
 
             self.assertEqual(0, result.returncode, result.stderr)
-            self.assertEqual({"forge_tag": "sourcehut", "tracker_id": 4, "number": 27}, json.loads(result.stdout))
+            self.assertEqual(
+                {
+                    "tracker": "weforge",
+                    "tracker_identity": "sourcehut:todo.weforge.build/~operator/weforge:4",
+                    "work_unit_identity": "sourcehut:todo.weforge.build/~operator/weforge:4#27",
+                    "number": 27,
+                },
+                json.loads(result.stdout),
+            )
             self.assertIn("https://todo.weforge.build/query", args.read_text(encoding="utf-8"))
 
             response.write_text('{"errors":[{"message":"no"}],"data":{"submitTicket":null}}\n', encoding="utf-8")
@@ -248,8 +305,6 @@ class ForgeOperationTests(unittest.TestCase):
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_TRACKER_ID": "4",
                 },
             ):
                 result = run_invocation(
@@ -262,7 +317,8 @@ class ForgeOperationTests(unittest.TestCase):
         self.assertIn("SourceHut submitTicket GraphQL response", result.stderr)
 
     def test_sourcehut_read_ticket_reaches_tracker_by_owner_and_name_and_keeps_numeric_handle(self) -> None:
-        mechanic = resolve_operation(ROOT, "read-ticket", forge_type="sourcehut")
+        with mock.patch.dict(os.environ, forge_cli_environment()):
+            mechanic = resolve_operation(ROOT, "read-ticket", tracker="weforge")
 
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -290,10 +346,6 @@ cat "{response}"
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "RUNA_FORGE_TRACKER_ID": "4",
                 },
             ):
                 result = run_invocation(
@@ -308,10 +360,6 @@ cat "{response}"
                 os.environ,
                 {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-                    "GROUNDWORK_FORGE_ENDPOINT": "weforge.build",
-                    "RUNA_FORGE_OWNER": "operator",
-                    "RUNA_FORGE_NAME": "weforge",
-                    "RUNA_FORGE_TRACKER_ID": "4",
                 },
             ):
                 error_result = run_invocation(
@@ -323,7 +371,12 @@ cat "{response}"
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual(
             {
-                "handle": {"forge_tag": "sourcehut", "tracker_id": 4, "number": 369},
+                "handle": {
+                    "tracker": "weforge",
+                    "tracker_identity": "sourcehut:todo.weforge.build/~operator/weforge:4",
+                    "work_unit_identity": "sourcehut:todo.weforge.build/~operator/weforge:4#369",
+                    "number": 369,
+                },
                 "title": "Fix read",
                 "body": "Ticket body",
                 "state": "reported",
@@ -349,7 +402,9 @@ cat "{response}"
 
         for forge_type, operation, forbidden_values in cases:
             with self.subTest(forge_type=forge_type, operation=operation):
-                mechanic = resolve_operation(ROOT, operation, forge_type=forge_type)
+                selector = {"repository": "groundwork"} if forge_type == "github" else {"tracker": "weforge"}
+                with mock.patch.dict(os.environ, forge_cli_environment()):
+                    mechanic = resolve_operation(ROOT, operation, **selector)
                 values = self.required_non_deployment_values(operation, forge_type)
                 values.update(forbidden_values)
 
@@ -477,7 +532,7 @@ cat "{response}"
         self.assertNotIn(secret, child_argv)
         self.assertEqual(secret, exposed_secret)
 
-    def test_cli_resolves_declared_deployment_value_without_parameter_name_knowledge(self) -> None:
+    def test_cli_rejects_deployment_value_not_provided_by_forge_address_contract(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_deployment_probe_methodology(root)
@@ -488,27 +543,22 @@ cat "{response}"
                     str(ROOT / "tooling" / "forge_operations.py"),
                     "--root",
                     str(root),
-                    "--forge-type",
-                    "sourcehut",
+                    "--repository",
+                    "weforge",
                     "run",
                     "probe",
                 ],
-                env=forge_cli_environment(
-                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                    RUNA_FORGE_OWNER="operator",
-                    RUNA_FORGE_NAME="weforge",
-                    RUNA_FORGE_TRACKER_ID="4",
-                    GROUNDWORK_FORGE_REPO_ID="42",
-                ),
+                env=forge_cli_environment(),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
 
-        self.assertEqual(0, result.returncode, result.stderr)
-        self.assertEqual("42\n", result.stdout)
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("repo_id", result.stderr)
+        self.assertIn("not provided by the forge-address contract", result.stderr)
 
-    def test_cli_resolves_sourcehut_deployment_values_from_runtime_and_groundwork_atoms(self) -> None:
+    def test_cli_resolves_sourcehut_repository_deployment_values_from_address_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_sourcehut_deployment_probe_methodology(root)
@@ -519,18 +569,12 @@ cat "{response}"
                     str(ROOT / "tooling" / "forge_operations.py"),
                     "--root",
                     str(root),
-                    "--forge-type",
-                    "sourcehut",
+                    "--repository",
+                    "weforge",
                     "run",
                     "probe",
                 ],
-                env=forge_cli_environment(
-                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                    RUNA_FORGE_OWNER="operator",
-                    RUNA_FORGE_NAME="weforge",
-                    RUNA_FORGE_TRACKER_ID="4",
-                    GROUNDWORK_FORGE_REPO_ID="42",
-                ),
+                env=forge_cli_environment(),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -542,8 +586,6 @@ cat "{response}"
                 "https://todo.weforge.build/query",
                 "https://git.weforge.build/query",
                 "git@git.weforge.build:~operator/weforge",
-                "4",
-                "42",
             ],
             result.stdout.strip().splitlines(),
         )
@@ -552,13 +594,7 @@ cat "{response}"
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_sourcehut_tracker_probe_methodology(root)
-            environment = forge_cli_environment(
-                RUNA_FORGE_TYPE="sourcehut",
-                GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                RUNA_FORGE_OWNER="operator",
-                RUNA_FORGE_NAME="weforge",
-                RUNA_FORGE_TRACKER_ID="4",
-            )
+            environment = forge_cli_environment()
             environment.pop("GROUNDWORK_FORGE_REPO_ID", None)
 
             result = subprocess.run(
@@ -567,6 +603,8 @@ cat "{response}"
                     str(ROOT / "tooling" / "forge_operations.py"),
                     "--root",
                     str(root),
+                    "--tracker",
+                    "weforge",
                     "run",
                     "probe",
                 ],
@@ -579,7 +617,7 @@ cat "{response}"
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual(["https://todo.weforge.build/query", "4"], result.stdout.strip().splitlines())
 
-    def test_cli_names_missing_sourcehut_deployment_atom(self) -> None:
+    def test_cli_names_missing_forge_address_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_sourcehut_deployment_probe_methodology(root)
@@ -590,26 +628,21 @@ cat "{response}"
                     str(ROOT / "tooling" / "forge_operations.py"),
                     "--root",
                     str(root),
-                    "--forge-type",
-                    "sourcehut",
+                    "--tracker",
+                    "weforge",
                     "run",
                     "probe",
                 ],
-                env=forge_cli_environment(
-                    GROUNDWORK_FORGE_ENDPOINT="weforge.build",
-                    RUNA_FORGE_OWNER="operator",
-                    RUNA_FORGE_NAME="weforge",
-                    GROUNDWORK_FORGE_REPO_ID="42",
-                ),
+                env={key: value for key, value in forge_cli_environment().items() if key != "RUNA_FORGE_ADDRESSES"},
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
 
         self.assertNotEqual(0, result.returncode)
-        self.assertIn("RUNA_FORGE_TRACKER_ID", result.stderr)
+        self.assertIn("RUNA_FORGE_ADDRESSES", result.stderr)
 
-    def test_cli_resolves_github_repository_from_runtime_atoms_with_default_forge_type(self) -> None:
+    def test_cli_resolves_github_repository_from_address_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_github_deployment_probe_methodology(root)
@@ -620,13 +653,12 @@ cat "{response}"
                     str(ROOT / "tooling" / "forge_operations.py"),
                     "--root",
                     str(root),
+                    "--repository",
+                    "groundwork",
                     "run",
                     "probe",
                 ],
-                env=forge_cli_environment(
-                    RUNA_FORGE_OWNER="tesserine",
-                    RUNA_FORGE_NAME="groundwork",
-                ),
+                env=forge_cli_environment(),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -646,14 +678,13 @@ cat "{response}"
                     str(ROOT / "tooling" / "forge_operations.py"),
                     "--root",
                     str(root),
+                    "--repository",
+                    "groundwork",
                     "run",
                     "probe",
                     "repository=attacker/repo",
                 ],
-                env=forge_cli_environment(
-                    RUNA_FORGE_OWNER="tesserine",
-                    RUNA_FORGE_NAME="groundwork",
-                ),
+                env=forge_cli_environment(),
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -786,7 +817,7 @@ cat "{response}"
                 name = "probe"
                 purpose = "Probe SourceHut deployment-value resolution."
                 forge_tag = "sourcehut"
-                default_invocation = 'printf "%s\\n%s\\n%s\\n%s\\n%s\\n" "$todo_url" "$git_url" "$remote" "$tracker" "$repo"'
+                default_invocation = 'printf "%s\\n%s\\n%s\\n" "$todo_url" "$git_url" "$remote"'
                 examples = ['printf "%s\\n" "$remote"']
 
                 [[parameters]]
@@ -806,18 +837,6 @@ cat "{response}"
                 purpose = "Git SSH remote."
                 required = true
                 deployment_value = "ssh_remote"
-
-                [[parameters]]
-                name = "tracker"
-                purpose = "Tracker ID."
-                required = true
-                deployment_value = "tracker_id"
-
-                [[parameters]]
-                name = "repo"
-                purpose = "Repo ID."
-                required = true
-                deployment_value = "repo_id"
 
                 [outcome]
                 description = "Printed."

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -215,6 +215,15 @@ class GroundworkInstallTests(unittest.TestCase):
                 """,
             )
         fixture.write("tooling/forge_operations.py", (ROOT / "tooling" / "forge_operations.py").read_text(encoding="utf-8"))
+        fixture.write("tooling/forge_address.py", (ROOT / "tooling" / "forge_address.py").read_text(encoding="utf-8"))
+        fixture.write(
+            "schemas/mechanic.schema.json",
+            (ROOT / "schemas" / "mechanic.schema.json").read_text(encoding="utf-8"),
+        )
+        fixture.write(
+            "schemas/forge-address.schema.json",
+            (ROOT / "schemas" / "forge-address.schema.json").read_text(encoding="utf-8"),
+        )
 
     def assert_handoff_projected_once(self, body: str) -> None:
         self.assertEqual(body.count(HANDOFF_BEGIN), 1)
@@ -250,7 +259,7 @@ class GroundworkInstallTests(unittest.TestCase):
             env={**os.environ, "RUNA_FORGE_TYPE": "sourcehut"},
         )
         assert_success(self, resolved)
-        self.assertEqual("close-out[sourcehut]\n", resolved.stdout)
+        self.assertEqual("close-out[github]\n", resolved.stdout)
 
     def test_installed_protocol_resolver_invocation_uses_runnable_managed_command(self) -> None:
         fixture = self.add_fixture("installed-runtime-command")
@@ -297,7 +306,7 @@ class GroundworkInstallTests(unittest.TestCase):
                 env={**os.environ, "RUNA_FORGE_TYPE": "sourcehut", "PATH": "/usr/bin:/bin"},
             )
             assert_success(self, resolved)
-            self.assertEqual("close-out[sourcehut]\n", resolved.stdout)
+            self.assertEqual("close-out[github]\n", resolved.stdout)
 
     def test_installed_protocol_resolver_invocation_runs_when_home_contains_whitespace(self) -> None:
         fixture = self.add_fixture("installed-runtime-command-spaced-home")
@@ -334,7 +343,7 @@ class GroundworkInstallTests(unittest.TestCase):
             env={**os.environ, "RUNA_FORGE_TYPE": "sourcehut", "PATH": "/usr/bin:/bin"},
         )
         assert_success(self, resolved)
-        self.assertEqual("close-out[sourcehut]\n", resolved.stdout)
+        self.assertEqual("close-out[github]\n", resolved.stdout)
 
     def test_install_projects_session_surface_handoff_into_every_protocol_entry(self) -> None:
         fixture = self.add_fixture("handoff-all-protocols")
@@ -661,6 +670,18 @@ class GroundworkInstallTests(unittest.TestCase):
         fixture.write(
             "tooling/forge_operations.py",
             (ROOT / "tooling" / "forge_operations.py").read_text(encoding="utf-8"),
+        )
+        fixture.write(
+            "tooling/forge_address.py",
+            (ROOT / "tooling" / "forge_address.py").read_text(encoding="utf-8"),
+        )
+        fixture.write(
+            "schemas/mechanic.schema.json",
+            (ROOT / "schemas" / "mechanic.schema.json").read_text(encoding="utf-8"),
+        )
+        fixture.write(
+            "schemas/forge-address.schema.json",
+            (ROOT / "schemas" / "forge-address.schema.json").read_text(encoding="utf-8"),
         )
         fixture.commit_new_ref("v2")
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -132,6 +132,18 @@ class MethodologyFixture:
             "tooling/forge_operations.py",
             (ROOT / "tooling" / "forge_operations.py").read_text(encoding="utf-8"),
         )
+        self.write(
+            "tooling/forge_address.py",
+            (ROOT / "tooling" / "forge_address.py").read_text(encoding="utf-8"),
+        )
+        self.write(
+            "schemas/mechanic.schema.json",
+            (ROOT / "schemas" / "mechanic.schema.json").read_text(encoding="utf-8"),
+        )
+        self.write(
+            "schemas/forge-address.schema.json",
+            (ROOT / "schemas" / "forge-address.schema.json").read_text(encoding="utf-8"),
+        )
 
     def init_git(self) -> None:
         run(["git", "init", "-q"], self.root, check=True)
@@ -259,7 +271,7 @@ class SelfInstallTests(unittest.TestCase):
             env={"PATH": "/usr/bin:/bin", "RUNA_FORGE_TYPE": "sourcehut"},
         )
         assert_success(self, resolved)
-        self.assertEqual("close-out[sourcehut]\n", resolved.stdout)
+        self.assertEqual("close-out[github]\n", resolved.stdout)
 
 
     def test_absent_input_and_config_resolves_embedded_default(self) -> None:

--- a/tests/test_interactive_session_surface.py
+++ b/tests/test_interactive_session_surface.py
@@ -56,7 +56,7 @@ def append_agent_command_config(project_dir: Path, command: list[Path]) -> None:
     config_path = project_dir / ".runa" / "config.toml"
     config = config_path.read_text(encoding="utf-8")
     quoted = ", ".join(json.dumps(str(part)) for part in command)
-    config_path.write_text(f"{config}\n[agent]\ncommand = [{quoted}]\n", encoding="utf-8")
+    config_path.write_text(f"{config}\n[runtime]\ncommand = [{quoted}]\n", encoding="utf-8")
 
 
 def groundwork_env() -> dict[str, str]:
@@ -96,8 +96,9 @@ class InteractiveSessionSurfaceTests(unittest.TestCase):
                             "Interactive sessions reach take through the runa session surface"
                         ],
                         "handle": {
-                            "forge_tag": "github",
-                            "url": "https://github.com/tesserine/groundwork/issues/382",
+                            "tracker": "groundwork",
+                            "tracker_identity": "github:github.com/tesserine/groundwork",
+                            "work_unit_identity": "github:github.com/tesserine/groundwork#382",
                             "number": 382,
                         },
                     },

--- a/tooling/artifact_schemas.py
+++ b/tooling/artifact_schemas.py
@@ -10,6 +10,8 @@ from urllib.parse import urlparse
 
 from jsonschema import Draft202012Validator, FormatChecker
 
+from tooling.forge_address import load_schema as load_forge_address_schema
+from tooling.forge_address import validate_work_unit_handle
 from tooling.mechanics import MechanicRegistry
 
 
@@ -18,9 +20,6 @@ SCHEMAS = ROOT / "schemas"
 MANIFEST = ROOT / "manifest.toml"
 DATE_TIME_PATTERN = re.compile(
     r"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})$"
-)
-GITHUB_WORK_UNIT_ISSUE_URL_PATTERN = re.compile(
-    r"^https://github[.]com/[^/]+/[^/]+/issues/([0-9]+)$"
 )
 
 
@@ -90,7 +89,11 @@ def _schema_errors(artifact_type: str, artifact: dict[str, Any]) -> list[tuple[s
     except FileNotFoundError as error:
         raise ArtifactSchemaError([(str(schema_path.relative_to(ROOT)), "artifact schema does not exist")]) from error
 
-    validator = Draft202012Validator(schema, format_checker=_format_checker())
+    validator = Draft202012Validator(
+        schema,
+        format_checker=_format_checker(),
+        registry=_schema_registry(),
+    )
     errors: list[tuple[str, str]] = []
     for error in sorted(validator.iter_errors(artifact), key=lambda item: list(item.path)):
         path = "/".join(str(part) for part in error.path)
@@ -99,6 +102,18 @@ def _schema_errors(artifact_type: str, artifact: dict[str, Any]) -> list[tuple[s
             path = f"{path}/{missing}" if path else missing
         errors.append((path or "<root>", error.message))
     return errors
+
+
+def _schema_registry():
+    from referencing import Registry, Resource
+
+    resource = Resource.from_contents(load_forge_address_schema())
+    return Registry().with_resources(
+        [
+            ("forge-address.schema.json", resource),
+            ("https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/forge-address.schema.json", resource),
+        ]
+    )
 
 
 def _format_checker() -> FormatChecker:
@@ -145,8 +160,6 @@ def _registry_errors(
 ) -> list[tuple[str, str]]:
     if artifact_type == "change-proposal":
         forge_tag = artifact["handle"]["forge_tag"]
-    elif artifact_type == "work-unit" and "handle" in artifact:
-        forge_tag = artifact["handle"]["forge_tag"]
     else:
         return []
 
@@ -156,11 +169,11 @@ def _registry_errors(
 
 
 def _artifact_contract_errors(artifact_type: str, artifact: dict[str, Any]) -> list[tuple[str, str]]:
-    if artifact_type != "work-unit" or artifact.get("handle", {}).get("forge_tag") != "github":
+    if artifact_type != "work-unit" or "handle" not in artifact:
         return []
 
-    handle = artifact["handle"]
-    match = GITHUB_WORK_UNIT_ISSUE_URL_PATTERN.fullmatch(handle["url"])
-    if match is not None and int(match.group(1)) != handle["number"]:
-        return [("handle/url", "GitHub issue URL number does not agree with handle number")]
+    try:
+        validate_work_unit_handle(artifact["handle"])
+    except ValueError as error:
+        return [("handle", str(error))]
     return []

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -12,6 +12,7 @@ from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError
 
 from tooling.artifact_schemas import ArtifactSchemaError, load_artifact, registry_from_manifest
+from tooling.forge_address import ForgeAddressContractError, assert_derived_schema_matches_authority
 from tooling.mechanics import MechanicError, load_mechanic
 from tooling.workflow_contracts import WorkflowContractError, load_workflow_contract, workflow_registry_from_manifest
 
@@ -220,10 +221,14 @@ def _check_schema_definition(path: Path) -> ConformanceResult:
     try:
         schema = json.loads(path.read_text(encoding="utf-8"))
         Draft202012Validator.check_schema(schema)
+        if path.name == "forge-address.schema.json":
+            assert_derived_schema_matches_authority(path)
     except json.JSONDecodeError as error:
         return ConformanceResult(path=path, category=CATEGORY_SCHEMA, passed=False, errors=[f"<json>: {error}"])
     except SchemaError as error:
         return ConformanceResult(path=path, category=CATEGORY_SCHEMA, passed=False, errors=[error.message])
+    except ForgeAddressContractError as error:
+        return ConformanceResult(path=path, category=CATEGORY_SCHEMA, passed=False, errors=[str(error)])
     return ConformanceResult(path=path, category=CATEGORY_SCHEMA, passed=True, errors=[])
 
 

--- a/tooling/forge_address.py
+++ b/tooling/forge_address.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Mapping
+
+from jsonschema import Draft202012Validator
+
+
+def _runtime_root() -> Path:
+    candidate = Path(__file__).resolve().parents[1]
+    if (candidate / "schemas").exists():
+        return candidate
+    installed = candidate.parent
+    if (installed / "schemas").exists():
+        return installed
+    return candidate
+
+
+ROOT = _runtime_root()
+FORGE_ADDRESS_SCHEMA = ROOT / "schemas" / "forge-address.schema.json"
+AUTHORITY_ENV = "RUNA_FORGE_CONTRACT_ROOT"
+
+
+class ForgeAddressContractError(ValueError):
+    pass
+
+
+def load_schema(path: Path | str = FORGE_ADDRESS_SCHEMA) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def validate_contract_value(value: Mapping[str, Any]) -> None:
+    schema = load_schema()
+    errors = sorted(Draft202012Validator(schema).iter_errors(value), key=lambda item: list(item.path))
+    if errors:
+        details = "; ".join(f"{'/'.join(str(part) for part in error.path) or '<root>'}: {error.message}" for error in errors)
+        raise ForgeAddressContractError(details)
+
+
+def validate_work_unit_handle(handle: Mapping[str, Any]) -> None:
+    schema = load_schema()
+    handle_schema = {"$ref": "forge-address.schema.json#/$defs/work_unit_handle"}
+    validator = Draft202012Validator(
+        handle_schema,
+        registry=_schema_registry(schema),
+    )
+    errors = sorted(validator.iter_errors(handle), key=lambda item: list(item.path))
+    if errors:
+        details = "; ".join(f"{'/'.join(str(part) for part in error.path) or '<root>'}: {error.message}" for error in errors)
+        raise ForgeAddressContractError(details)
+
+    tracker_identity = handle["tracker_identity"]
+    number = handle["number"]
+    expected = f"{tracker_identity}#{number}"
+    if handle["work_unit_identity"] != expected:
+        raise ForgeAddressContractError(f"work_unit_identity must be derived as {expected}")
+
+
+def assert_derived_schema_matches_authority(schema_path: Path | str = FORGE_ADDRESS_SCHEMA) -> None:
+    derived = load_schema(schema_path)
+    canonical = derived.get("x-tesserine-canonical")
+    if not isinstance(canonical, dict):
+        raise ForgeAddressContractError("forge-address schema is missing x-tesserine-canonical provenance")
+    commit = canonical.get("commit")
+    schema_url = canonical.get("schema_url")
+    if not isinstance(commit, str) or not _is_commit_sha(commit):
+        raise ForgeAddressContractError("forge-address canonical commit must be an immutable commit SHA")
+    if not isinstance(schema_url, str) or commit not in schema_url:
+        raise ForgeAddressContractError("forge-address canonical schema_url must include the pinned commit SHA")
+
+    authoritative = _load_authoritative_schema(canonical)
+    if _comparable_schema(derived) != _comparable_schema(authoritative):
+        raise ForgeAddressContractError(
+            "derived forge-address schema diverges from the pinned runa authority"
+        )
+
+
+def _schema_registry(schema: dict[str, Any]):
+    from referencing import Registry, Resource
+
+    return Registry().with_resource("forge-address.schema.json", Resource.from_contents(schema))
+
+
+def _load_authoritative_schema(canonical: Mapping[str, Any]) -> dict[str, Any]:
+    contract_root = os.environ.get(AUTHORITY_ENV)
+    if contract_root:
+        path = Path(contract_root) / "contracts" / "forge-address" / "forge-address.schema.json"
+        if not path.exists():
+            raise ForgeAddressContractError(f"{AUTHORITY_ENV} does not contain {path}")
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    schema_url = canonical["schema_url"]
+    try:
+        with urllib.request.urlopen(schema_url, timeout=15) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        raise ForgeAddressContractError(
+            f"cannot resolve pinned runa forge-address schema {schema_url}: {error}"
+        ) from error
+
+
+def _comparable_schema(schema: Mapping[str, Any]) -> dict[str, Any]:
+    comparable = deepcopy(dict(schema))
+    comparable.pop("$id", None)
+    comparable.pop("$comment", None)
+    comparable.pop("x-tesserine-canonical", None)
+    return comparable
+
+
+def _is_commit_sha(value: str) -> bool:
+    return (
+        len(value) == 40
+        and value != "0" * 40
+        and all(character in "0123456789abcdef" for character in value)
+    )

--- a/tooling/forge_operations.py
+++ b/tooling/forge_operations.py
@@ -1,18 +1,42 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
+import sys
 import tomllib
 from pathlib import Path
 from typing import Any, Mapping
 
+def _runtime_root() -> Path:
+    candidate = Path(__file__).resolve().parents[1]
+    if (candidate / "manifest.toml").exists() or (candidate / "schemas").exists():
+        return candidate
+    installed = candidate.parent
+    if (installed / "manifest.toml").exists() or (installed / "schemas").exists():
+        return installed
+    return candidate
 
-ROOT = Path(__file__).resolve().parents[1]
-RUNA_FORGE_TYPE = "RUNA_FORGE_TYPE"
-RUNA_FORGE_OWNER = "RUNA_FORGE_OWNER"
-RUNA_FORGE_NAME = "RUNA_FORGE_NAME"
-RUNA_FORGE_TRACKER_ID = "RUNA_FORGE_TRACKER_ID"
+
+ROOT = _runtime_root()
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(ROOT / "lib") not in sys.path:
+    sys.path.insert(0, str(ROOT / "lib"))
+
+from tooling.forge_address import ForgeAddressContractError, validate_contract_value
+
+MECHANIC_SCHEMA = ROOT / "schemas" / "mechanic.schema.json"
+RUNA_FORGE_ADDRESSES = "RUNA_FORGE_ADDRESSES"
+TRACKER_OPERATIONS = {
+    "claim-work-unit",
+    "close-out",
+    "create-ticket",
+    "read-ticket",
+    "record-progress",
+    "reflect-disposition",
+}
 
 
 class ForgeOperationError(ValueError):
@@ -22,13 +46,21 @@ class ForgeOperationError(ValueError):
 def active_forge_type(environment: Mapping[str, str], override: str | None) -> str:
     if override:
         return override
-    return environment.get(RUNA_FORGE_TYPE) or "github"
+    return "github"
 
 
-def resolve_operation(root: Path | str, operation: str, *, forge_type: str | None = None) -> dict[str, Any]:
+def resolve_operation(
+    root: Path | str,
+    operation: str,
+    *,
+    forge_type: str | None = None,
+    repository: str | None = None,
+    tracker: str | None = None,
+) -> dict[str, Any]:
     root_path = Path(root)
     manifest = _load_toml(root_path / "manifest.toml")
-    selected_forge_type = active_forge_type(os.environ, forge_type)
+    resource = _selected_resource(operation, repository=repository, tracker=tracker, environment=os.environ)
+    selected_forge_type = resource["forge_type"] if resource is not None else active_forge_type(os.environ, forge_type)
     forge_tags = _manifest_names(manifest, "forge_tags")
     if selected_forge_type not in forge_tags:
         raise ForgeOperationError(f"forge type `{selected_forge_type}` does not resolve in forge_tags")
@@ -47,7 +79,10 @@ def resolve_operation(root: Path | str, operation: str, *, forge_type: str | Non
         raise ForgeOperationError(
             f"operation `{operation}` for forge type `{selected_forge_type}` resolves to {len(matches)} mechanics; expected exactly 1"
         )
-    return matches[0]
+    mechanic = dict(matches[0])
+    if resource is not None:
+        mechanic["_groundwork_resource"] = resource
+    return mechanic
 
 
 def inspect_invocation(mechanic: Mapping[str, Any], values: Mapping[str, str]) -> str:
@@ -100,7 +135,9 @@ def run_invocation(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Resolve and invoke Groundwork forge operations.")
     parser.add_argument("--root", default=str(ROOT), help="Groundwork methodology root. Defaults to this checkout.")
-    parser.add_argument("--forge-type", help="Active forge type override. Defaults to RUNA_FORGE_TYPE, then github.")
+    parser.add_argument("--forge-type", help=argparse.SUPPRESS)
+    parser.add_argument("--repository", help="Repository selector from RUNA_FORGE_ADDRESSES.")
+    parser.add_argument("--tracker", help="Tracker selector from RUNA_FORGE_ADDRESSES.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     resolve_parser = subparsers.add_parser("resolve", help="Print the resolved mechanic path-equivalent name.")
@@ -122,7 +159,13 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
     try:
-        mechanic = resolve_operation(args.root, args.operation, forge_type=args.forge_type)
+        mechanic = resolve_operation(
+            args.root,
+            args.operation,
+            forge_type=args.forge_type,
+            repository=args.repository,
+            tracker=args.tracker,
+        )
         if args.command == "resolve":
             print(f"{mechanic['name']}[{mechanic['forge_tag']}]")
             return 0
@@ -208,7 +251,13 @@ def _deployment_parameter_values(
     forge_type = mechanic.get("forge_tag")
     if not isinstance(forge_type, str):
         raise ForgeOperationError("deployment-resolved parameters require mechanic forge_tag")
-    resolved = _resolved_deployment_values(forge_type, set(deployments.values()), environment)
+    resource = mechanic.get("_groundwork_resource")
+    resolved = _resolved_deployment_values(
+        forge_type,
+        set(deployments.values()),
+        environment,
+        resource if isinstance(resource, dict) else None,
+    )
     values: dict[str, str] = {}
     for name, deployment_value in deployments.items():
         values[name] = resolved[deployment_value]
@@ -219,9 +268,10 @@ def _resolved_deployment_values(
     forge_type: str,
     deployment_values: set[str],
     environment: Mapping[str, str],
+    resource: Mapping[str, Any] | None = None,
 ) -> dict[str, str]:
     return {
-        deployment_value: _resolve_deployment_value(forge_type, deployment_value, environment)
+        deployment_value: _resolve_deployment_value(forge_type, deployment_value, environment, resource)
         for deployment_value in deployment_values
     }
 
@@ -230,54 +280,166 @@ def _resolve_deployment_value(
     forge_type: str,
     deployment_value: str,
     environment: Mapping[str, str],
+    resource: Mapping[str, Any] | None = None,
 ) -> str:
+    if deployment_value not in deployment_value_vocabulary():
+        raise ForgeOperationError(f"deployment value `{deployment_value}` is not declared by mechanic.schema.json")
+    if resource is not None:
+        return _resolve_resource_deployment_value(forge_type, deployment_value, resource)
+    raise ForgeOperationError(
+        f"deployment value `{deployment_value}` requires --repository or --tracker with {RUNA_FORGE_ADDRESSES}"
+    )
+
+
+def deployment_value_vocabulary() -> set[str]:
+    schema = json.loads(MECHANIC_SCHEMA.read_text(encoding="utf-8"))
+    values = schema["$defs"]["parameter"]["properties"]["deployment_value"]["enum"]
+    return {str(value) for value in values}
+
+
+def _selected_resource(
+    operation: str,
+    *,
+    repository: str | None,
+    tracker: str | None,
+    environment: Mapping[str, str],
+) -> dict[str, Any] | None:
+    if repository and tracker:
+        raise ForgeOperationError("--repository and --tracker are mutually exclusive")
+    if not repository and not tracker:
+        return None
+
+    payload = _address_payload(environment)
+    if repository:
+        resource = _named_resource(payload, "repositories", repository)
+        instance = _instance(payload, resource["instance"])
+        forge_type = instance["type"]
+        tracker_resource = _tracker_for_repository(payload, resource) if forge_type == "github" else None
+        if operation in TRACKER_OPERATIONS and forge_type != "github":
+            raise ForgeOperationError(f"operation `{operation}` requires --tracker for sourcehut resources")
+        return {
+            "kind": "repository",
+            "forge_type": forge_type,
+            "resource": resource,
+            "instance": instance,
+            "tracker": tracker_resource,
+        }
+
+    assert tracker is not None
+    resource = _named_resource(payload, "trackers", tracker)
+    forge_type = resource["type"]
     if forge_type == "github":
-        if deployment_value == "owner":
-            return _required_environment(environment, RUNA_FORGE_OWNER)
-        if deployment_value == "name":
-            return _required_environment(environment, RUNA_FORGE_NAME)
-        if deployment_value == "repository":
-            owner = _required_environment(environment, RUNA_FORGE_OWNER)
-            name = _required_environment(environment, RUNA_FORGE_NAME)
-            return f"{owner}/{name}"
-        raise ForgeOperationError(
-            f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
-        )
-    if forge_type == "sourcehut":
-        if deployment_value == "owner":
-            return _required_environment(environment, RUNA_FORGE_OWNER)
-        if deployment_value == "name":
-            return _required_environment(environment, RUNA_FORGE_NAME)
-        if deployment_value == "repository":
-            owner = _required_environment(environment, RUNA_FORGE_OWNER)
-            name = _required_environment(environment, RUNA_FORGE_NAME)
-            return f"{owner}/{name}"
-        if deployment_value == "todo_query_url":
-            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
-            return f"https://todo.{endpoint}/query"
-        if deployment_value == "git_query_url":
-            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
-            return f"https://git.{endpoint}/query"
-        if deployment_value == "ssh_remote":
-            endpoint = _required_environment(environment, "GROUNDWORK_FORGE_ENDPOINT")
-            owner = _required_environment(environment, RUNA_FORGE_OWNER)
-            name = _required_environment(environment, RUNA_FORGE_NAME)
-            return f"git@git.{endpoint}:~{owner}/{name}"
-        if deployment_value == "tracker_id":
-            return _required_environment(environment, RUNA_FORGE_TRACKER_ID)
-        if deployment_value == "repo_id":
-            return _required_environment(environment, "GROUNDWORK_FORGE_REPO_ID")
-        raise ForgeOperationError(
-            f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`"
-        )
-    raise ForgeOperationError(f"forge type `{forge_type}` does not support deployment identity")
+        raise ForgeOperationError(f"github operation `{operation}` must use --repository")
+    return {
+        "kind": "tracker",
+        "forge_type": forge_type,
+        "resource": resource,
+        "instance": _instance(payload, resource["instance"]),
+        "tracker": resource,
+    }
 
 
-def _required_environment(environment: Mapping[str, str], name: str) -> str:
-    value = environment.get(name)
-    if value is None or value == "":
-        raise ForgeOperationError(f"missing required deployment identity atom `{name}`")
-    return value
+def _address_payload(environment: Mapping[str, str]) -> Mapping[str, Any]:
+    raw = environment.get(RUNA_FORGE_ADDRESSES)
+    if not raw:
+        raise ForgeOperationError(f"missing required {RUNA_FORGE_ADDRESSES} payload")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ForgeOperationError(f"{RUNA_FORGE_ADDRESSES} is invalid JSON: {error}") from error
+    if not isinstance(payload, dict):
+        raise ForgeOperationError(f"{RUNA_FORGE_ADDRESSES} must be a JSON object")
+    try:
+        validate_contract_value(payload)
+    except ForgeAddressContractError as error:
+        raise ForgeOperationError(f"{RUNA_FORGE_ADDRESSES} does not match forge-address schema: {error}") from error
+    return payload
+
+
+def _named_resource(payload: Mapping[str, Any], collection: str, name: str) -> Mapping[str, Any]:
+    matches = [
+        resource
+        for resource in payload.get(collection, [])
+        if isinstance(resource, dict) and resource.get("name") == name
+    ]
+    if len(matches) != 1:
+        raise ForgeOperationError(f"{collection[:-1]} selector `{name}` resolved to {len(matches)} resources; expected exactly 1")
+    return matches[0]
+
+
+def _instance(payload: Mapping[str, Any], name: str) -> Mapping[str, Any]:
+    return _named_resource(payload, "instances", name)
+
+
+def _tracker_for_repository(payload: Mapping[str, Any], repository: Mapping[str, Any]) -> Mapping[str, Any]:
+    matches = [
+        tracker
+        for tracker in payload.get("trackers", [])
+        if (
+            isinstance(tracker, dict)
+            and tracker.get("type") == "github"
+            and tracker.get("repository") == repository.get("name")
+        )
+    ]
+    if len(matches) != 1:
+        raise ForgeOperationError(
+            f"github repository selector `{repository.get('name')}` resolved to {len(matches)} trackers; expected exactly 1"
+        )
+    return matches[0]
+
+
+def _resolve_resource_deployment_value(
+    forge_type: str,
+    deployment_value: str,
+    selected: Mapping[str, Any],
+) -> str:
+    resource = selected["resource"]
+    instance = selected["instance"]
+    if deployment_value == "owner":
+        return _bare_owner(str(resource["owner"]))
+    if deployment_value == "name":
+        return str(resource.get("repository") or resource.get("tracker"))
+    if deployment_value == "tracker":
+        tracker = selected.get("tracker")
+        if not isinstance(tracker, dict):
+            raise ForgeOperationError("deployment value `tracker` requires a tracker-backed selector")
+        return str(tracker["name"])
+    if deployment_value == "tracker_identity":
+        tracker = selected.get("tracker")
+        if not isinstance(tracker, dict):
+            raise ForgeOperationError("deployment value `tracker_identity` requires a tracker-backed selector")
+        return str(tracker["identity"])
+    if deployment_value == "repository":
+        if selected["kind"] != "repository":
+            raise ForgeOperationError("deployment value `repository` requires a repository selector")
+        return f"{_bare_owner(str(resource['owner']))}/{resource['repository']}"
+    if deployment_value == "todo_query_url":
+        if forge_type != "sourcehut":
+            raise ForgeOperationError("deployment value `todo_query_url` requires a sourcehut resource")
+        return f"https://{instance['tracker_host']}/query"
+    if deployment_value == "git_query_url":
+        if forge_type != "sourcehut":
+            raise ForgeOperationError("deployment value `git_query_url` requires a sourcehut resource")
+        return f"https://{instance['git_host']}/query"
+    if deployment_value == "ssh_remote":
+        if selected["kind"] != "repository" or forge_type != "sourcehut":
+            raise ForgeOperationError("deployment value `ssh_remote` requires a sourcehut repository selector")
+        return f"git@{instance['git_host']}:{_canonical_sourcehut_owner(str(resource['owner']))}/{resource['repository']}"
+    if deployment_value == "tracker_id":
+        if selected["kind"] != "tracker":
+            raise ForgeOperationError("deployment value `tracker_id` requires a tracker selector")
+        return str(resource["tracker_id"])
+    if deployment_value == "repo_id":
+        raise ForgeOperationError("deployment value `repo_id` is declared but not provided by the forge-address contract")
+    raise ForgeOperationError(f"deployment value `{deployment_value}` is not supported for forge type `{forge_type}`")
+
+
+def _bare_owner(owner: str) -> str:
+    return owner.removeprefix("~")
+
+
+def _canonical_sourcehut_owner(owner: str) -> str:
+    return "~" + _bare_owner(owner)
 
 
 def _invocation_body(mechanic: Mapping[str, Any]) -> str:

--- a/tooling/forge_operations.py
+++ b/tooling/forge_operations.py
@@ -314,7 +314,6 @@ def _selected_resource(
         resource = _named_resource(payload, "repositories", repository)
         instance = _instance(payload, resource["instance"])
         forge_type = instance["type"]
-        tracker_resource = _tracker_for_repository(payload, resource) if forge_type == "github" else None
         if operation in TRACKER_OPERATIONS and forge_type != "github":
             raise ForgeOperationError(f"operation `{operation}` requires --tracker for sourcehut resources")
         return {
@@ -322,7 +321,7 @@ def _selected_resource(
             "forge_type": forge_type,
             "resource": resource,
             "instance": instance,
-            "tracker": tracker_resource,
+            "payload": payload,
         }
 
     assert tracker is not None
@@ -401,11 +400,15 @@ def _resolve_resource_deployment_value(
         return str(resource.get("repository") or resource.get("tracker"))
     if deployment_value == "tracker":
         tracker = selected.get("tracker")
+        if not isinstance(tracker, dict) and forge_type == "github" and selected["kind"] == "repository":
+            tracker = _tracker_for_repository(selected["payload"], resource)
         if not isinstance(tracker, dict):
             raise ForgeOperationError("deployment value `tracker` requires a tracker-backed selector")
         return str(tracker["name"])
     if deployment_value == "tracker_identity":
         tracker = selected.get("tracker")
+        if not isinstance(tracker, dict) and forge_type == "github" and selected["kind"] == "repository":
+            tracker = _tracker_for_repository(selected["payload"], resource)
         if not isinstance(tracker, dict):
             raise ForgeOperationError("deployment value `tracker_identity` requires a tracker-backed selector")
         return str(tracker["identity"])

--- a/tooling/install.py
+++ b/tooling/install.py
@@ -253,10 +253,20 @@ def project_runtime_bundle(source: Path, sha: str, target: Path) -> None:
     """Build the methodology runtime bundle into ``target``."""
     (target / "bin").mkdir(parents=True, exist_ok=True)
     (target / "lib" / "tooling").mkdir(parents=True, exist_ok=True)
+    (target / "schemas").mkdir(parents=True, exist_ok=True)
     (target / "manifest.toml").write_bytes(show_file(source, sha, "manifest.toml"))
     extract_tree(source, sha, "mechanics", target / "mechanics")
     (target / "lib" / "tooling" / "forge_operations.py").write_bytes(
         show_file(source, sha, "tooling/forge_operations.py")
+    )
+    (target / "lib" / "tooling" / "forge_address.py").write_bytes(
+        show_file(source, sha, "tooling/forge_address.py")
+    )
+    (target / "schemas" / "mechanic.schema.json").write_bytes(
+        show_file(source, sha, "schemas/mechanic.schema.json")
+    )
+    (target / "schemas" / "forge-address.schema.json").write_bytes(
+        show_file(source, sha, "schemas/forge-address.schema.json")
     )
     resolver = target / "bin" / "groundwork-mechanic"
     resolver.write_text(RESOLVER_WRAPPER, encoding="utf-8")
@@ -266,7 +276,7 @@ def project_runtime_bundle(source: Path, sha: str, target: Path) -> None:
 # The runtime-bundle children this installer manages under `~/.groundwork`.
 # The resolved corpus (`principles/`) lives beside them and is converged
 # separately — bundle convergence never rebuilds the whole root.
-RUNTIME_BUNDLE_CHILDREN = ("manifest.toml", "mechanics", "lib", "bin", MARKER_NAME)
+RUNTIME_BUNDLE_CHILDREN = ("manifest.toml", "mechanics", "schemas", "lib", "bin", MARKER_NAME)
 
 
 def converge_runtime_bundle(options: Options, sha: str) -> None:


### PR DESCRIPTION
## Summary

Consumes the runa forge-address contract for tesserine/groundwork#420.

- Vendors `schemas/forge-address.schema.json` as a derived copy with `x-tesserine-canonical` provenance pinned to immutable runa commit `4334e53aed9826ed250eabeec8c1a423dcebdf8a`.
- Adds steady-state drift checks so CI fails if the derived copy diverges or the pinned runa schema cannot be resolved.
- Replaces the local `work-unit.handle` definition with a `$ref` to runa's `work_unit_handle` definition and validates handles through that contract.
- Resolves forge operations from validated `RUNA_FORGE_ADDRESSES` selectors and derives deployment values from `mechanic.schema.json`.
- Updates mechanics, install bundles, acquisition, fixtures, and docs to emit and consume the authoritative handle.

## Coordinated Landing

Depends on tesserine/runa#202. The two PRs must land together: groundwork pins to the runa authority delivered by that PR, and runa landing alone breaks the current consumer.

## Verification

- `RUNA_FORGE_CONTRACT_ROOT=/var/home/core/src/tesserine/runa python -m unittest discover -s tests`
- `RUNA_FORGE_CONTRACT_ROOT=/var/home/core/src/tesserine/runa python -m tooling.conformance`
- `python -m unittest tests.test_forge_address_schema_vendoring`
- `python -m tooling.conformance`
- `python -m unittest discover -s tests && python -m tooling.conformance`
