### PR TITLE
fix(take,plan): reconcile the reckon trigger to reckon's authoritative trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **reckon trigger reconciled in the generative protocols** (`take`, `plan`).
+  Their cross-references gated reckon behind "only when the problem space is
+  unclear/contested," contradicting reckon's own trigger — every generative
+  act, the trigger is creation not sequence position — and `orient`'s
+  statement of it, while `survey`/`decompose` reckon unconditionally.
+  Authoring the behavior contract (`take`) and producing a decision-complete
+  design (`plan`) are generative acts; both now defer to reckon's
+  authoritative trigger and fire it before convergence, grounding the
+  contract and the design in the navigational principles rather than
+  pattern-matching the existing system. take 3.2.0→3.2.1, plan 2.0.0→2.1.0.
 - README hero rewritten for the ecosystem README pass: groundwork positioned
   as software delivery expressed as an enforceable methodology — evidence-
   gated completion, CI-gated documentation coherence, forge-agnostic

--- a/protocols/plan/PROTOCOL.md
+++ b/protocols/plan/PROTOCOL.md
@@ -6,8 +6,8 @@ description: >-
   before implement. If you are about to start coding with unresolved design
   choices, plan first.
 metadata:
-  version: "2.0.0"
-  updated: "2026-06-11"
+  version: "2.1.0"
+  updated: "2026-06-17"
   origin: "Adapted from OpenAI Codex CLI (Apache-2.0). See LICENSE-UPSTREAM."
 ---
 
@@ -105,8 +105,12 @@ long. Multi-subsystem or interface-changing work earns the full convergence.
 
 ## Cross-References
 
-- `reckon` (skill): first-principles constraint framing — runs before plan
-  when the problem space itself is unclear.
+- `reckon` (skill): first-principles constraint framing. A decision-complete
+  design is a generative act, so reckon fires before the plan converges —
+  grounding the design in the navigational principles, not pattern-matching
+  the existing system or an adjacent example. Per reckon's own trigger
+  (every generative act, not a sequence position); dose proportional to the
+  change, the discipline constant.
 - `take` (protocol): produced the behavior contract this plan serves.
 - `implement` (protocol): executes this plan through RED-GREEN-REFACTOR.
 - `research` (skill): external evidence when design decisions depend on

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -8,7 +8,7 @@ description: >-
   carries to land; until the runtime sequences the stations autonomously,
   take carries it. Trigger on: 'take', 'take work', 'start work-unit'.
 metadata:
-  version: "3.2.0"
+  version: "3.2.1"
   updated: "2026-06-17"
 ---
 
@@ -173,8 +173,11 @@ begins — the dose is proportional.
 
 - `contract` (skill): the BDD discipline — authoring the contract here,
   carrying it through every later stage.
-- `reckon` (skill): when framing reveals the work-unit's premise is unclear
-  or contested, reckon before contracting.
+- `reckon` (skill): authoring the behavior contract is a generative act, so
+  reckon fires before the contract is set — grounding what "done" means in
+  the navigational principles, not pattern-matching an adjacent work-unit.
+  Per reckon's own trigger (every generative act, not a sequence position);
+  dose proportional to the change, the discipline constant.
 - `decompose` (protocol): owns work-unit boundaries and acceptance-criteria
   quality. A work-unit that cannot be framed or contracted routes back there.
 - `acquire` (skill): the other entry source — materializes the work-unit


### PR DESCRIPTION
Closes #432.

Reconciles the reckon cross-references in `take` and `plan` to defer to reckon's authoritative trigger (every generative act — the trigger is creation, not sequence position) instead of gating it behind "only when the problem space is unclear/contested." The two generative protocols that author the contract and the design were the two with the weakest trigger; this is the class repair. Single home: the trigger lives in the `reckon` skill / `orient`; the protocols consult it.

- `plan` 2.0.0 → 2.1.0
- `take` 3.2.0 → 3.2.1
- CHANGELOG [Unreleased] entry