### PR TITLE
task(take): define validation across contract dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`skills/contract/references/code-quality-contract.md`), consulting the
   corpus rather than a separate rulebook. `verify` audits both declared
   contracts (`protocols/verify/references/documentation-review.md`,
-  `code-quality-review.md`) and `take` declares them alongside the behavior
-  contract. No new artifact schema — the dimensions are a declared
-  discipline; schema formalization is deferred.
+  `code-quality-review.md`), and `take` now defines validation across all
+  three dimensions from the work-unit's contract inputs. Runtime behavior
+  still delivers the scenario-shaped `behavior-contract`; documentation
+  deliverables carry structural, coherence, and conformance gate coverage.
+  No new artifact schema — the dimensions are a declared discipline; schema
+  formalization is deferred.
 
 - **Methodology self-install for runtime-driven deployments** (#416).
   `scripts/install` (logic in `tooling/install.py`, stdlib-only) installs

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -8,8 +8,8 @@ description: >-
   carries to land; until the runtime sequences the stations autonomously,
   take carries it. Trigger on: 'take', 'take work', 'start work-unit'.
 metadata:
-  version: "3.3.0"
-  updated: "2026-06-17"
+  version: "3.4.0"
+  updated: "2026-06-19"
 ---
 
 # Take — Contract-First Entry
@@ -46,30 +46,51 @@ proves it, or records it.
    work whose `dependencies` are still open; a blocked work-unit is a
    substrate signal, not an invitation.
 
-4. **Author the behavior contract.** First reckon it: authoring the
+4. **Define the contract validation.** First reckon it: authoring the
    contract is a generative act — open the resolved principles corpus at
    `~/.groundwork/principles/`, select the principles that govern what
    "done" means here, read them, and reason the contract from them rather
    than the work-unit's surface wording alone (the reckon skill is the
-   move). Then refine each acceptance criterion into
-   one or more sentence-named Given/When/Then scenarios — the executable
-   definition of done. The `contract` skill is the authoring discipline:
-   behavior before mechanics, one behavior per scenario, names that read as
-   specification. Invoke it. Where a criterion cannot be expressed as an
-   observable behavior, that is a defect in the work-unit — resolve it
-   against the work-unit's intent, and record the interpretation in the
-   scenario's `criterion` reference rather than silently guessing.
+   move). Then consume the work-unit's **contract inputs** — the acceptance
+   criteria, documentation recipient outcomes, and code quality corpus
+   pointers or stressed universals — and turn those inputs to validation
+   into **validation defined** across behavior, documentation, and code
+   quality. The `contract` skill owns that lifecycle and the teeth principle;
+   take consults it instead of keeping a second lifecycle home.
 
-   The behavior contract is the contract's first dimension, not its whole.
-   As you author it, also declare the change's **documentation** and
-   **code-quality** dimensions per the `contract` skill: which documentation
-   pillars the change owes — user, developer, discovery — and the outcome
-   each must reach, and which principles-corpus universals this change most
-   stresses. A subset is legitimate; silence where the change clearly serves
-   a recipient or stresses a universal is under-declaration. These
-   declarations travel with the work-unit and are audited at `verify`;
-   behavior is the dimension delivered as the `behavior-contract` artifact
-   below.
+   For **behavior**, consult the `contract` skill's behavioral dimension.
+   Runtime-behavior work-units refine each acceptance criterion into
+   sentence-named Given/When/Then executable scenarios, one behavior per
+   scenario, with observable outcomes a stub cannot pass.
+   Documentation-deliverable work-units define behavior as
+   documentation-deliverable gates: structural, coherence, and conformance
+   checks such as reference-link resolution, script-path resolution,
+   template-schema conformance, and internal lifecycle coherence. Those gates
+   are realized as the
+   methodology's committed tests and carried downstream as gate coverage,
+   not squeezed into fake scenarios.
+
+   For **documentation**, consult
+   `skills/contract/references/documentation-contract.md` and `orient`'s
+   documentation audience taxonomy. Define the selected user, developer, and
+   discovery pillars as an audience-outcome checklist: each recipient
+   outcome says what the reader can do after the change, and a hollow or
+   doc-less delivery fails it. Artifact-existence claims such as "the README
+   is updated" are not validation defined.
+
+   For **code quality**, consult
+   `skills/contract/references/code-quality-contract.md` and the resolved
+   principles corpus at `~/.groundwork/principles/`. Define the universals
+   this change most stresses as projected reviewer-checkable items: the
+   universal as a question of the change, the failing tell a careless change
+   leaves, and the locus where the diff shows the universal holds. A claim
+   that "the code is clean" is not validation defined.
+
+   Apply pointer-as-default. Every dimension is considered, but a dimension
+   with no special input does not require a body section: it is not a
+   mandatory per-dimension block; its general contract pointer carries
+   validation. Silence is valid only after the dimension was considered and
+   the general contract is enough.
 
 5. **Deliver the `behavior-contract`.** Invoke the `behavior-contract` MCP
    tool. The object below is MCP tool input, not artifact body. `instance_id`
