### PR TITLE
Declare contract lifecycle across dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Contract lifecycle made explicit across dimensions** (#444). The
+  `contract` skill now states the inputs to validation -> validation defined
+  -> validation performed lifecycle for behavior, documentation, and code
+  quality, including stage handoffs, pointer-as-default for dimensions with
+  no special input, and documentation-deliverable behavior gates for
+  structural, conformance, and coherence validation. The documentation and
+  code-quality contract references now use the same lifecycle vocabulary.
+  contract 2.2.0→2.3.0.
 - **reckon invoked directly in the generative protocols** (#438). orient's
   standing-mode stance (4.1.0) was necessary but not sufficient — a stochastic
   agent acts on invoked procedure, not on disposition prose, and was observed

--- a/skills/contract/SKILL.md
+++ b/skills/contract/SKILL.md
@@ -3,16 +3,16 @@ name: contract
 description: >-
   The contract discipline: a contract is the executable definition of done
   across every dimension a change must satisfy — behavior, documentation,
-  and code quality — each declared at entry, verified before it binds, and
-  carried unbroken through implementation, verification, and closure. Use
-  when authoring or reviewing a contract, refining acceptance criteria into
-  Given/When/Then scenarios, declaring a change's documentation or
-  code-quality obligations, and whenever code, tests, docs, or completion
-  claims must stay traceable to a declared contract instead of drifting
-  toward implementation convenience.
+  and code quality — considered as inputs, defined as validation, performed
+  as evidence, and carried unbroken through implementation, verification,
+  and closure. Use when authoring or reviewing a contract, refining
+  acceptance criteria into Given/When/Then scenarios, declaring a change's
+  documentation or code-quality obligations, and whenever code, tests, docs,
+  or completion claims must stay traceable to a defined contract instead of
+  drifting toward implementation convenience.
 metadata:
-  version: "2.2.0"
-  updated: "2026-06-18"
+  version: "2.3.0"
+  updated: "2026-06-19"
 ---
 
 # Contract
@@ -24,11 +24,13 @@ one aspect of a change but to every aspect that must hold when the work
 lands. A contract has dimensions; each declares what done means for one
 aspect, in the form that gives that aspect teeth.
 
-This skill is the home of the contract across its dimensions. It authors
-the contract where work begins (`take`) and carries it as the source of
-truth through every later stage: plans link decisions to it, the build is
-shaped to it, verification is decided against it, and landing records what
-shipped.
+This skill is the home of the contract across its dimensions. It declares
+the lifecycle that turns issue-shaped inputs into defined validation,
+performed evidence, and a landing record. Per-stage protocols consult this
+home for their role instead of keeping their own lifecycle statement. The
+contract remains the source of truth through every later stage: plans link
+decisions to it, the build is shaped to it, verification is decided against
+it, and landing records what shipped.
 
 ## The teeth principle
 
@@ -53,9 +55,43 @@ the failing-hollow-delivery test, not the apparatus that runs it.
 A contract declares the dimensions the work demands — behavior is always
 present; documentation and code quality are declared as the change
 warrants, and a subset is legitimate the way a behavior contract need not
-exercise every code path. Each dimension is **declared** at `take`,
-**carried** through `implement`, **verified** at `verify`, and **recorded**
-at `land`.
+exercise every code path. The lifecycle is inputs to validation ->
+validation defined -> validation performed, with validation carried through
+`implement` and recorded at `land`.
+
+| Dimension | Lifecycle |
+|---|---|
+| **Behavior** | Work-unit acceptance criteria are inputs to validation; `take` produces validation defined as executable scenarios or documentation-deliverable gates; validation is carried through `implement`; `verify` produces validation performed as scenario or gate coverage; the result is recorded at `land`. |
+| **Documentation** | Issue-craft recipient outcomes are inputs to validation; `take` produces validation defined as documentation outcomes; validation is carried through `implement`; `verify` produces validation performed as an audience-outcome review; the result is recorded at `land`. |
+| **Code quality** | Issue-craft corpus pointers and stressed universals are inputs to validation; `take` produces validation defined as reviewer-checkable projections; validation is carried through `implement`; `verify` produces validation performed as diff loci or findings; the result is recorded at `land`. |
+
+### Stage Handoffs
+
+The stage boundary is part of the contract lifecycle:
+
+- issue-craft produces inputs to validation: the work-unit criteria,
+  recipient outcomes, and corpus pointers each dimension must consider.
+- `take` consumes inputs to validation and produces validation defined: the
+  behavior contract plus the documentation and code-quality outcomes the
+  change puts under verification.
+- `implement` consumes validation defined and keeps the change traced to it:
+  tests, docs, and code-quality decisions name the scenario or dimension
+  they advance.
+- `verify` consumes validation defined and produces validation performed:
+  scenario results, documentation review, and code-quality findings.
+- `land` consumes validation performed and records what shipped, including
+  explicit gaps if any remain.
+
+### Pointer-as-default
+
+Issue-craft must consider every dimension, but consideration is not a
+mandatory per-dimension declaration. A dimension carrying no special input
+is still validated: its general contract remains the validation pointer.
+The rule is: density across dimensions is unequal; consideration is equal. A
+refactor may need detailed code-quality inputs and only the general
+documentation contract; a user-facing capability may need dense user
+documentation inputs and ordinary code-quality projection. Silence is valid
+only after the dimension was considered and the general contract is enough.
 
 - **[Behavioral dimension](#the-behavioral-dimension)** — what the system
   does. The most developed dimension and the worked exemplar below; its
@@ -68,7 +104,7 @@ at `land`.
   universals projected onto the diff.
 
 New dimensions join here as they earn their place; satisfying the teeth
-principle and the declare–carry–verify–record threading is what makes a
+principle and the inputs-defined-performed lifecycle is what makes a
 dimension one.
 
 ## The behavioral dimension
@@ -180,6 +216,25 @@ runs, Then the transport received the create request with the mapped fields and
 the ticket named by the returned handle reads back. The fabricating stub fails
 the first Then; the no-request stub fails the second.
 
+### Documentation-deliverable behavior gates
+
+Some work-units deliver methodology documentation rather than runtime
+behavior. Their behavior dimension still needs teeth: validation defined is
+the set of structural, conformance, and coherence gates that prove the
+documented discipline works as a surface a recipient can use.
+
+Structural gates include reference-link resolution and script-path
+resolution. Conformance gates include template-schema conformance where a
+document describes a shaped artifact or protocol output. Coherence gates
+include internal coherence: the document's lifecycle, names, and handoffs
+agree within the skill and with the protocol references it points to.
+
+These gates stand in for runtime scenarios only when the deliverable is
+documentation. A hollow documentation change fails at least one gate: broken
+links fail structural validation, a template that no longer matches its
+schema fails conformance, and a lifecycle that says different things in two
+sections fails internal coherence.
+
 ### Carrying the Contract
 
 - **Implementation maps to behavior.** Every implementation increment names
@@ -228,9 +283,9 @@ hollow-item test, is
 
 The dimension keeps a single home at each layer: the audience taxonomy and
 writing stance live in the `orient` skill's documentation discipline; this
-contract declares the outcomes; the `verify` protocol's documentation
-review audits the change against the declared contract and records the
-result in `completion-evidence`. The contract declares, orient styles,
+contract defines the outcomes; the `verify` protocol's documentation
+review audits the change against the defined contract and records the
+result in `completion-evidence`. The contract defines, orient styles,
 verify checks — no layer restates another.
 
 ## The code-quality dimension
@@ -318,14 +373,16 @@ owns. *Recognition:* two homes for one truth, kept in agreement by hand.
 
 ## Cross-References
 
-- `take` (protocol): authors the contract across its declared dimensions at
-  entry, using this discipline.
+- `work-unit-craft` and `decompose`: produce the inputs each dimension
+  considers before validation is defined.
+- `take` (protocol): consumes dimension inputs and defines validation using
+  this discipline.
 - `plan` (protocol): maps scenarios to a decision-complete design.
 - `implement` (protocol): executes RED-GREEN-REFACTOR per named scenario.
-- `verify` (protocol): decides completion against each declared dimension —
+- `verify` (protocol): performs validation against each defined dimension —
   scenario and criterion coverage for behavior, and the documentation and
   code-quality contracts via its review references.
-- `land` (protocol): records shipped coverage and explicit gaps per
+- `land` (protocol): records performed coverage and explicit gaps per
   dimension.
 - `orient` (skill): owns the documentation audience taxonomy and writing
   stance the documentation dimension consults.

--- a/skills/contract/SKILL.md
+++ b/skills/contract/SKILL.md
@@ -25,12 +25,13 @@ lands. A contract has dimensions; each declares what done means for one
 aspect, in the form that gives that aspect teeth.
 
 This skill is the home of the contract across its dimensions. It declares
-the lifecycle that turns issue-shaped inputs into defined validation,
-performed evidence, and a landing record. Per-stage protocols consult this
-home for their role instead of keeping their own lifecycle statement. The
-contract remains the source of truth through every later stage: plans link
-decisions to it, the build is shaped to it, verification is decided against
-it, and landing records what shipped.
+the lifecycle as the single home for the contract surface: work-unit
+authoring inputs become defined validation, performed evidence, and a
+landing record. Consuming protocol migration proceeds unit by unit across
+epic #443; until a protocol's migration unit lands, its current framing
+remains local to that protocol. The contract remains the source of truth
+through every later stage: plans link decisions to it, the build is shaped
+to it, verification is decided against it, and landing records what shipped.
 
 ## The teeth principle
 
@@ -62,14 +63,14 @@ validation defined -> validation performed, with validation carried through
 | Dimension | Lifecycle |
 |---|---|
 | **Behavior** | Work-unit acceptance criteria are inputs to validation; `take` produces validation defined as executable scenarios or documentation-deliverable gates; validation is carried through `implement`; `verify` produces validation performed as scenario or gate coverage; the result is recorded at `land`. |
-| **Documentation** | Issue-craft recipient outcomes are inputs to validation; `take` produces validation defined as documentation outcomes; validation is carried through `implement`; `verify` produces validation performed as an audience-outcome review; the result is recorded at `land`. |
-| **Code quality** | Issue-craft corpus pointers and stressed universals are inputs to validation; `take` produces validation defined as reviewer-checkable projections; validation is carried through `implement`; `verify` produces validation performed as diff loci or findings; the result is recorded at `land`. |
+| **Documentation** | `work-unit-craft`/`decompose` recipient outcomes are inputs to validation; `take` produces validation defined as documentation outcomes; validation is carried through `implement`; `verify` produces validation performed as an audience-outcome review; the result is recorded at `land`. |
+| **Code quality** | `work-unit-craft`/`decompose` corpus pointers and stressed universals are inputs to validation; `take` produces validation defined as reviewer-checkable projections; validation is carried through `implement`; `verify` produces validation performed as diff loci or findings; the result is recorded at `land`. |
 
 ### Stage Handoffs
 
 The stage boundary is part of the contract lifecycle:
 
-- issue-craft produces inputs to validation: the work-unit criteria,
+- `work-unit-craft`/`decompose` produces inputs to validation: the work-unit criteria,
   recipient outcomes, and corpus pointers each dimension must consider.
 - `take` consumes inputs to validation and produces validation defined: the
   behavior contract plus the documentation and code-quality outcomes the
@@ -84,7 +85,7 @@ The stage boundary is part of the contract lifecycle:
 
 ### Pointer-as-default
 
-Issue-craft must consider every dimension, but consideration is not a
+`work-unit-craft`/`decompose` must consider every dimension, but consideration is not a
 mandatory per-dimension declaration. A dimension carrying no special input
 is still validated: its general contract remains the validation pointer.
 The rule is: density across dimensions is unequal; consideration is equal. A

--- a/skills/contract/references/code-quality-contract.md
+++ b/skills/contract/references/code-quality-contract.md
@@ -42,10 +42,10 @@ Signal**).
 
 ## Projecting the corpus
 
-The projection is generated, not hardcoded. When the contract is authored,
-consult the resolved corpus (`~/.groundwork/principles/`), select the
-universals this change most stresses, and write each as a checklist item in
-one shape:
+The projection is generated, not hardcoded. When issue-craft supplies
+inputs or `take` defines validation, consult the resolved corpus
+(`~/.groundwork/principles/`), select the universals this change most
+stresses, and write each as a checklist item in one shape:
 
 - the universal as a **question** asked of the diff,
 - the **failing tell** a careless change leaves, and
@@ -75,19 +75,21 @@ demand.
   prestige, a fallback masking failure, silent acceptance of an unsupported
   condition. *Holds when:* wrong assumptions fail loudly where they arise.
 
-## Declaring the contract
+## Lifecycle
 
-At `take`, the contract declares the universals this change most stresses —
-the subset it puts under real pressure, named from the resolved corpus, not
-a ritual recital. A subset is legitimate; under-declaration is not. A change
-that touches a shared asset without declaring the universal that governs
-single homes, adds an abstraction without the one that governs earning a
-place, or moves a public surface without the one that governs honest
-surfaces, has declared around its own risk.
+Issue-craft supplies corpus pointers and stressed universals as inputs to
+validation. `take` turns those inputs into validation defined: the subset of
+universals the change puts under real pressure, named from the resolved
+corpus, not a ritual recital. `verify` performs validation by auditing the
+diff against each projected item. A subset is legitimate; under-declaration
+is not. A change that touches a shared asset without naming the universal
+that governs single homes, adds an abstraction without the one that governs
+earning a place, or moves a public surface without the one that governs
+honest surfaces, has left its risk outside validation.
 
 ## Verifying the contract
 
-At `verify`, the reviewer audits the diff against each declared item and
+At `verify`, the reviewer audits the diff against each defined item and
 records, per item, the locus where it holds or the finding where it fails.
 The method is `protocols/verify/references/code-quality-review.md`. The
 review is the gate; a self-report of cleanliness is not the evidence.

--- a/skills/contract/references/code-quality-contract.md
+++ b/skills/contract/references/code-quality-contract.md
@@ -42,8 +42,8 @@ Signal**).
 
 ## Projecting the corpus
 
-The projection is generated, not hardcoded. When issue-craft supplies
-inputs or `take` defines validation, consult the resolved corpus
+The projection is generated, not hardcoded. When `work-unit-craft`/`decompose`
+supplies inputs or `take` defines validation, consult the resolved corpus
 (`~/.groundwork/principles/`), select the universals this change most
 stresses, and write each as a checklist item in one shape:
 
@@ -77,7 +77,7 @@ demand.
 
 ## Lifecycle
 
-Issue-craft supplies corpus pointers and stressed universals as inputs to
+`work-unit-craft`/`decompose` supplies corpus pointers and stressed universals as inputs to
 validation. `take` turns those inputs into validation defined: the subset of
 universals the change puts under real pressure, named from the resolved
 corpus, not a ritual recital. `verify` performs validation by auditing the

--- a/skills/contract/references/documentation-contract.md
+++ b/skills/contract/references/documentation-contract.md
@@ -30,7 +30,7 @@ as the recipient's outcome.
 
 ## Lifecycle
 
-Issue-craft supplies recipient outcomes as inputs to validation. `take`
+`work-unit-craft`/`decompose` supplies recipient outcomes as inputs to validation. `take`
 turns those inputs into validation defined: the pillars the change touches
 and the outcome each recipient must reach. `verify` performs validation by
 auditing whether those recipients can reach the outcomes. A subset is

--- a/skills/contract/references/documentation-contract.md
+++ b/skills/contract/references/documentation-contract.md
@@ -23,24 +23,27 @@ outcome** — what the reader can now do — never as artifact existence.
   diff," "the next maintainer finds the decision at the point they meet it."
   A hollow doc fails these.
 
-The check, run when the contract is authored and again when it is verified:
-*could a delivery that wrote nothing useful for this recipient still pass
-this item?* If yes, rewrite it as the recipient's outcome.
+The check, run when documentation inputs are shaped, when validation is
+defined, and again when it is performed: *could a delivery that wrote
+nothing useful for this recipient still pass this item?* If yes, rewrite it
+as the recipient's outcome.
 
-## Declaring the contract
+## Lifecycle
 
-At `take`, the contract declares the pillars the change touches and the
-outcome each must reach. A subset is legitimate — a refactor with no
-user-visible effect carries no user pillar; a first public release carries
-all three. What is illegitimate is silence where the change clearly serves a
-recipient: a new user-facing capability with no user pillar is an
-under-declared contract, not a small one.
+Issue-craft supplies recipient outcomes as inputs to validation. `take`
+turns those inputs into validation defined: the pillars the change touches
+and the outcome each recipient must reach. `verify` performs validation by
+auditing whether those recipients can reach the outcomes. A subset is
+legitimate — a refactor with no user-visible effect carries no user pillar;
+a first public release carries all three. What is illegitimate is silence
+where the change clearly serves a recipient: a new user-facing capability
+with no user pillar is an under-declared contract, not a small one.
 
 The audience taxonomy, artifact types, and writing stance are **not**
 restated here — they live in the `orient` skill's documentation discipline
 (`skills/orient/references/documentation.md`), which this contract consults.
-This module declares outcomes; orient says who the readers are and how to
-write for them.
+This module defines the outcome form; orient says who the readers are and
+how to write for them.
 
 ## The three sub-modules
 
@@ -109,9 +112,9 @@ Checklist:
 
 ## Verifying the contract
 
-At `verify`, the documentation review audits the change against the declared
-contract: for each declared pillar, it confirms the recipient can now reach
-the declared outcome, and it keeps existing docs honest against drift. The
+At `verify`, the documentation review audits the change against the defined
+contract: for each selected pillar, it confirms the recipient can now reach
+the defined outcome, and it keeps existing docs honest against drift. The
 method is `protocols/verify/references/documentation-review.md`; the outcome
 is recorded in the `documentation` section of `completion-evidence`.
 Verification is evidence, not assertion: the audit finds, per item, the
@@ -123,10 +126,10 @@ Three layers, one home each, none restating another:
 
 - **Taxonomy and stance** — `orient`'s documentation discipline: who the
   readers are, what artifacts serve them, how to write at the right depth.
-- **Declaration** — this module: the per-recipient outcomes a given change
-  must reach.
+- **Inputs and definition** — this module: the per-recipient outcomes a
+  given change must reach.
 - **Audit** — `verify`'s documentation review: the change checked against
-  the declared outcomes, recorded in `completion-evidence`.
+  the defined outcomes, recorded in `completion-evidence`.
 
 ## Cross-references
 

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -1,0 +1,156 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+CONTRACT_SURFACE = [
+    CONTRACT_SKILL,
+    ROOT / "skills" / "contract" / "references" / "documentation-contract.md",
+    ROOT / "skills" / "contract" / "references" / "code-quality-contract.md",
+]
+INSTRUCTION_FILES = [
+    *sorted((ROOT / "protocols").glob("*/PROTOCOL.md")),
+    *sorted((ROOT / "protocols").glob("*/references/*.md")),
+    *sorted((ROOT / "skills").glob("*/SKILL.md")),
+    *sorted((ROOT / "skills").glob("*/references/*.md")),
+]
+NON_CONTRACT_INSTRUCTION_FILES = [
+    path for path in INSTRUCTION_FILES if not path.is_relative_to(ROOT / "skills" / "contract")
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def section(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^### {re.escape(heading)}\n(?P<section>.*?)(?=^### |^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing section: {heading}")
+    return match.group("section")
+
+
+def lifecycle_rows(body: str) -> dict[str, str]:
+    rows = {}
+    for line in body.splitlines():
+        match = re.match(r"\| \*\*(?P<dimension>Behavior|Documentation|Code quality)\*\* \| (?P<row>.+) \|$", line)
+        if match:
+            rows[match.group("dimension")] = match.group("row")
+    return rows
+
+
+class ContractSkillLifecycleTests(unittest.TestCase):
+    def test_lifecycle_matrix_covers_every_dimension_stage_cell(self) -> None:
+        rows = lifecycle_rows(read(CONTRACT_SKILL))
+        expected_cells = {
+            "Behavior": [
+                "acceptance criteria",
+                "inputs to validation",
+                "validation defined",
+                "executable scenarios",
+                "documentation-deliverable gates",
+                "carried through `implement`",
+                "validation performed",
+                "scenario or gate coverage",
+                "recorded at `land`",
+            ],
+            "Documentation": [
+                "recipient outcomes",
+                "inputs to validation",
+                "validation defined",
+                "documentation outcomes",
+                "carried through `implement`",
+                "validation performed",
+                "audience-outcome review",
+                "recorded at `land`",
+            ],
+            "Code quality": [
+                "corpus pointers",
+                "stressed universals",
+                "inputs to validation",
+                "validation defined",
+                "reviewer-checkable projections",
+                "carried through `implement`",
+                "validation performed",
+                "diff loci or findings",
+                "recorded at `land`",
+            ],
+        }
+
+        self.assertEqual(set(expected_cells), set(rows))
+        for dimension, cells in expected_cells.items():
+            with self.subTest(dimension=dimension):
+                row = rows[dimension]
+                for cell in cells:
+                    self.assertIn(cell, row)
+
+    def test_stage_handoffs_have_one_receive_produce_home(self) -> None:
+        handoffs = normalized(section(read(CONTRACT_SKILL), "Stage Handoffs"))
+        expected_handoffs = [
+            "issue-craft produces inputs to validation",
+            "`take` consumes inputs to validation and produces validation defined",
+            "`implement` consumes validation defined",
+            "`verify` consumes validation defined and produces validation performed",
+            "`land` consumes validation performed",
+        ]
+
+        for handoff in expected_handoffs:
+            with self.subTest(handoff=handoff):
+                self.assertIn(handoff, handoffs)
+
+        duplicated_lifecycle_terms = re.compile(
+            r"inputs to validation|validation defined|validation performed|documentation-deliverable gates"
+        )
+        for path in NON_CONTRACT_INSTRUCTION_FILES:
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertIsNone(duplicated_lifecycle_terms.search(read(path)))
+
+    def test_contract_surface_replaces_entry_only_framing_everywhere(self) -> None:
+        forbidden = re.compile(
+            r"declared at `take`|At `take`, the contract declares|declared at entry|"
+            r"Each dimension is \*\*declared\*\* at `take`",
+            flags=re.IGNORECASE,
+        )
+
+        for path in CONTRACT_SURFACE:
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertIsNone(forbidden.search(read(path)))
+
+    def test_pointer_as_default_distinguishes_consideration_from_dense_inputs(self) -> None:
+        pointer = normalized(section(read(CONTRACT_SKILL), "Pointer-as-default"))
+
+        self.assertRegex(pointer, r"consider every dimension")
+        self.assertRegex(pointer, r"not a mandatory per-dimension declaration")
+        self.assertRegex(pointer, r"general contract remains the validation pointer")
+        self.assertRegex(pointer, r"density across dimensions is unequal; consideration is equal")
+        self.assertNotRegex(pointer, r"no special input[^.]+not validated")
+
+    def test_documentation_deliverable_gates_define_behavior_teeth(self) -> None:
+        gates = normalized(section(read(CONTRACT_SKILL), "Documentation-deliverable behavior gates"))
+        required_mappings = [
+            r"Structural gates[^.]+reference-link resolution",
+            r"Structural gates[^.]+script-path resolution",
+            r"Conformance gates[^.]+template-schema conformance",
+            r"Coherence gates[^.]+internal coherence",
+            r"broken links fail structural validation",
+            r"schema fails conformance",
+            r"lifecycle[^.]+sections fails internal coherence",
+        ]
+
+        for mapping in required_mappings:
+            with self.subTest(mapping=mapping):
+                self.assertRegex(gates, mapping)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -97,7 +97,7 @@ class ContractSkillLifecycleTests(unittest.TestCase):
     def test_stage_handoffs_have_one_receive_produce_home(self) -> None:
         handoffs = normalized(section(read(CONTRACT_SKILL), "Stage Handoffs"))
         expected_handoffs = [
-            "issue-craft produces inputs to validation",
+            "`work-unit-craft`/`decompose` produces inputs to validation",
             "`take` consumes inputs to validation and produces validation defined",
             "`implement` consumes validation defined",
             "`verify` consumes validation defined and produces validation performed",
@@ -114,6 +114,34 @@ class ContractSkillLifecycleTests(unittest.TestCase):
         for path in NON_CONTRACT_INSTRUCTION_FILES:
             with self.subTest(path=path.relative_to(ROOT)):
                 self.assertIsNone(duplicated_lifecycle_terms.search(read(path)))
+
+    def test_contract_surface_uses_public_work_unit_authoring_stage_names(self) -> None:
+        deprecated_stage_name = re.compile(r"\bissue-craft\b", flags=re.IGNORECASE)
+
+        for path in CONTRACT_SURFACE:
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertIsNone(deprecated_stage_name.search(read(path)))
+
+        handoffs = normalized(section(read(CONTRACT_SKILL), "Stage Handoffs"))
+        first_handoff = handoffs.split(".")[0]
+        self.assertIn("`work-unit-craft`/`decompose` produces inputs to validation", first_handoff)
+        self.assertNotRegex(first_handoff, r"\bissue-craft\b")
+
+    def test_lifecycle_single_home_claim_is_scoped_to_contract_surface(self) -> None:
+        body = read(CONTRACT_SKILL)
+        intro = normalized(body.split("## The teeth principle", maxsplit=1)[0])
+
+        self.assertIn("declares the lifecycle as the single home for the contract surface", intro)
+        self.assertIn("migration proceeds unit by unit across epic #443", intro)
+        present_tense_protocol_claim = re.compile(
+            r"(?:per-stage|consuming) protocols (?:now |already )?consult this home|"
+            r"protocols consult this home|instead of keeping their own lifecycle statement",
+            flags=re.IGNORECASE,
+        )
+        self.assertNotRegex(
+            intro,
+            present_tense_protocol_claim,
+        )
 
     def test_contract_surface_replaces_entry_only_framing_everywhere(self) -> None:
         forbidden = re.compile(


### PR DESCRIPTION
## Summary

- states the contract lifecycle as inputs to validation -> validation defined -> validation performed for behavior, documentation, and code quality
- documents the stage handoffs, pointer-as-default rule, and documentation-deliverable behavior gates in the contract skill
- updates the documentation/code-quality contract references, bumps contract skill metadata to 2.3.0, records the change in the changelog, and adds a unittest gate for lifecycle coherence

Closes #444.

## Contract Coverage

- `lifecycle_matrix_covers_every_dimension_stage_cell`
- `stage_handoffs_have_one_receive_produce_home`
- `contract_surface_replaces_entry_only_framing_everywhere`
- `pointer_as_default_distinguishes_consideration_from_dense_inputs`
- `documentation_deliverable_gates_define_behavior_teeth`

## Verification

- `python -m unittest discover -s tests` -> 335 tests passed
- `python -m tooling.conformance` -> 36 passed, 0 failed
- `git diff --check` -> passed
