### PR TITLE
task(take): define validation across contract dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`skills/contract/references/code-quality-contract.md`), consulting the
   corpus rather than a separate rulebook. `verify` audits both declared
   contracts (`protocols/verify/references/documentation-review.md`,
-  `code-quality-review.md`) and `take` declares them alongside the behavior
-  contract. No new artifact schema — the dimensions are a declared
+  `code-quality-review.md`) and `take` defines their validation alongside the
+  behavior contract. No new artifact schema — the dimensions are a declared
   discipline; schema formalization is deferred.
 
 - **Methodology self-install for runtime-driven deployments** (#416).
@@ -48,6 +48,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **take defines validation across every contract dimension** (#451). The
+  `take` protocol now consumes multidimensional contract inputs from
+  work-unit-craft/decompose and produces validation defined for behavior,
+  documentation, and code quality. Behavior uses runtime Given/When/Then
+  scenarios or documentation-deliverable gates; documentation uses
+  audience-outcome checklists; code quality uses projected corpus universals.
+  The protocol consults the `contract` skill and its dimension references
+  without re-encoding their lifecycle. take 3.3.0→3.4.0.
 - **work-unit-craft invokes reckon in its primary workflow** (#447). The
   `work-unit-craft` skill now points authors to `reckon` as the cognitive
   process for establishing a record's verified constraints before shaping the

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -8,8 +8,8 @@ description: >-
   carries to land; until the runtime sequences the stations autonomously,
   take carries it. Trigger on: 'take', 'take work', 'start work-unit'.
 metadata:
-  version: "3.3.0"
-  updated: "2026-06-17"
+  version: "3.4.0"
+  updated: "2026-06-19"
 ---
 
 # Take — Contract-First Entry
@@ -46,30 +46,49 @@ proves it, or records it.
    work whose `dependencies` are still open; a blocked work-unit is a
    substrate signal, not an invitation.
 
-4. **Author the behavior contract.** First reckon it: authoring the
+4. **Define validation across the contract.** First reckon it: authoring the
    contract is a generative act — open the resolved principles corpus at
    `~/.groundwork/principles/`, select the principles that govern what
    "done" means here, read them, and reason the contract from them rather
    than the work-unit's surface wording alone (the reckon skill is the
-   move). Then refine each acceptance criterion into
-   one or more sentence-named Given/When/Then scenarios — the executable
-   definition of done. The `contract` skill is the authoring discipline:
-   behavior before mechanics, one behavior per scenario, names that read as
-   specification. Invoke it. Where a criterion cannot be expressed as an
-   observable behavior, that is a defect in the work-unit — resolve it
-   against the work-unit's intent, and record the interpretation in the
-   scenario's `criterion` reference rather than silently guessing.
+   move). Then invoke the `contract` skill and consume the work-unit's
+   inputs to validation: behavior from acceptance criteria, documentation
+   from recipient outcomes, and code quality from corpus pointers and
+   stressed universals. `take` produces validation defined for every
+   dimension; it consults the `contract` skill for the lifecycle,
+   `documentation-contract.md` for the documentation form,
+   `code-quality-contract.md` for the code-quality form, `orient` for the
+   audience taxonomy, and `~/.groundwork/principles/` for the universals.
 
-   The behavior contract is the contract's first dimension, not its whole.
-   As you author it, also declare the change's **documentation** and
-   **code-quality** dimensions per the `contract` skill: which documentation
-   pillars the change owes — user, developer, discovery — and the outcome
-   each must reach, and which principles-corpus universals this change most
-   stresses. A subset is legitimate; silence where the change clearly serves
-   a recipient or stresses a universal is under-declaration. These
-   declarations travel with the work-unit and are audited at `verify`;
-   behavior is the dimension delivered as the `behavior-contract` artifact
+   For **behavior**, choose the form that matches the deliverable. A
+   runtime-behavior work-unit is defined as sentence-named Given/When/Then
+   scenarios — behavior before mechanics, one behavior per scenario, names
+   that read as specification. A documentation-deliverable work-unit is
+   defined as documentation-deliverable gates: structural, coherence, and
+   conformance checks that prove the documented discipline works as a
+   usable surface. Where a criterion cannot be expressed as observable
+   behavior or as a documentation-deliverable gate, resolve the mismatch
+   against the work-unit's intent and record the interpretation in the
+   scenario's or gate's criterion reference rather than silently guessing.
+   Behavior is the dimension delivered as the `behavior-contract` artifact
    below.
+
+   For **documentation**, define the pillars the change touches — user,
+   developer, discovery — as an audience-outcome checklist. Each item names
+   the outcome the recipient must reach, not an artifact that must exist; a
+   delivery with hollow docs must fail it.
+
+   For **code quality**, define the projected corpus universals this change
+   puts under real pressure. Each universal becomes a reviewer-checkable
+   item: the universal as a question of the diff, the failing tell a
+   careless change would leave, and the locus where the change holds.
+
+   Agents must consider every dimension. A dimension with no special input
+   uses the general contract pointer; density is unequal, but consideration
+   is equal. Silence is valid only after the dimension was considered and the
+   general contract is enough. These defined validations travel with the
+   work-unit and are performed at `verify`; `take` consults the single homes
+   above and does not keep a second lifecycle statement.
 
 5. **Deliver the `behavior-contract`.** Invoke the `behavior-contract` MCP
    tool. The object below is MCP tool input, not artifact body. `instance_id`

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -108,12 +108,25 @@ class ContractSkillLifecycleTests(unittest.TestCase):
             with self.subTest(handoff=handoff):
                 self.assertIn(handoff, handoffs)
 
-        duplicated_lifecycle_terms = re.compile(
-            r"inputs to validation|validation defined|validation performed|documentation-deliverable gates"
+        reencoded_lifecycle_table = re.compile(
+            r"\|\s*(?:Dimension|Dimension\s+)\s*\|\s*(?:Lifecycle|Lifecycle\s+)\s*\|"
+            r"|"
+            r"\| \*\*Behavior\*\* \|.+?\| \*\*Documentation\*\* \|.+?"
+            r"\| \*\*Code quality\*\* \|",
+            flags=re.DOTALL,
+        )
+        reencoded_stage_handoffs = re.compile(
+            r"^### Stage Handoffs\b|"
+            r"`work-unit-craft`/`decompose` produces inputs to validation.+?"
+            r"`take` consumes inputs to validation and produces validation defined.+?"
+            r"`verify` consumes validation defined and produces validation performed",
+            flags=re.MULTILINE | re.DOTALL,
         )
         for path in NON_CONTRACT_INSTRUCTION_FILES:
             with self.subTest(path=path.relative_to(ROOT)):
-                self.assertIsNone(duplicated_lifecycle_terms.search(read(path)))
+                body = read(path)
+                self.assertIsNone(reencoded_lifecycle_table.search(body))
+                self.assertIsNone(reencoded_stage_handoffs.search(body))
 
     def test_contract_surface_uses_public_work_unit_authoring_stage_names(self) -> None:
         deprecated_stage_name = re.compile(r"\bissue-craft\b", flags=re.IGNORECASE)

--- a/tests/test_take_protocol_contract_dimensions.py
+++ b/tests/test_take_protocol_contract_dimensions.py
@@ -1,0 +1,193 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TAKE_PROTOCOL = ROOT / "protocols" / "take" / "PROTOCOL.md"
+CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+DOCUMENTATION_CONTRACT = ROOT / "skills" / "contract" / "references" / "documentation-contract.md"
+CODE_QUALITY_CONTRACT = ROOT / "skills" / "contract" / "references" / "code-quality-contract.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def take_body() -> str:
+    return read(TAKE_PROTOCOL)
+
+
+def take_step_4() -> str:
+    body = take_body()
+    match = re.search(
+        r"^4\. \*\*.*?\n(?P<section>.*?)(?=^5\. \*\*)",
+        body,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError("missing take step 4")
+    return normalized(match.group("section"))
+
+
+def section(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^## {re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing section: {heading}")
+    return match.group("section")
+
+
+class TakeProtocolContractDimensionTests(unittest.TestCase):
+    def test_primary_flow_defines_validation_for_every_contract_dimension(self) -> None:
+        step = take_step_4()
+
+        expected = [
+            "inputs to validation",
+            "validation defined",
+            "acceptance criteria",
+            "recipient outcomes",
+            "corpus pointers",
+            "stressed universals",
+            "behavior",
+            "documentation",
+            "code quality",
+        ]
+        for item in expected:
+            with self.subTest(item=item):
+                self.assertIn(item, step)
+
+        self.assertRegex(
+            step,
+            r"(?s)behavior.*documentation.*code quality|code quality.*documentation.*behavior",
+        )
+
+    def test_documentation_and_code_quality_defined_forms_have_teeth(self) -> None:
+        step = take_step_4()
+
+        expected = [
+            "audience-outcome checklist",
+            "hollow docs",
+            "projected corpus universals",
+            "reviewer-checkable item",
+            "question",
+            "failing tell",
+            "locus",
+        ]
+        for item in expected:
+            with self.subTest(item=item):
+                self.assertIn(item, step)
+
+        self.assertNotRegex(step, r"README is updated|code is clean")
+
+    def test_behavior_form_matches_the_deliverable(self) -> None:
+        step = take_step_4()
+
+        expected = [
+            "Given/When/Then scenarios",
+            "runtime-behavior work-unit",
+            "documentation-deliverable work-unit",
+            "structural",
+            "coherence",
+            "conformance",
+            "gates",
+        ]
+        for item in expected:
+            with self.subTest(item=item):
+                self.assertIn(item, step)
+
+    def test_pointer_as_default_keeps_dimensions_considered_without_mandatory_blocks(self) -> None:
+        step = take_step_4()
+
+        expected = [
+            "consider every dimension",
+            "general contract",
+            "pointer",
+            "no special input",
+            "density is unequal",
+        ]
+        for item in expected:
+            with self.subTest(item=item):
+                self.assertIn(item, step)
+
+        self.assertNotIn("mandatory per-dimension", step)
+
+    def test_take_consults_single_homes_without_reencoding_the_lifecycle(self) -> None:
+        step = take_step_4()
+
+        expected = [
+            "`contract` skill",
+            "documentation-contract.md",
+            "code-quality-contract.md",
+            "`orient`",
+            "~/.groundwork/principles/",
+            "consult",
+        ]
+        for item in expected:
+            with self.subTest(item=item):
+                self.assertIn(item, step)
+
+        self.assertNotRegex(step, r"\| Dimension \| Lifecycle \|")
+        self.assertNotIn("Stage Handoffs", step)
+
+    def test_take_defined_forms_conform_to_contract_skill_single_home(self) -> None:
+        step = take_step_4()
+        contract = read(CONTRACT_SKILL)
+        documentation_contract = read(DOCUMENTATION_CONTRACT)
+        code_quality_contract = read(CODE_QUALITY_CONTRACT)
+
+        for phrase in [
+            "documentation-deliverable gates",
+            "audience-outcome review",
+            "reviewer-checkable projections",
+            "pointer",
+        ]:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, contract)
+
+        self.assertIn("audience", documentation_contract)
+        self.assertIn("outcome", documentation_contract)
+        self.assertIn("checklist", documentation_contract)
+        self.assertIn("question", code_quality_contract)
+        self.assertIn("failing tell", code_quality_contract)
+        self.assertIn("locus", code_quality_contract)
+        self.assertIn("documentation-deliverable gates", step)
+        self.assertIn("audience-outcome checklist", step)
+        self.assertIn("projected corpus universals", step)
+
+    def test_existing_take_discipline_sections_survive(self) -> None:
+        body = take_body()
+        sections = {
+            "Steps": "Prepare the workspace",
+            "Scale": "Depth scales with the change",
+            "Operating Principles": "The contract is the spine",
+            "Corruption Modes": "contract-after-code",
+            "Cross-References": "`reckon`",
+        }
+
+        for heading, expected in sections.items():
+            with self.subTest(heading=heading):
+                self.assertIn(expected, normalized(section(body, heading)))
+
+        for corruption_mode in [
+            "scope-creep",
+            "criteria-parroting",
+            "skip-preparation",
+            "state-lag",
+            "abandon-at-contract",
+            "mechanics-as-plan",
+            "delegate-to-unwired-runtime",
+        ]:
+            with self.subTest(corruption_mode=corruption_mode):
+                self.assertIn(corruption_mode, body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Updates `take` so Step 4 consumes multidimensional contract inputs and defines validation for behavior, documentation, and code quality.
- Keeps `contract` and its references as the single home of the lifecycle while allowing `take` to name the lifecycle terms it consumes.
- Adds a dedicated coherence gate for `take` and refines the existing lifecycle guard to reject re-encoded lifecycle tables or Stage Handoffs blocks, not legitimate consumer terms.

Refs #451.

## Verification

- `python -m unittest tests.test_take_protocol_contract_dimensions tests.test_contract_skill_lifecycle`
- `python -m unittest discover -s tests`
- `python -m tooling.conformance`