@@ -95,11 +116,16 @@ proves it, or records it.
 
    Runa validates the remaining artifact body fields against the
    behavior-contract schema, persists the artifact, and records it in the
-   artifact store. Where no runtime is present to accept the MCP tool — a
-   checkout that is not an initialized runa project — author the same
-   contract as a committed workspace artifact (the behavior-contract JSON,
-   or the work-unit issue if there is no workspace store) so the spine
-   exists and binds the test-first cycle either way.
+   artifact store. The schema remains the runtime-behavior scenario form. For
+   documentation-deliverable work-units, the behavior gates are realized as
+   committed structural, coherence, and conformance tests and carried as gate
+   coverage beside the contract. Do not encode documentation-deliverable
+   gates as scenarios. Where no runtime is present to accept the MCP tool —
+   a checkout that is not an initialized runa project — author the same
+   scenario contract as a committed workspace artifact when the work is
+   runtime behavior, or commit the gate tests that realize the documentation
+   deliverable's behavior validation, so the spine exists and binds the
+   test-first cycle either way.
 
 6. **Carry the contract through to a submitted change.** Take does not end
    at contract delivery. When the runtime sequences the pipeline
@@ -108,24 +134,28 @@ proves it, or records it.
 
    The carry begins at `plan`, and the plan is where the work converges.
    The plan that serves this work is the `plan` protocol's contract-centered
-   design: the goal stated from the contract's scenarios, each scenario
-   mapped to the steps that make it true, the test strategy that turns each
-   into a failing test before its code. Where the harness plans before it
-   executes, *that design is the plan you surface for approval* — not a
-   narration of pipeline mechanics, which station comes next or which
-   command advances it. Lead with the contract: its scenario coverage (the
-   design), the absence of any gap through which a delivery the contract
-   accepts as done could still fail (the robustness), and how each scenario
-   is driven red-then-green (the validation). Surface that, and accepting
-   the plan is accepting the contracted work — full convergence at the
-   planning surface.
+   design: the goal stated from the contract's scenarios for runtime
+   behavior, or from the contract's gates for documentation deliverables;
+   each scenario or gate mapped to the steps that make it true; the test
+   strategy that turns each into a failing test before its code or
+   documentation change. Where the harness plans before it executes, *that
+   design is the plan you surface for approval* — not a narration of
+   pipeline mechanics, which station comes next or which command advances
+   it. Lead with the contract: scenario coverage for runtime behavior, gate
+   coverage for documentation deliverables, the absence of any gap through
+   which a delivery the contract accepts as done could still fail, and how
+   each scenario or gate is driven red-then-green. Surface that, and
+   accepting the plan is accepting the contracted work — full convergence at
+   the planning surface.
 
    On acceptance, carry it forward yourself. You are already the agent:
    deliver the `implementation-plan` artifact through its output tool to
    advance `plan`, then drive the remaining stations directly — `implement`
