### PR TITLE
fix(reckon,orient): reckon is the standing cognitive mode, not invocation-gated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **reckon established as the standing cognitive mode** (#436). reckon was
+  declared as general first-principles cognition but operated as a discipline
+  invoked at generative checkpoints, leaving the agent's ambient reasoning —
+  planning, diagnosis, approach-framing — ungrounded (it never opened reckon
+  unless a protocol named it). orient's Operating Stance now establishes reckon
+  as the standing cognitive mode (always on, dose-proportional, distinct from
+  the trigger-gated cross-cutting disciplines, reaching planning and
+  diagnosis), and reckon's `When NOT to Reckon` carve-out no longer frames
+  execution as reckon-free. orient 4.0.0→4.1.0, reckon 5.2.1→5.3.0.
 - **reckon corpus resolution made deterministic** (#434). The Navigational
   Principles passage presented the installed corpus (`~/.groundwork/principles/`)
   and the embedded default (`principles/`) as parallel options and named

--- a/skills/orient/SKILL.md
+++ b/skills/orient/SKILL.md
@@ -6,8 +6,8 @@ description: >-
   documentation-writing guidance. Activates the full skill system as one
   connected methodology and carries the always-on documentation discipline.
 metadata:
-  version: "4.0.0"
-  updated: "2026-06-11"
+  version: "4.1.0"
+  updated: "2026-06-17"
 ---
 
 # Orient
@@ -22,6 +22,15 @@ Skills are the default operating mode, not optional extras. When a skill's
 trigger matches the current work, invoke it — the default is activation,
 not restraint. The corruption to watch for is under-use, not over-use; the
 triggers themselves provide the scope.
+
+One discipline is not situational. `reckon` — first-principles reasoning —
+is the standing cognitive mode, not a skill awaiting a trigger. Whenever
+you reason toward producing, deciding, or diagnosing — framing an approach,
+planning, navigating friction, designing, authoring — reason from ground
+and principle, not pattern and convention. That posture is always on; its
+depth is dose-proportional: a quick grounding check for a small move, the
+full move for a load-bearing one. The cross-cutting disciplines below
+engage when their trigger fires; reckon underlies all of them.
 
 ## Entry Point
 
@@ -80,8 +89,10 @@ completeness.
 
 These are not stations; they engage when their trigger fires, at any stage.
 
-- **`reckon`** — first-principles reasoning, on every generative act. Not
-  step-one-once: the trigger is creation, not sequence position.
+- **`reckon`** — the standing cognitive mode (see Operating Stance), not a
+  trigger-gated discipline like the others here: first-principles reasoning on
+  every generative act — planning and diagnosis included — the trigger is
+  creation, not sequence position.
 - **`contract`** — the BDD discipline: authoring the behavior contract at
   `take`, carrying traceability through every station after.
 - **`work-unit-craft`** — the discipline for authoring a work-unit's tracker

--- a/skills/reckon/SKILL.md
+++ b/skills/reckon/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   earning its chain (momentum). Dead reckoning: advance from an established
   fix using trusted constants.
 metadata:
-  version: "5.2.1"
+  version: "5.3.0"
   updated: "2026-06-17"
 ---
 
@@ -150,15 +150,18 @@ drilling and recursive why: [references/excavation.md](references/excavation.md)
 ## When to Reckon
 
 You are about to accept a frame, a cost, a constraint, a structure, or a
-"how things work" — or to create something — or to reason forward from
-established ground. Ask: "Have I established what is actually true and
+"how things work" — or to create, plan, design, diagnose, or decide anything — or to reason
+forward from established ground. Ask: "Have I established what is actually true and
 needed, and am I reasoning from ground and principle rather than pattern
 and analogy?"
 
 ## When NOT to Reckon
 
-- **Mid-execution.** Finish the current step, then reassess. Reckoning
-  fires at decision points.
+- **Mid-step thrashing.** Finish the current step; don't re-run the full
+  move continuously or re-litigate a decision just grounded. This pauses the
+  *procedure* between decision points — it does not switch off the *mode*.
+  Execution is not a reckon-free zone: planning, diagnosis, and navigating
+  friction are dense with decision points, and each fires reckon.
 - **Verified external constraints.** Users at scale, contracts, and
   regulations are ground truth — they survive decomposition.
 - **Diminishing returns.** If reckoning produces the same design as the


### PR DESCRIPTION
Closes #436.

Establishes reckon as the agent's standing cognitive mode — applied whenever it reasons toward producing, deciding, or diagnosing (planning and approach-framing included), not only when a protocol invokes it. orient's Operating Stance elevates reckon out of the trigger-gated cross-cutting disciplines; reckon's `When NOT to Reckon` carve-out keeps its anti-thrash kernel but no longer frames execution as reckon-free. Discipline constant, dose proportional. orient 4.0.0 → 4.1.0, reckon 5.2.1 → 5.3.0.