### PR TITLE
contract v2.1.0: define contract robustness — the stub test

### DIFF
--- a/skills/contract/SKILL.md
+++ b/skills/contract/SKILL.md
@@ -2,13 +2,13 @@
 name: contract
 description: >-
   The behavior-driven development discipline: authoring the behavior contract
-  at entry and carrying it unbroken through implementation, verification, and
+  at entry, validating it is robust before it binds, and carrying it unbroken through implementation, verification, and
   closure. Use when refining acceptance criteria into Given/When/Then
   scenarios, when deciding what behavior to implement next, and whenever code
   changes, tests, or completion claims need to stay traceable to specified
   behaviors instead of drifting toward implementation convenience.
 metadata:
-  version: "2.0.0"
+  version: "2.1.0"
   updated: "2026-06-11"
 ---
 
@@ -66,6 +66,60 @@ The name is the specification line; the assertions check observable
 outcomes. A test asserting `validator._cache` or `result.internal_state`
 breaks on refactor and specifies nothing.
 
+## Robustness — the stub test
+
+A well-formed scenario can still specify nothing. "Observable, not internal"
+guards one direction — assertions that reach into internals break on refactor
+and pin implementation. The opposite failure is as fatal: a Then so shallow a
+canned return satisfies it. `create-ticket returns a complete-scoped handle` is
+observable, and a connector that builds the handle string while creating no
+ticket passes it. The scenario proves the shape of a return, not that the work
+happened.
+
+A contract is robust when **every scenario fails on a stub** — a vacuous or
+canned implementation must break at least one Then. That single property is
+what makes green mean functional; a contract whose scenarios a stub passes is a
+definition of done that nothing has to do.
+
+Three shapes of hollow scenario, with the repair:
+
+- **Shape, not effect.** The Then asserts the structure of a return — a
+  well-formed handle, a schema-valid payload — which a stub fabricates. Assert
+  the effect a stub cannot fake instead: not "create-ticket returns a handle"
+  but "the ticket named by the handle reads back"; not "the connector validates
+  the operation" but "the operation issues the provider request," checkable
+  against a recording transport with no live side effect.
+- **No falsifying case.** Every scenario is a positive — "valid input is
+  accepted." A validator that accepts everything passes them all, so the
+  vacuous validator and the correct one are indistinguishable. Add the negative
+  the degenerate implementation fails: "a malformed payload is rejected," "a
+  wrong-but-well-formed identity is refused." A schema that quietly stops
+  validating — a detached `$ref`, a dropped constraint — is caught only by a
+  fixture that must be rejected.
+- **Uncovered surface.** One representative operation is proven; the rest are
+  asserted only at the shape level, and a delivery stubs the unproven ones and
+  ships green. Every operation or capability surface carries its own
+  stub-failing scenario — not one exemplar standing in for the set.
+
+### The completeness check
+
+Before the contract is delivered, and again by whoever reviews it before
+acceptance, validate it against itself. Of each scenario ask: *could a stub — a
+canned return, a no-op, a validator that always says yes — pass this?* If yes,
+it is hollow; strengthen it until a stub fails. The contract is complete when
+the answer is no for every scenario and every criterion is covered by at least
+one such scenario. The check is cheap, it runs before any code exists, and it
+is the line between a contract that defines done and one that describes the
+happy shape of done.
+
+Hollow: `create_ticket_returns_complete_handle` — asserts the returned handle is
+well-formed; a connector that fabricates the handle and never calls the forge
+passes. Robust: `create_ticket_persists_a_retrievable_ticket` — Given a
+recording transport (or a real forge on the gated path), When create-ticket
+runs, Then the transport received the create request with the mapped fields and
+the ticket named by the returned handle reads back. The fabricating stub fails
+the first Then; the no-request stub fails the second.
+
 ## Carrying the Contract
 
 - **Implementation maps to behavior.** Every implementation increment names
@@ -100,6 +154,11 @@ citing which behaviors have evidence.
 **Testing implementation.** Assertions reference private fields, internals,
 or intermediate state. *Recognition:* the test would break on a
 behavior-preserving refactor.
+
+**Hollow scenario.** A Then so shallow a stub passes it — the shape of a
+return, not the effect. *Recognition:* a canned return or a no-op
+implementation would satisfy the assertion; the vacuous and the correct
+implementation are indistinguishable under it.
 
 **Vague names.** Test names are labels, not behavior statements.
 *Recognition:* you cannot reconstruct what the module does from names alone.


### PR DESCRIPTION
Closes #430.

The `contract` skill captured the *form* of a behavior contract and the BDD discipline, but not *sufficiency* — no rule that a scenario must fail on a stub. That gap produced two hollow connector deliveries (5/8 stubbed, vacuous `$ref` validator, green throughout). v2.1.0 adds the Robustness layer: the stub test (every scenario fails on a stub), the three hollow shapes with repairs (shape-not-effect, no-falsifying-case, uncovered-surface), the pre-acceptance completeness check, a hollow-vs-robust forge example, and a `Hollow scenario` corruption mode.

Single home — `take`/`plan`/`implement`/`verify`/`land` already reference the skill, so it propagates with no changes to them. Governance-authored amendment.
