### PR TITLE
task(verify): report documentation behavior gate coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **verify reports documentation-deliverable behavior as gate coverage**
+  (#456). The `verify` protocol now performs behavior coverage in the form
+  the `contract` skill names for the deliverable: scenario coverage for
+  runtime-behavior work-units, and structural/coherence/conformance gate
+  coverage for documentation-deliverable work-units. Runtime delivery of
+  gate-keyed `completion-evidence` remains deferred to #454.
 - **work-unit-craft invokes reckon in its primary workflow** (#447). The
   `work-unit-craft` skill now points authors to `reckon` as the cognitive
   process for establishing a record's verified constraints before shaping the

--- a/protocols/verify/PROTOCOL.md
+++ b/protocols/verify/PROTOCOL.md
@@ -30,31 +30,44 @@ claim-by-claim requirements, and the rationalization table:
 
 This protocol owns the aggregate gate — the moment before "done." Per-test
 cycle evidence (each test watched failing, then passing) belongs to
-`implement`. Completion here means: the contract's scenarios pass, the
-work-unit's criteria are covered, and the documentation still tells the
-truth.
+`implement`. Completion here means: the contract's behavior coverage is
+performed in the form the deliverable requires, the work-unit's criteria
+are covered, and the documentation still tells the truth. For a
+runtime-behavior work-unit, coverage is scenario coverage; for a
+documentation-deliverable work-unit, coverage is gate coverage.
 
 ## Steps
 
 1. **Identify the gate.** From the behavior contract and the work-unit's
    acceptance criteria, name what proves completion: the full verification
-   command (test suite, build, linter as applicable) and the
-   criterion-coverage that must hold.
+   command (test suite, build, linter as applicable) and the behavior
+   coverage that must hold. Consult the `contract` skill's behavior
+   lifecycle in `skills/contract/SKILL.md` to select the form:
+   scenario coverage for a runtime-behavior work-unit, gate coverage for a
+   documentation-deliverable work-unit. The gate form is consulted from the
+   contract; this protocol does not re-model the lifecycle.
 
 2. **Run fresh.** Execute the full command. Read the entire output; check
    the exit code; count the failures. Output from any earlier run is stale
    the moment code changed.
 
-3. **Assess coverage.** Join criteria × scenarios × results: for every
-   acceptance criterion, which scenarios cover it and do their tests pass?
-   If verification surfaces a failure, stop and invoke `debug` — root cause
-   before fixes. A fix to this work-unit's own increment applies
-   `implement`'s cycle discipline (failing test first, minimal change),
-   then the gate re-runs fresh from step 2. Record honestly whatever the
-   evidence shows — covered, partial, or uncovered.
+3. **Assess coverage.** Report behavior coverage in the form selected in
+   step 1. For a runtime-behavior work-unit, join criteria × scenarios ×
+   results: for every acceptance criterion, which scenarios cover it and do
+   their tests pass? For a documentation-deliverable work-unit, join
+   acceptance criteria × documentation-deliverable gates × results:
+   structural, coherence, and conformance gates each report pass or failure
+   and name which acceptance criteria they cover. This is gate coverage,
+   not fabricated scenario coverage. If verification surfaces a failure,
+   stop and invoke `debug` — root cause before fixes. A fix to this
+   work-unit's own increment applies `implement`'s cycle discipline
+   (failing test first, minimal change), then the gate re-runs fresh from
+   step 2. Record honestly whatever the evidence shows — covered, partial,
+   or uncovered.
 
 4. **Review the declared contracts.** Audit the change against each
-   non-behavioral dimension the contract declared. For **documentation**:
+   dimension the contract declared beyond the behavior coverage assessment.
+   For **documentation**:
    confirm each declared pillar's outcome is met, and keep existing docs
    honest against drift — classify each mapped document as accurate,
    drifted, missing, or obsolete; update what the change touched in the same
@@ -64,8 +77,11 @@ truth.
    recording the locus where it holds or the finding where it fails. Method:
    [references/code-quality-review.md](references/code-quality-review.md).
 
-5. **Deliver `completion-evidence`.** Invoke the `completion-evidence` MCP
-   tool. The object below is MCP tool input, not artifact body.
+5. **Deliver `completion-evidence`.**
+   A runtime-behavior work-unit invokes the scenario-keyed
+   `completion-evidence` MCP tool. The
+   `completion-evidence` MCP tool is the runtime delivery path for scenario
+   coverage today. The object below is MCP tool input, not artifact body.
    `instance_id` is a tool parameter that names the artifact instance; it is
    extracted before validating artifact content, becomes the workspace
    filename, and must not appear in the artifact body. Runa injects
@@ -93,6 +109,14 @@ truth.
    completion-evidence schema, persists the artifact, and records it in the
    artifact store.
 
+   For a documentation-deliverable work-unit, report gate coverage as
+   committed evidence. The structural, coherence, and conformance gate
+   results name the covered criteria and any failures. Runa-backed runtime
+   sequencing of gate-keyed completion evidence is deferred to #454; name
+   that boundary honestly rather than routing this path through the
+   scenario-keyed tool or implying the documentation-only runtime path
+   advances end to end today.
+
 The evidence is honest, not aspirational: gaps and failures are recorded as
 gaps and failures. Review consumes this evidence and blocks on it — an
 uncovered criterion shipped to review is a blocking finding, not a secret.
@@ -110,13 +134,22 @@ uncovered criterion shipped to review is a blocking finding, not a secret.
   confirm it. Evidence determines the claim, never the reverse.
 - `drift-tolerance`: documentation known stale but recorded as accurate, or
   deferred without a tracking work-unit.
+- `gate-as-scenario`: encoding a documentation-deliverable gate as a
+  scenario so the scenario-keyed evidence tool accepts it. Gate coverage is
+  the behavior form for that deliverable, not a scenario disguise.
+- `lifecycle-modeling`: re-encoding the behavior lifecycle in `verify`
+  instead of consulting the `contract` skill as the single home.
+- `false-runtime-advance`: implying a documentation-deliverable unit can
+  deliver gate-keyed runtime `completion-evidence` before #454 supplies that
+  path.
 
 ## Cross-References
 
 - `implement` (protocol): owns per-cycle evidence; this protocol owns the
   aggregate gate.
-- `contract` (skill): coverage is reported behavior-first — scenarios and
-  criteria, not just command exit codes.
+- `contract` (skill): owns the behavior lifecycle this protocol consults —
+  `verify` reports scenario or gate coverage according to that lifecycle,
+  not just command exit codes.
 - `debug` (skill): fires on any failure surfaced here, before any fix.
 - `submit` (protocol): consumes this evidence — work is packaged for review
   only after the gate has run.

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -19,10 +19,12 @@ INSTRUCTION_FILES = [
 NON_CONTRACT_INSTRUCTION_FILES = [
     path for path in INSTRUCTION_FILES if not path.is_relative_to(ROOT / "skills" / "contract")
 ]
+MIGRATED_LIFECYCLE_CONSUMERS = {
+    ROOT / "protocols" / "take" / "PROTOCOL.md",
+    ROOT / "protocols" / "verify" / "PROTOCOL.md",
+}
 UNMIGRATED_LIFECYCLE_CONSUMERS = [
-    path
-    for path in NON_CONTRACT_INSTRUCTION_FILES
-    if path != ROOT / "protocols" / "take" / "PROTOCOL.md"
+    path for path in NON_CONTRACT_INSTRUCTION_FILES if path not in MIGRATED_LIFECYCLE_CONSUMERS
 ]
 
 

--- a/tests/test_verify_protocol_gate_coverage.py
+++ b/tests/test_verify_protocol_gate_coverage.py
@@ -1,0 +1,148 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_PROTOCOL = ROOT / "protocols" / "verify" / "PROTOCOL.md"
+CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def step(body: str, number: int) -> str:
+    pattern = re.compile(
+        rf"^{number}\. \*\*.*?\n(?P<section>.*?)(?=^{number + 1}\. \*\*|^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing step {number}")
+    return match.group("section")
+
+
+def section(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^## {re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing section: {heading}")
+    return match.group("section")
+
+
+def lifecycle_rows(body: str) -> dict[str, str]:
+    rows = {}
+    for line in body.splitlines():
+        match = re.match(
+            r"\| \*\*(?P<dimension>Behavior|Documentation|Code quality)\*\* \| (?P<row>.+) \|$",
+            line,
+        )
+        if match:
+            rows[match.group("dimension")] = match.group("row")
+    return rows
+
+
+class VerifyProtocolGateCoverageTests(unittest.TestCase):
+    def test_primary_coverage_assessment_reports_gate_coverage_for_documentation_deliverables(self) -> None:
+        coverage = normalized(step(read(VERIFY_PROTOCOL), 3)).lower()
+
+        for expected in [
+            "documentation-deliverable work-unit",
+            "gate coverage",
+            "structural",
+            "coherence",
+            "conformance",
+            "acceptance criteria",
+            "results",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, coverage)
+
+    def test_behavior_coverage_is_conditional_by_deliverable_type(self) -> None:
+        body = normalized(step(read(VERIFY_PROTOCOL), 1) + step(read(VERIFY_PROTOCOL), 3)).lower()
+
+        for expected in [
+            "runtime-behavior work-unit",
+            "scenario coverage",
+            "documentation-deliverable work-unit",
+            "gate coverage",
+            "`contract` skill",
+            "behavior lifecycle",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+    def test_documentation_and_code_quality_reviews_remain_present(self) -> None:
+        review = normalized(step(read(VERIFY_PROTOCOL), 4))
+
+        for expected in [
+            "For **documentation**",
+            "declared pillar's outcome",
+            "existing docs honest",
+            "[references/documentation-review.md](references/documentation-review.md)",
+            "For **code quality**",
+            "declared universal",
+            "[references/code-quality-review.md](references/code-quality-review.md)",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, review)
+
+    def test_verify_consults_contract_lifecycle_without_reencoding_it(self) -> None:
+        body = read(VERIFY_PROTOCOL)
+
+        for expected in [
+            "`contract` skill",
+            "behavior lifecycle",
+            "`skills/contract/SKILL.md`",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+        lifecycle_table = re.compile(
+            r"\| \*\*(?:Behavior|Documentation|Code quality)\*\* \| .*?"
+            r"(?:inputs to validation|validation defined|validation performed)",
+            flags=re.IGNORECASE,
+        )
+        self.assertIsNone(lifecycle_table.search(body))
+
+    def test_gate_keyed_completion_evidence_runtime_delivery_names_454_deferral(self) -> None:
+        delivery = normalized(step(read(VERIFY_PROTOCOL), 5))
+
+        for expected in [
+            "runtime-behavior work-unit",
+            "scenario-keyed",
+            "`completion-evidence` MCP tool",
+            "documentation-deliverable work-unit",
+            "gate coverage",
+            "committed evidence",
+            "#454",
+            "deferred",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, delivery)
+
+        self.assertNotRegex(delivery, r"documentation-deliverable work-unit[^.]+scenarios")
+
+    def test_named_gate_form_agrees_with_contract_skill_lifecycle(self) -> None:
+        verify_body = normalized(read(VERIFY_PROTOCOL))
+        behavior_row = lifecycle_rows(read(CONTRACT_SKILL))["Behavior"]
+
+        for expected in [
+            "documentation-deliverable gates",
+            "scenario or gate coverage",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, behavior_row)
+                self.assertIn(expected, verify_body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- update `verify` so behavior coverage is reported in the form selected from the `contract` skill lifecycle
- add documentation-deliverable gate coverage through structural, coherence, and conformance gate results
- keep runtime-behavior work-units on scenario-keyed `completion-evidence` and name the gate-keyed runtime deferral to #454
- add coherence tests guarding the new verify discipline and lifecycle consultation

## Verification

- `python -m unittest tests.test_verify_protocol_gate_coverage tests.test_contract_skill_lifecycle tests.test_take_protocol_contract_dimensions`
- `python -m unittest discover -s tests` (357 tests)
- `python -m tooling.conformance` (36 checks)
- `git diff --check`
