### PR TITLE
task(work-unit-craft): author multidimensional contract inputs

### DIFF
--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -60,6 +60,21 @@ say what kind (unit, integration, behavior). If it affects user-facing behavior,
 include documentation updates as criteria. Making these explicit prevents the
 implementer from treating them as optional.
 
+### Contract inputs
+
+Every work-unit authoring pass records contract inputs across the dimensions
+the `work-unit-craft` skill names: behavior, documentation, and code quality.
+Behavior inputs are the positive acceptance criteria. Documentation inputs are
+recipient outcomes, using `orient` for the audience taxonomy. Code quality
+inputs point to the principles corpus and name stressed universals when the
+work puts any under special pressure. The `contract` skill owns the lifecycle
+these inputs enter; decompose consults it and does not restate it.
+
+Considering a dimension does not require a dedicated body section. A dimension
+with no special input remains covered by the general contract pointer. The
+record is incomplete only when the author skipped the consideration pass or
+hid special inputs the implementer needs.
+
 ### Dependencies
 
 **Explicit and hard only.** Dependencies name other work-units that represent
@@ -115,9 +130,13 @@ the earlier discussion" to understand, it is incomplete.
 4. Define scope with concrete files or modules.
 5. Write acceptance criteria as observable outcomes — functional behavior,
    testing expectations, documentation updates where applicable.
-6. Identify dependencies by searching existing work-units in the tracker.
+6. Record contract inputs by applying `work-unit-craft`: behavior through
+   criteria, documentation through recipient outcomes from `orient`, and code
+   quality through the principles corpus plus any stressed universals. Consult
+   `contract` for how these inputs are used downstream.
+7. Identify dependencies by searching existing work-units in the tracker.
    Record each as a work-unit reference.
-7. Assemble using template from `references/templates.md`. Title format:
+8. Assemble using template from `references/templates.md`. Title format:
    `<type>(<scope>): <what>`.
 
 A structural linter is available at `protocols/decompose/scripts/issue_lint.py`
@@ -142,9 +161,12 @@ agents; consult it when authoring or re-scoping a record.
 5. Group by module boundary where it clarifies ownership.
 6. Build dependency graph (Mermaid `graph TD` + layered text summary —
    see [`work-unit-model.md`](../../docs/architecture/work-unit-model.md) § Dependency Graph Format).
-7. Size-check each candidate: split if oversized, merge if trivial.
-8. Create task work-units in topological order (lowest execution layer first).
-9. Create or update parent epic with task checklist and dependency graph.
+7. For each task, record contract inputs by applying `work-unit-craft`:
+   behavior, documentation, and code quality are considered before the task is
+   filed.
+8. Size-check each candidate: split if oversized, merge if trivial.
+9. Create task work-units in topological order (lowest execution layer first).
+10. Create or update parent epic with task checklist and dependency graph.
 
 ### define-task-boundary
 
@@ -165,7 +187,10 @@ A well-bounded task has:
 2. Diagnose: vague summary, missing scope, untestable criteria, implicit
    dependencies, oversized scope, or prescription leaking into criteria.
 3. Apply targeted fixes only where weak. Keep already-strong sections unchanged.
-4. Re-verify the central discipline — does any criterion or scope statement
+4. Re-apply the contract input pass from `work-unit-craft`, preserving any
+   behavior, documentation, and code quality inputs that remain true and adding
+   any missing special inputs.
+5. Re-verify the central discipline — does any criterion or scope statement
    prescribe an implementation approach?
 
 ### triage-work-units

--- a/skills/work-unit-craft/SKILL.md
+++ b/skills/work-unit-craft/SKILL.md
@@ -45,6 +45,34 @@ establishes the verified constraints the record will state. `reckon` owns how
 those constraints are grounded; this craft owns the record shape that carries
 them across the delegation boundary.
 
