### PR TITLE
[codex] Invoke reckon in work-unit-craft primary workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **work-unit-craft invokes reckon in its primary workflow** (#447). The
+  `work-unit-craft` skill now points authors to `reckon` as the cognitive
+  process for establishing a record's verified constraints before shaping the
+  record, while keeping reckon as the single home of that method.
+  work-unit-craft 1.0.0→1.1.0.
 - **Contract lifecycle made explicit across dimensions** (#444). The
   `contract` skill now states the inputs to validation -> validation defined
   -> validation performed lifecycle for behavior, documentation, and code

--- a/skills/work-unit-craft/SKILL.md
+++ b/skills/work-unit-craft/SKILL.md
@@ -9,8 +9,8 @@ description: >-
   and the corruption modes that make records mis-steer the agents who
   read them.
 metadata:
-  version: "1.0.0"
-  updated: "2026-06-11"
+  version: "1.1.0"
+  updated: "2026-06-19"
   origin: >-
     Adapted from pentaxis93/with-claude
     _shared/methodology/issue-craft.md (internal), renamed and
@@ -37,6 +37,13 @@ end state. The implementer's job is to find the path.
 
 This is not a stylistic preference. It is the structural defense against the
 most common failure mode in work-unit-driven development.
+
+## Ground the Record With Reckon
+
+Before shaping the record, use `reckon` as the cognitive process that
+establishes the verified constraints the record will state. `reckon` owns how
+those constraints are grounded; this craft owns the record shape that carries
+them across the delegation boundary.
 
 ## The Sovereignty Test
 

--- a/tests/test_work_unit_craft_skill.py
+++ b/tests/test_work_unit_craft_skill.py
@@ -1,0 +1,96 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORK_UNIT_CRAFT = ROOT / "skills" / "work-unit-craft" / "SKILL.md"
+
+
+def read_work_unit_craft() -> str:
+    return WORK_UNIT_CRAFT.read_text(encoding="utf-8")
+
+
+def section_between(body: str, start: str, end: str) -> str:
+    pattern = re.compile(
+        rf"^## {re.escape(start)}\n(?P<section>.*?)(?=^## {re.escape(end)}\n)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing section boundary: {start} -> {end}")
+    return match.group("section")
+
+
+def section(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^## {re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing section: {heading}")
+    return match.group("section")
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+class WorkUnitCraftSkillTests(unittest.TestCase):
+    def test_primary_workflow_invokes_reckon_for_verified_constraints(self) -> None:
+        body = read_work_unit_craft()
+        primary_workflow = section_between(
+            body,
+            "The Central Discipline",
+            "The Sovereignty Test",
+        )
+
+        self.assertIn("`reckon`", primary_workflow)
+        self.assertRegex(primary_workflow, r"\bcognitive process\b")
+        self.assertRegex(primary_workflow, r"\bverified constraints\b")
+        self.assertRegex(
+            primary_workflow,
+            r"(?s)`reckon`.*verified constraints|verified constraints.*`reckon`",
+        )
+
+    def test_reckon_invocation_is_a_pointer_not_a_second_home(self) -> None:
+        body = read_work_unit_craft()
+        primary_workflow = section_between(
+            body,
+            "The Central Discipline",
+            "The Sovereignty Test",
+        )
+
+        copied_method_terms = [
+            "six steps",
+            "Navigational Principles",
+            "Recognition Index",
+            "The Move",
+        ]
+        for term in copied_method_terms:
+            with self.subTest(term=term):
+                self.assertNotIn(term, primary_workflow)
+
+    def test_existing_craft_discipline_sections_remain_present(self) -> None:
+        body = read_work_unit_craft()
+        expected_sections = {
+            "The Central Discipline": "Records describe what must be true",
+            "The Sovereignty Test": "Is this a constraint the implementer must satisfy",
+            "Milestone Discipline": "release scope then becomes a query",
+            "Label Discipline": "Labels must discriminate",
+            "The Body Is the Spec; Comments Are a Log": "The body must be a complete, standalone specification",
+            "Corruption Modes": "stale-comment-direction",
+            "What Belongs in a Record": "Acceptance criteria",
+            "What Does Not Belong in a Record": "Implementation step sequences",
+            "Metadata at File Time": "Label (required)",
+            "Cross-References": "`decompose`",
+        }
+
+        for heading, expected_text in expected_sections.items():
+            with self.subTest(heading=heading):
+                self.assertIn(expected_text, normalized(section(body, heading)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a primary-workflow pointer in `work-unit-craft` that names `reckon` as the cognitive process for establishing verified constraints before shaping a record.
- Keep `reckon` as the single home of the method: no copied move, no principle subset list.
- Add a positional unittest gate so incidental mentions and Cross-References cannot satisfy the contract.

## Impact

Authors following `work-unit-craft` now reach `reckon` where the craft discipline is applied, not only as an incidental aside or cross-reference.

## Verification

- RED: `python -m unittest tests.test_work_unit_craft_skill` failed before the prose change because the primary workflow region lacked `reckon`.
- GREEN: `python -m unittest tests.test_work_unit_craft_skill`
- `python -m unittest tests.test_reference_links tests.test_principles_coherence tests.test_contract_skill_lifecycle`
- `python -m unittest discover -s tests -p 'test*.py'` — 340 tests passed
- `python -m tooling.conformance` — 36 passed, 0 failed

Closes #447.
