### PR TITLE
fix(take,plan,implement): invoke reckon directly in the generative protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **reckon invoked directly in the generative protocols** (#438). orient's
+  standing-mode stance (4.1.0) was necessary but not sufficient — a stochastic
+  agent acts on invoked procedure, not on disposition prose, and was observed
+  authoring a plan without ever opening reckon or the corpus. take, plan, and
+  implement now invoke reckon as a concrete executed step that names the corpus
+  read (open `~/.groundwork/principles/`, select the governing principles, read
+  them, reason the output from them) — at the contract-authoring, design-
+  convergence, and implementation-design points. The mechanical protocols
+  (submit, verify, land) are unchanged. take 3.2.1→3.3.0, plan 2.1.0→2.2.0,
+  implement 2.0.0→2.1.0.
 - **reckon established as the standing cognitive mode** (#436). reckon was
   declared as general first-principles cognition but operated as a discipline
   invoked at generative checkpoints, leaving the agent's ambient reasoning —

--- a/protocols/implement/PROTOCOL.md
+++ b/protocols/implement/PROTOCOL.md
@@ -6,8 +6,8 @@ description: >-
   production code is about to be written — implementing contracted
   behaviors, fixing bugs, or refactoring.
 metadata:
-  version: "2.0.0"
-  updated: "2026-06-11"
+  version: "2.1.0"
+  updated: "2026-06-17"
   origin: "Adapted from obra/superpowers (MIT). See LICENSE-UPSTREAM."
 ---
 
@@ -49,7 +49,12 @@ Take the next behavior scenario from the contract (the plan's
 3. **GREEN — write minimal code to pass.** The simplest code that satisfies
    the test. No extra parameters, no configuration, no error handling that
    no test requires. Over-engineering in GREEN is scope creep wearing a
-   productivity mask.
+   productivity mask. Where the minimal code involves a real design choice
+   — a structure, an abstraction, a boundary — reckon it: open the resolved
+   principles corpus at `~/.groundwork/principles/`, select the principles
+   that govern the choice, and reason it from them rather than the nearest
+   pattern (the reckon skill is the move). Dose-proportional — a trivial
+   pass needs no reckon; a real structural choice does.
 
 4. **Verify GREEN — watch it pass.** Run the test: it passes. Run the
    suite: everything else still passes, output pristine. A failing test

--- a/protocols/plan/PROTOCOL.md
+++ b/protocols/plan/PROTOCOL.md
@@ -6,7 +6,7 @@ description: >-
   before implement. If you are about to start coding with unresolved design
   choices, plan first.
 metadata:
-  version: "2.1.0"
+  version: "2.2.0"
   updated: "2026-06-17"
   origin: "Adapted from OpenAI Codex CLI (Apache-2.0). See LICENSE-UPSTREAM."
 ---
@@ -47,7 +47,12 @@ something other than the contracted work.
    explored further; a genuine preference or tradeoff is decided on codebase
    evidence and recorded as an explicit assumption.
 
-3. **Converge the design.** Choose the approach (compare tradeoffs against
+3. **Converge the design.** First reckon the design: converging a
+   decision-complete design is a generative act — open the resolved
+   principles corpus at `~/.groundwork/principles/`, select the principles
+   that govern this design, read them, and reason the approach from them
+   rather than the nearest pattern or an adjacent example (the reckon skill
+   is the move). Then choose the approach (compare tradeoffs against
    the constraints when several are valid). Specify interfaces, signatures,
    and data flow. Decide handling for each edge case and failure mode.
    Define the test strategy: which scenarios become which tests, what must

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -8,7 +8,7 @@ description: >-
   carries to land; until the runtime sequences the stations autonomously,
   take carries it. Trigger on: 'take', 'take work', 'start work-unit'.
 metadata:
-  version: "3.2.1"
+  version: "3.3.0"
   updated: "2026-06-17"
 ---
 
@@ -46,7 +46,12 @@ proves it, or records it.
    work whose `dependencies` are still open; a blocked work-unit is a
    substrate signal, not an invitation.
 
-4. **Author the behavior contract.** Refine each acceptance criterion into
+4. **Author the behavior contract.** First reckon it: authoring the
+   contract is a generative act — open the resolved principles corpus at
+   `~/.groundwork/principles/`, select the principles that govern what
+   "done" means here, read them, and reason the contract from them rather
+   than the work-unit's surface wording alone (the reckon skill is the
+   move). Then refine each acceptance criterion into
    one or more sentence-named Given/When/Then scenarios — the executable
    definition of done. The `contract` skill is the authoring discipline:
    behavior before mechanics, one behavior per scenario, names that read as


### PR DESCRIPTION
Closes #438.

The orient standing-mode stance (4.1.0) was necessary but not sufficient: a stochastic agent acts on invoked procedure, not disposition prose, and was observed authoring a plan without opening reckon or the corpus. take, plan, and implement now invoke reckon as a concrete executed step naming the corpus read, at the generative acts (author contract / converge design / implementation design choice). Mechanical protocols (submit, verify, land) untouched; survey/decompose already reckon. take 3.2.1→3.3.0, plan 2.1.0→2.2.0, implement 2.0.0→2.1.0.