### PR TITLE
fix(reckon): deterministic corpus resolution — installed corpus over source-tree embedded default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **reckon corpus resolution made deterministic** (#434). The Navigational
+  Principles passage presented the installed corpus (`~/.groundwork/principles/`)
+  and the embedded default (`principles/`) as parallel options and named
+  `PRINCIPLES.md` as a valid index — letting an agent in a source tree read the
+  adjacent groundwork *source* checkout's embedded `principles/PRINCIPLES.md`
+  instead of the installed canonical corpus. Resolution now states a location
+  order (installed corpus first; embedded only in a bare checkout) and names a
+  source tree's `principles/` as the embedded default, not the corpus. reckon
+  5.2.0→5.2.1.
 - **reckon trigger reconciled in the generative protocols** (`take`, `plan`).
   Their cross-references gated reckon behind "only when the problem space is
   unclear/contested," contradicting reckon's own trigger — every generative

--- a/skills/reckon/SKILL.md
+++ b/skills/reckon/SKILL.md
@@ -11,8 +11,8 @@ description: >-
   earning its chain (momentum). Dead reckoning: advance from an established
   fix using trusted constants.
 metadata:
-  version: "5.2.0"
-  updated: "2026-06-12"
+  version: "5.2.1"
+  updated: "2026-06-17"
 ---
 
 # Reckon
@@ -99,13 +99,19 @@ during Reconstruct.
 The principles are defined in the resolved principles corpus, not here —
 they are consulted, never duplicated. Which corpus that is resolves
 through methodology configuration, and it is materialized locally at
-setup: in an installed deployment the resolved corpus lives at
-`~/.groundwork/principles/`; in a bare groundwork checkout it is the
-embedded default at `principles/`. (Selection and lifecycle:
+setup. Resolve its location in order: when `~/.groundwork/principles/`
+exists, that is the corpus — read it; the embedded default at
+`principles/` applies only in a bare groundwork checkout with no
+installed corpus. A groundwork *source* checkout's `principles/`
+directory is that embedded default, not the resolved corpus: an agent
+working in or beside a groundwork source tree still reads the installed
+corpus at `~/.groundwork/principles/`, never a source tree's
+`principles/`. (Selection and lifecycle:
 `docs/principles-corpus.md` in the groundwork repository.)
 
-During Orient, read the corpus index (`PRINCIPLES.md` or `README.md` at
-the corpus root) and select what governs reasoning in this domain. The
+During Orient, having resolved the location above, read the index at
+the resolved corpus root (its `README.md`, or `PRINCIPLES.md` for the
+embedded default) and select what governs reasoning in this domain. The
 corpus speaks for itself: no principle is privileged in advance of
 Orient, and selection is per-domain, per-inquiry. What stays in this
 skill is the cognition methodology — the move, the chain discipline, the


### PR DESCRIPTION
Closes #434.

Makes reckon's corpus resolution deterministic: read `~/.groundwork/principles/` (the installed resolved corpus) first; the embedded `principles/` applies only in a bare checkout with no installed corpus. Names a groundwork *source* checkout's `principles/` as the embedded default, not the corpus, so an agent working in or beside a source tree does not ground in the adjacent embedded 8-default. Orient resolves the location before reading an index. reckon 5.2.0 → 5.2.1.