### PR TITLE
Declare contract lifecycle across dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Contract lifecycle made explicit across dimensions** (#444). The
+  `contract` skill now states the inputs -> validation-defined ->
+  validation-performed lifecycle for behavior, documentation, and code
+  quality, including stage handoffs from issue-craft through `land`,
+  pointer-as-default for dimensions with no special input, and
+  documentation-deliverable behavior gates for structural, coherence, and
+  conformance validation. The documentation and code-quality reference
+  modules now use the same lifecycle vocabulary. contract 2.2.0→2.3.0.
 - **reckon invoked directly in the generative protocols** (#438). orient's
   standing-mode stance (4.1.0) was necessary but not sufficient — a stochastic
   agent acts on invoked procedure, not on disposition prose, and was observed

--- a/skills/contract/SKILL.md
+++ b/skills/contract/SKILL.md
@@ -3,16 +3,16 @@ name: contract
 description: >-
   The contract discipline: a contract is the executable definition of done
   across every dimension a change must satisfy — behavior, documentation,
-  and code quality — each declared at entry, verified before it binds, and
-  carried unbroken through implementation, verification, and closure. Use
-  when authoring or reviewing a contract, refining acceptance criteria into
-  Given/When/Then scenarios, declaring a change's documentation or
-  code-quality obligations, and whenever code, tests, docs, or completion
-  claims must stay traceable to a declared contract instead of drifting
-  toward implementation convenience.
+  and code quality — considered as inputs, defined as validation, performed
+  as evidence, and carried unbroken through implementation, verification,
+  and closure. Use when authoring or reviewing a contract, refining
+  acceptance criteria into Given/When/Then scenarios, declaring a change's
+  documentation or code-quality obligations, and whenever code, tests, docs,
+  or completion claims must stay traceable to a declared contract instead of
+  drifting toward implementation convenience.
 metadata:
-  version: "2.2.0"
-  updated: "2026-06-18"
+  version: "2.3.0"
+  updated: "2026-06-19"
 ---
 
 # Contract
@@ -24,11 +24,12 @@ one aspect of a change but to every aspect that must hold when the work
 lands. A contract has dimensions; each declares what done means for one
 aspect, in the form that gives that aspect teeth.
 
-This skill is the home of the contract across its dimensions. It authors
-the contract where work begins (`take`) and carries it as the source of
-truth through every later stage: plans link decisions to it, the build is
-shaped to it, verification is decided against it, and landing records what
-shipped.
+This skill is the home of the contract across its dimensions. It declares
+the lifecycle that turns issue-shaped inputs into validation, evidence, and
+landing record; per-stage protocols point here for their role and do not
+duplicate this lifecycle. The contract remains the source of truth through
+every later stage: plans link decisions to it, the build is shaped to it,
+verification is decided against it, and landing records what shipped.
 
 ## The teeth principle
 
@@ -53,9 +54,43 @@ the failing-hollow-delivery test, not the apparatus that runs it.
 A contract declares the dimensions the work demands — behavior is always
 present; documentation and code quality are declared as the change
 warrants, and a subset is legitimate the way a behavior contract need not
-exercise every code path. Each dimension is **declared** at `take`,
-**carried** through `implement`, **verified** at `verify`, and **recorded**
-at `land`.
+exercise every code path. The lifecycle is inputs to validation ->
+validation defined -> validation performed, carried through `implement` and
+recorded at `land`.
+
+| Dimension | Lifecycle |
+|---|---|
+| **Behavior** | Work-unit acceptance criteria are inputs to validation; `take` turns them into validation defined as executable scenarios or documentation-deliverable gates; `verify` reports validation performed as scenario or gate coverage; the result is carried through `implement` and recorded at `land`. |
+| **Documentation** | Issue-craft recipient outcomes are inputs to validation; `take` turns them into validation defined as documentation outcomes; `verify` reports validation performed as an audience-outcome review; the result is carried through `implement` and recorded at `land`. |
+| **Code quality** | Issue-craft corpus pointers and stressed universals are inputs to validation; `take` turns them into validation defined as reviewer-checkable projections; `verify` reports validation performed as diff loci or findings; the result is carried through `implement` and recorded at `land`. |
+
+### Stage Handoffs
+
+The stage boundary is part of the contract, not local protocol folklore:
+
+- issue-craft produces inputs to validation: the work-unit criteria,
+  recipient outcomes, and corpus pointers that describe what each dimension
+  must consider.
+- `take` consumes inputs to validation and produces validation defined: the
+  behavior contract plus declared documentation and code-quality outcomes.
+- `implement` consumes validation defined and keeps the change traced to it:
+  tests, docs, and code-quality decisions name the scenario or dimension
+  they advance.
+- `verify` consumes validation defined and produces validation performed:
+  scenario results, documentation review, and code-quality findings.
+- `land` consumes validation performed and records what shipped, including
+  explicit gaps if any remain.
+
+### Pointer-as-default
+
+Issue-craft must consider every dimension, but consideration is not a
+mandatory per-dimension declaration. A dimension carrying no special input
+is still validated: its general contract remains the validation pointer.
+The rule is: density across dimensions is unequal; consideration is equal. A
+refactor may need detailed code-quality inputs and only the general
+documentation contract; a user-facing capability may need dense user
+documentation inputs and ordinary code-quality projection. Silence is valid
+only after the dimension was considered and the general contract is enough.
 
 - **[Behavioral dimension](#the-behavioral-dimension)** — what the system
   does. The most developed dimension and the worked exemplar below; its
@@ -68,7 +103,7 @@ at `land`.
   universals projected onto the diff.
 
 New dimensions join here as they earn their place; satisfying the teeth
-principle and the declare–carry–verify–record threading is what makes a
+principle and the inputs-defined-performed lifecycle is what makes a
 dimension one.
 
 ## The behavioral dimension
@@ -179,6 +214,24 @@ recording transport (or a real forge on the gated path), When create-ticket
 runs, Then the transport received the create request with the mapped fields and
 the ticket named by the returned handle reads back. The fabricating stub fails
 the first Then; the no-request stub fails the second.
+
+### Documentation-deliverable behavior gates
+
+Some work-units deliver methodology documentation rather than runtime
+behavior. Their behavior dimension still needs teeth: validation defined is
+the set of structural, coherence, and conformance gates that prove the
+documented discipline works as a surface a recipient can use. Structural
+gates include reference-link resolution and script-path resolution.
+Conformance gates include template-schema conformance where a document
+describes a shaped artifact or protocol output. Coherence gates include
+internal coherence: the document's lifecycle, names, and handoffs agree
+within the skill and with the protocol references it points to.
+
+These gates stand in for runtime scenarios only when the deliverable is
+documentation. A hollow documentation change fails at least one gate: broken
+links fail structural validation, a template that no longer matches its
+schema fails conformance, and a lifecycle that says different things in two
+sections fails internal coherence.
 
 ### Carrying the Contract
 
@@ -318,14 +371,16 @@ owns. *Recognition:* two homes for one truth, kept in agreement by hand.
 
 ## Cross-References
 
-- `take` (protocol): authors the contract across its declared dimensions at
-  entry, using this discipline.
+- `work-unit-craft` and `decompose`: produce the inputs each dimension
+  considers before validation is defined.
+- `take` (protocol): consumes dimension inputs and defines validation using
+  this discipline.
 - `plan` (protocol): maps scenarios to a decision-complete design.
 - `implement` (protocol): executes RED-GREEN-REFACTOR per named scenario.
-- `verify` (protocol): decides completion against each declared dimension —
+- `verify` (protocol): performs validation against each defined dimension —
   scenario and criterion coverage for behavior, and the documentation and
   code-quality contracts via its review references.
-- `land` (protocol): records shipped coverage and explicit gaps per
+- `land` (protocol): records performed coverage and explicit gaps per
   dimension.
 - `orient` (skill): owns the documentation audience taxonomy and writing
   stance the documentation dimension consults.

--- a/skills/contract/references/code-quality-contract.md
+++ b/skills/contract/references/code-quality-contract.md
@@ -42,10 +42,10 @@ Signal**).
 
 ## Projecting the corpus
 
-The projection is generated, not hardcoded. When the contract is authored,
-consult the resolved corpus (`~/.groundwork/principles/`), select the
-universals this change most stresses, and write each as a checklist item in
-one shape:
+The projection is generated, not hardcoded. When issue-craft supplies
+inputs or `take` defines validation, consult the resolved corpus
+(`~/.groundwork/principles/`), select the universals this change most
+stresses, and write each as a checklist item in one shape:
 
 - the universal as a **question** asked of the diff,
 - the **failing tell** a careless change leaves, and
@@ -75,19 +75,21 @@ demand.
   prestige, a fallback masking failure, silent acceptance of an unsupported
   condition. *Holds when:* wrong assumptions fail loudly where they arise.
 
-## Declaring the contract
+## Lifecycle
 
-At `take`, the contract declares the universals this change most stresses —
-the subset it puts under real pressure, named from the resolved corpus, not
-a ritual recital. A subset is legitimate; under-declaration is not. A change
-that touches a shared asset without declaring the universal that governs
-single homes, adds an abstraction without the one that governs earning a
-place, or moves a public surface without the one that governs honest
-surfaces, has declared around its own risk.
+Issue-craft supplies corpus pointers and stressed universals as inputs to
+validation. `take` turns those inputs into validation defined: the subset of
+universals the change puts under real pressure, named from the resolved
+corpus, not a ritual recital. `verify` performs validation by auditing the
+diff against each projected item. A subset is legitimate;
+under-declaration is not. A change that touches a shared asset without
+naming the universal that governs single homes, adds an abstraction without
+the one that governs earning a place, or moves a public surface without the
+one that governs honest surfaces, has left its risk outside validation.
 
 ## Verifying the contract
 
-At `verify`, the reviewer audits the diff against each declared item and
+At `verify`, the reviewer audits the diff against each defined item and
 records, per item, the locus where it holds or the finding where it fails.
 The method is `protocols/verify/references/code-quality-review.md`. The
 review is the gate; a self-report of cleanliness is not the evidence.

--- a/skills/contract/references/documentation-contract.md
+++ b/skills/contract/references/documentation-contract.md
@@ -23,24 +23,27 @@ outcome** — what the reader can now do — never as artifact existence.
   diff," "the next maintainer finds the decision at the point they meet it."
   A hollow doc fails these.
 
-The check, run when the contract is authored and again when it is verified:
-*could a delivery that wrote nothing useful for this recipient still pass
-this item?* If yes, rewrite it as the recipient's outcome.
+The check, run when documentation inputs are shaped, when validation is
+defined, and again when it is verified: *could a delivery that wrote nothing
+useful for this recipient still pass this item?* If yes, rewrite it as the
+recipient's outcome.
 
-## Declaring the contract
+## Lifecycle
 
-At `take`, the contract declares the pillars the change touches and the
-outcome each must reach. A subset is legitimate — a refactor with no
-user-visible effect carries no user pillar; a first public release carries
-all three. What is illegitimate is silence where the change clearly serves a
-recipient: a new user-facing capability with no user pillar is an
-under-declared contract, not a small one.
+Issue-craft supplies recipient outcomes as inputs to validation. `take`
+turns those inputs into validation defined: the pillars the change touches
+and the outcome each recipient must reach. `verify` performs validation by
+auditing whether those recipients can reach the outcomes. A subset is
+legitimate — a refactor with no user-visible effect carries no user pillar;
+a first public release carries all three. What is illegitimate is silence
+where the change clearly serves a recipient: a new user-facing capability
+with no user pillar is an under-declared contract, not a small one.
 
 The audience taxonomy, artifact types, and writing stance are **not**
 restated here — they live in the `orient` skill's documentation discipline
 (`skills/orient/references/documentation.md`), which this contract consults.
-This module declares outcomes; orient says who the readers are and how to
-write for them.
+This module defines the outcome form; orient says who the readers are and
+how to write for them.
 
 ## The three sub-modules
 
@@ -109,9 +112,9 @@ Checklist:
 
 ## Verifying the contract
 
-At `verify`, the documentation review audits the change against the declared
-contract: for each declared pillar, it confirms the recipient can now reach
-the declared outcome, and it keeps existing docs honest against drift. The
+At `verify`, the documentation review audits the change against the defined
+contract: for each selected pillar, it confirms the recipient can now reach
+the defined outcome, and it keeps existing docs honest against drift. The
 method is `protocols/verify/references/documentation-review.md`; the outcome
 is recorded in the `documentation` section of `completion-evidence`.
 Verification is evidence, not assertion: the audit finds, per item, the
@@ -123,10 +126,10 @@ Three layers, one home each, none restating another:
 
 - **Taxonomy and stance** — `orient`'s documentation discipline: who the
   readers are, what artifacts serve them, how to write at the right depth.
-- **Declaration** — this module: the per-recipient outcomes a given change
-  must reach.
+- **Inputs and definition** — this module: the per-recipient outcomes a
+  given change must reach.
 - **Audit** — `verify`'s documentation review: the change checked against
-  the declared outcomes, recorded in `completion-evidence`.
+  the defined outcomes, recorded in `completion-evidence`.
 
 ## Cross-references
 

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -1,0 +1,104 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+CONTRACT_SURFACE = [
+    CONTRACT_SKILL,
+    ROOT / "skills" / "contract" / "references" / "documentation-contract.md",
+    ROOT / "skills" / "contract" / "references" / "code-quality-contract.md",
+]
+
+
+def contract_text() -> str:
+    return CONTRACT_SKILL.read_text(encoding="utf-8")
+
+
+def normalized_contract_text() -> str:
+    return re.sub(r"\s+", " ", contract_text())
+
+
+class ContractSkillLifecycleTests(unittest.TestCase):
+    def test_lifecycle_roles_are_stated_for_every_dimension(self) -> None:
+        body = contract_text()
+
+        for dimension in ["Behavior", "Documentation", "Code quality"]:
+            with self.subTest(dimension=dimension):
+                row = re.search(rf"\| \*\*{dimension}\*\* \|(?P<row>[^\n]+)", body)
+                self.assertIsNotNone(row)
+                for expected in [
+                    "inputs to validation",
+                    "validation defined",
+                    "validation performed",
+                    "carried through `implement`",
+                    "recorded at `land`",
+                ]:
+                    self.assertIn(expected, row.group("row"))
+
+    def test_stage_handoffs_name_inputs_and_outputs(self) -> None:
+        body = normalized_contract_text()
+
+        for expected in [
+            "issue-craft produces inputs to validation",
+            "`take` consumes inputs to validation and produces validation defined",
+            "`verify` consumes validation defined and produces validation performed",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+    def test_pointer_as_default_distinguishes_consideration_from_declaration(self) -> None:
+        body = normalized_contract_text()
+
+        for expected in [
+            "Pointer-as-default",
+            "consider every dimension",
+            "not a mandatory per-dimension declaration",
+            "general contract remains the validation pointer",
+            "density across dimensions is unequal; consideration is equal",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+    def test_documentation_deliverable_behavior_gates_are_named(self) -> None:
+        body = normalized_contract_text()
+
+        for expected in [
+            "documentation-deliverable",
+            "structural",
+            "coherence",
+            "conformance",
+            "reference-link resolution",
+            "template-schema conformance",
+            "internal coherence",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+    def test_contract_skill_remains_lifecycle_single_home(self) -> None:
+        body = normalized_contract_text()
+
+        self.assertNotIn("Each dimension is **declared** at `take`", contract_text())
+        for expected in [
+            "per-stage protocols point here for their role",
+            "do not duplicate this lifecycle",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+    def test_contract_surface_does_not_keep_entry_only_lifecycle_framing(self) -> None:
+        forbidden = [
+            "At `take`, the contract declares",
+            "declared at `take`",
+        ]
+
+        for path in CONTRACT_SURFACE:
+            body = path.read_text(encoding="utf-8")
+            for phrase in forbidden:
+                with self.subTest(path=path.relative_to(ROOT), phrase=phrase):
+                    self.assertNotIn(phrase, body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- states the contract lifecycle as inputs -> validation-defined -> validation-performed for behavior, documentation, and code quality
- documents stage handoffs, pointer-as-default, and documentation-deliverable behavior gates in the contract skill
- updates documentation/code-quality contract references, bumps contract skill metadata to 2.3.0, and records the change in the changelog

Closes #444.

## Contract Coverage

- `contract_skill_states_lifecycle_for_each_dimension`
- `contract_skill_states_stage_handoffs`
- `contract_skill_documents_pointer_as_default`
- `contract_skill_defines_documentation_deliverable_teeth`
- `contract_skill_remains_single_home`

## Verification

- `python -m pytest -q` -> 336 passed, 924 subtests passed
- `python -m tooling.conformance` -> 36 passed, 0 failed
- `git diff --check`