+## Author Contract Inputs
+
+After reckoning the work, author the record's **contract inputs**. The
+`contract` skill owns the lifecycle these inputs enter; this craft owns making
+the inputs visible in the work-unit record without turning them into
+implementation prescription.
+
+The authoring pass must **consider every dimension**:
+
+- **Behavior:** write acceptance criteria as positive, observable outcomes.
+  These are the behavior input the later contract sharpens into executable
+  checks.
+- **Documentation:** consult `orient`'s audience taxonomy and record any
+  recipient outcomes the work must make true. If no recipient needs a special
+  outcome beyond the general documentation contract, say nothing more.
+- **Code quality:** point to the principles corpus and name any stressed
+  universals the work puts under unusual pressure. If the general code-quality
+  contract is enough, the corpus pointer is sufficient.
+
+This is a consideration prompt, **not a mandatory per-dimension body
+section**. The **general contract pointer** carries any dimension with no
+special input. Density is unequal; consideration is equal. A terse bug may
+carry only behavior criteria after the documentation and code quality
+dimensions were considered. A documentation-deliverable unit may carry dense
+recipient outcomes and only the general corpus pointer. In every case,
+silence is valid only after the dimension was considered and the general
+contract is enough.
+
 ## The Sovereignty Test
 
 Before writing any record content, ask:
@@ -263,6 +291,26 @@ rather than adding a negative.
 be satisfied by an implementation that has the unwanted behavior? If no, the
 negative was redundant. If yes, strengthen the positive criteria.
 
+### contract-modeling
+
+The record creates a hand-maintained model of a declared contract — operation names or
+shapes, lifecycle steps, schema members, or supported cases — instead of
+requiring the implementer to consult the contract itself. The model looks like
+verification, but it can drift from the authority and makes the record a second
+home for the contract.
+
+*Recognition:* A criterion says "cover operations A, B, C" or reproduces a
+field table that already lives in a schema, capability contract, or protocol
+surface. If the authority changes, the record would have to be edited by hand
+to stay true.
+
+*The test:* Could the declared contract add, rename, or remove a shape while
+the record still appears complete? If yes, the record modeled the contract.
+
+*The fix:* State the positive conformance outcome and require the work to
+consult the contract. Criteria derive from the declaration and verify against
+the declaration, not against a copied list in the record.
+
 ### activity-criteria
 
 Criteria describe activities ("refactor", "clean up", "investigate") rather
@@ -348,6 +396,9 @@ to start?" If the answer references unfinished work, that is a dependency.
   boundary conditions exist.
 - **Acceptance criteria:** Observable outcomes — functional behavior,
   testing expectations, documentation updates. Binary pass/fail.
+- **Declared contract conformance:** when work conforms to an existing
+  contract, consult the declared contract, derive criteria from its
+  declarations, and verify positively against the declaration.
 - **Dependencies:** Work-unit references that represent true blockers.
 
 ## What Does Not Belong in a Record
@@ -381,6 +432,13 @@ to start?" If the answer references unfinished work, that is a dependency.
   schemas.
 - `reckon`: establishes the verified constraints a record states; fire it
   before framing the work-unit.
+- `contract`: owns the multidimensional lifecycle that receives the contract
+  inputs a record carries; this craft points to that home and does not restate
+  it.
+- `orient`: owns the documentation audience taxonomy used when authoring
+  documentation recipient outcomes.
+- principles corpus (`~/.groundwork/principles/`): owns the code-quality
+  universals a record points to when a change stresses them.
 - [`docs/architecture/work-unit-model.md`](../../docs/architecture/work-unit-model.md):
   the work-unit state model and dependency graph format the record
   participates in.

--- a/tests/test_work_unit_craft_skill.py
+++ b/tests/test_work_unit_craft_skill.py
@@ -5,10 +5,15 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORK_UNIT_CRAFT = ROOT / "skills" / "work-unit-craft" / "SKILL.md"
+DECOMPOSE_PROTOCOL = ROOT / "protocols" / "decompose" / "PROTOCOL.md"
 
 
 def read_work_unit_craft() -> str:
     return WORK_UNIT_CRAFT.read_text(encoding="utf-8")