-   (build it test-first; every scenario a failing test before its code,
-   `contract-after-code` forbidden), `verify` (every scenario green, the
-   change sound), `submit` (deliver the change for review) — opening
+   (build it test-first; every scenario or gate a failing test before its
+   code or documentation change, `contract-after-code` forbidden), `verify`
+   (every scenario or gate green, the documentation outcomes met, the code
+   quality projections audited, the change sound), `submit` (deliver the
+   change for review) — opening
    `runa-mcp` in session mode for the work-unit and, at each station,
    reading its context, doing the work, producing its artifact, advancing.
    Do not hand the carry-through to `runa go --work-unit`: that spawns a

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -19,6 +19,10 @@ INSTRUCTION_FILES = [
 NON_CONTRACT_INSTRUCTION_FILES = [
     path for path in INSTRUCTION_FILES if not path.is_relative_to(ROOT / "skills" / "contract")
 ]
+TAKE_PROTOCOL = ROOT / "protocols" / "take" / "PROTOCOL.md"
+NON_CONTRACT_NON_TAKE_INSTRUCTION_FILES = [
+    path for path in NON_CONTRACT_INSTRUCTION_FILES if path != TAKE_PROTOCOL
+]
 
 
 def read(path: Path) -> str:
@@ -111,9 +115,15 @@ class ContractSkillLifecycleTests(unittest.TestCase):
         duplicated_lifecycle_terms = re.compile(
             r"inputs to validation|validation defined|validation performed|documentation-deliverable gates"
         )
-        for path in NON_CONTRACT_INSTRUCTION_FILES:
+        for path in NON_CONTRACT_NON_TAKE_INSTRUCTION_FILES:
             with self.subTest(path=path.relative_to(ROOT)):
                 self.assertIsNone(duplicated_lifecycle_terms.search(read(path)))
+
+        take_body = read(TAKE_PROTOCOL)
+        self.assertRegex(take_body, duplicated_lifecycle_terms)
+        self.assertNotRegex(take_body, r"\| \*\*Behavior\*\* \|")
+        self.assertNotRegex(take_body, r"\| \*\*Documentation\*\* \|")
+        self.assertNotRegex(take_body, r"\| \*\*Code quality\*\* \|")
 
     def test_contract_surface_uses_public_work_unit_authoring_stage_names(self) -> None:
         deprecated_stage_name = re.compile(r"\bissue-craft\b", flags=re.IGNORECASE)

--- a/tests/test_take_multidimensional_contract.py
+++ b/tests/test_take_multidimensional_contract.py
@@ -1,0 +1,165 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TAKE_PROTOCOL = ROOT / "protocols" / "take" / "PROTOCOL.md"
+CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def numbered_step(body: str, number: int) -> str:
+    pattern = re.compile(
+        rf"^{number}\. \*\*[^*]+\.\*\*(?P<section>.*?)(?=^\d+\. \*\*|^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing numbered step {number}")
+    return match.group("section")
+
+
+def lifecycle_row(dimension: str) -> str:
+    pattern = re.compile(
+        rf"^\| \*\*{re.escape(dimension)}\*\* \| (?P<row>.+) \|$",
+        flags=re.MULTILINE,
+    )
+    match = pattern.search(read(CONTRACT_SKILL))
+    if match is None:
+        raise AssertionError(f"missing lifecycle row for {dimension}")
+    return match.group("row")
+
+
+class TakeMultidimensionalContractTests(unittest.TestCase):
+    def test_primary_authoring_step_defines_validation_for_every_dimension(self) -> None:
+        authoring = normalized(numbered_step(read(TAKE_PROTOCOL), 4))
+
+        for expected in [
+            "contract inputs",
+            "inputs to validation",
+            "validation defined",
+            "behavior",
+            "documentation",
+            "code quality",
+            "`contract`",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, authoring)
+
+        self.assertNotIn("merely declare", authoring.lower())
+        self.assertNotIn("audited at `verify`; behavior is the dimension delivered", authoring)
+
+    def test_dimension_forms_match_the_contract_skill_lifecycle(self) -> None:
+        authoring = normalized(numbered_step(read(TAKE_PROTOCOL), 4))
+
+        behavior_terms = ["executable scenarios", "documentation-deliverable gates"]
+        documentation_terms = ["audience-outcome checklist", "recipient outcome"]
+        code_quality_terms = ["projected", "reviewer-checkable", "question", "failing tell", "locus"]
+
+        for term in behavior_terms:
+            with self.subTest(dimension="behavior", term=term):
+                self.assertIn(term, authoring)
+                self.assertIn(term, lifecycle_row("Behavior"))
+
+        for term in ["documentation outcomes"]:
+            with self.subTest(dimension="documentation lifecycle", term=term):
+                self.assertIn(term, lifecycle_row("Documentation"))
+        for term in documentation_terms:
+            with self.subTest(dimension="documentation authoring", term=term):
+                self.assertIn(term, authoring)
+
+        self.assertIn("reviewer-checkable projections", lifecycle_row("Code quality"))
+        for term in code_quality_terms:
+            with self.subTest(dimension="code quality", term=term):
+                self.assertIn(term, authoring)
+
+    def test_documentation_deliverable_gates_are_realized_and_carried(self) -> None:
+        body = normalized(read(TAKE_PROTOCOL))
+        delivery = normalized(numbered_step(read(TAKE_PROTOCOL), 5))
+        carry = normalized(numbered_step(read(TAKE_PROTOCOL), 6))
+
+        for expected in [
+            "structural",
+            "coherence",
+            "conformance",
+            "committed",
+            "tests",
+            "gate coverage",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+        self.assertIn("scenario coverage", carry)
+        self.assertIn("gate coverage", carry)
+        self.assertIn("documentation-deliverable", delivery)
+        self.assertIn("Do not encode documentation-deliverable gates as scenarios", delivery)
+
+    def test_pointer_as_default_is_defined_without_mandatory_dimension_blocks(self) -> None:
+        authoring = normalized(numbered_step(read(TAKE_PROTOCOL), 4))
+
+        for expected in [
+            "pointer-as-default",
+            "considered",
+            "general contract pointer",
+            "no special input",
+            "not a mandatory",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, authoring)
+
+    def test_take_consults_single_homes_without_reencoding_the_lifecycle(self) -> None:
+        body = read(TAKE_PROTOCOL)
+        authoring = normalized(numbered_step(body, 4))
+
+        for expected in [
+            "skills/contract/references/documentation-contract.md",
+            "skills/contract/references/code-quality-contract.md",
+            "`orient`",
+            "documentation audience taxonomy",
+            "~/.groundwork/principles/",
+            "consult",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, authoring)
+
+        self.assertNotRegex(body, r"\| \*\*Behavior\*\* \|")
+        self.assertNotRegex(body, r"\| \*\*Documentation\*\* \|")
+        self.assertNotRegex(body, r"\| \*\*Code quality\*\* \|")
+
+    def test_existing_take_discipline_sections_and_corruptions_survive(self) -> None:
+        body = read(TAKE_PROTOCOL)
+
+        for heading in [
+            "## Steps",
+            "## Scale",
+            "## Operating Principles",
+            "## Corruption Modes",
+            "## Cross-References",
+        ]:
+            with self.subTest(heading=heading):
+                self.assertIn(heading, body)
+
+        for corruption in [
+            "contract-after-code",
+            "scope-creep",
+            "criteria-parroting",
+            "skip-preparation",
+            "state-lag",
+            "abandon-at-contract",
+            "mechanics-as-plan",
+            "delegate-to-unwired-runtime",
+        ]:
+            with self.subTest(corruption=corruption):
+                self.assertIn(corruption, body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Updates `take` so contract authoring defines validation across behavior, documentation, and code quality from work-unit contract inputs.
- Keeps `contract`, its dimension references, `orient`, and the principles corpus as the consulted single homes instead of re-encoding the lifecycle in `take`.
- Adds a coherence suite for the new documentation-deliverable gates and adjusts the lifecycle single-home test to allow `take` as the migrated consumer.

## Validation

- `python -m unittest tests.test_take_multidimensional_contract tests.test_contract_skill_lifecycle tests.test_protocol_artifact_delivery_docs`
- `python -m unittest discover -s tests`
- `python -m tooling.conformance`

Refs #451