+
+
+def read_decompose_protocol() -> str:
+    return DECOMPOSE_PROTOCOL.read_text(encoding="utf-8")
 
 
 def section_between(body: str, start: str, end: str) -> str:
@@ -90,6 +95,99 @@ class WorkUnitCraftSkillTests(unittest.TestCase):
         for heading, expected_text in expected_sections.items():
             with self.subTest(heading=heading):
                 self.assertIn(expected_text, normalized(section(body, heading)))
+
+    def test_primary_workflow_authors_contract_inputs_for_every_dimension(self) -> None:
+        body = read_work_unit_craft()
+        primary_workflow = normalized(
+            section_between(
+                body,
+                "The Central Discipline",
+                "The Sovereignty Test",
+            )
+        )
+
+        expected_inputs = [
+            "contract inputs",
+            "`contract`",
+            "behavior",
+            "acceptance criteria",
+            "documentation",
+            "`orient`",
+            "recipient outcomes",
+            "code quality",
+            "principles corpus",
+            "stressed universals",
+        ]
+        for expected in expected_inputs:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, primary_workflow)
+
+    def test_pointer_as_default_is_a_considered_dimension_not_a_body_requirement(self) -> None:
+        body = read_work_unit_craft()
+        primary_workflow = normalized(
+            section_between(
+                body,
+                "The Central Discipline",
+                "The Sovereignty Test",
+            )
+        )
+
+        self.assertIn("consider every dimension", primary_workflow)
+        self.assertIn("not a mandatory per-dimension body section", primary_workflow)
+        self.assertIn("general contract pointer", primary_workflow)
+        self.assertIn("silence is valid only after the dimension was considered", primary_workflow)
+
+    def test_declared_contract_work_consults_the_contract_instead_of_modeling_it(self) -> None:
+        body = read_work_unit_craft()
+        belongs = normalized(section(body, "What Belongs in a Record"))
+        corruption_modes = normalized(section(body, "Corruption Modes"))
+
+        positive_craft = [
+            "Declared contract conformance",
+            "consult the declared contract",
+            "derive criteria from its declarations",
+            "verify positively against the declaration",
+        ]
+        for expected in positive_craft:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, belongs)
+
+        corruption_checks = [
+            "contract-modeling",
+            "hand-maintained model",
+            "operation names or shapes",
+            "consult the contract",
+        ]
+        for expected in corruption_checks:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, corruption_modes)
+
+    def test_decompose_procedures_apply_the_contract_input_pass(self) -> None:
+        body = read_decompose_protocol()
+        create_work_unit = normalized(
+            section_between(
+                body,
+                "Procedures",
+                "Triggers",
+            )
+        )
+
+        expected = [
+            "contract inputs",
+            "behavior",
+            "documentation",
+            "code quality",
+            "`work-unit-craft`",
+            "`contract`",
+            "`orient`",
+            "principles corpus",
+            "create-work-unit",
+            "decompose-epic",
+            "refine-work-unit",
+        ]
+        for item in expected:
+            with self.subTest(item=item):
+                self.assertIn(item, create_work_unit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Extend the canonical `work-unit-craft` skill so the primary workflow authors contract inputs across behavior, documentation, and code quality.
- Add pointer-as-default consideration discipline and consult-don't-model criterion craft for declared-contract conformance.
- Update `decompose` create/refine/epic procedures to apply the contract-input pass while keeping lifecycle authority in `contract`.
- Add coherence tests guarding the new craft behavior and preservation of existing craft sections.

Part of tesserine/groundwork#449.

Companion PRs:
- pentaxis93/with-claude#121
- pentaxis93/principles#25

## Verification

- `python -m unittest tests.test_work_unit_craft_skill tests.test_contract_skill_lifecycle`
- `python -m unittest discover -s tests`
- `python -m tooling.conformance`
- `git diff --check`