### PR TITLE
Build stations work against the multidimensional contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **plan and implement work against the multidimensional contract** (#458).
+  The build stations now consult the `contract` skill for the behavior
+  lifecycle and declared dimensions: `plan` maps behavior in the deliverable's
+  form (runtime scenarios or documentation-deliverable structural/coherence/
+  conformance gates) while designing against documentation and code-quality
+  validation, and `implement` drives each behavior item check-first in that
+  same form while carrying all three dimensions. Runtime delivery of
+  gate-form `implementation-plan` and `test-evidence` artifacts remains
+  deferred to #454. plan 2.2.0->2.3.0, implement 2.1.0->2.2.0.
 - **verify reports documentation-deliverable behavior as gate coverage**
   (#456). The `verify` protocol now performs behavior coverage in the form
   the `contract` skill names for the deliverable: scenario coverage for

--- a/protocols/implement/PROTOCOL.md
+++ b/protocols/implement/PROTOCOL.md
@@ -1,13 +1,13 @@
 ---
 name: implement
 description: >-
-  Execute the behavior contract through test-driven development:
+  Execute the multidimensional contract through test-driven development:
   RED-GREEN-REFACTOR with delete-and-start-over discipline. Fires when
   production code is about to be written — implementing contracted
   behaviors, fixing bugs, or refactoring.
 metadata:
-  version: "2.1.0"
-  updated: "2026-06-17"
+  version: "2.2.0"
+  updated: "2026-06-20"
   origin: "Adapted from obra/superpowers (MIT). See LICENSE-UPSTREAM."
 ---
 
@@ -32,39 +32,52 @@ Every excuse for skipping this has been offered sincerely and every one
 leads to untrusted code:
 [references/anti-rationalization.md](references/anti-rationalization.md).
 
-## Steps — the cycle, per scenario
+## Steps
 
-Take the next behavior scenario from the contract (the plan's
-`behavior_mapping` orders them), then:
+Take the next behavior item from the contract in the deliverable's behavior
+form (the plan orders them). Consult the `contract` skill
+(`skills/contract/SKILL.md`) for the behavior lifecycle: a
+runtime-behavior work-unit is driven by a scenario test for each executable
+scenario, and a documentation-deliverable work-unit is driven by a
+structural, coherence, and conformance gate for each gate-form behavior
+item. Build toward all three declared dimensions — behavior,
+documentation, and code quality — not behavior alone.
 
-1. **RED — write one failing test.** The test name is the scenario's
-   behavior statement. One behavior, real code over mocks
+1. **RED — write one failing check.** The check name is the behavior
+   statement. One behavior, real code over mocks
    ([references/testing-anti-patterns.md](references/testing-anti-patterns.md)),
-   intent visible in the assertion.
+   intent visible in the assertion or gate. For a runtime-behavior work-unit
+   this is a scenario test; for a documentation-deliverable work-unit this
+   is the structural, coherence, or conformance gate the contract names.
 
-2. **Verify RED — watch it fail.** Run the test. It must *fail*, not error,
-   and fail because the behavior is missing — not a typo or import problem.
-   A test that passes immediately proves nothing: fix the test.
+2. **Verify RED — watch the check fail.** Run the check. It must *fail*,
+   not error, and fail because the behavior is missing — not a typo or
+   import problem. A check that passes immediately proves nothing: fix the
+   check.
 
-3. **GREEN — write minimal code to pass.** The simplest code that satisfies
-   the test. No extra parameters, no configuration, no error handling that
-   no test requires. Over-engineering in GREEN is scope creep wearing a
-   productivity mask. Where the minimal code involves a real design choice
-   — a structure, an abstraction, a boundary — reckon it: open the resolved
-   principles corpus at `~/.groundwork/principles/`, select the principles
-   that govern the choice, and reason it from them rather than the nearest
-   pattern (the reckon skill is the move). Dose-proportional — a trivial
-   pass needs no reckon; a real structural choice does.
+3. **GREEN — write minimal code or documentation to pass.** The simplest
+   change that satisfies the check and the relevant documentation or
+   code-quality dimension. No extra parameters, no configuration, no error
+   handling that no check requires. Over-engineering in GREEN is scope creep
+   wearing a productivity mask. Where the minimal change involves a real
+   design choice — a structure, an abstraction, a boundary — reckon it: open
+   the resolved principles corpus at `~/.groundwork/principles/`, select the
+   principles that govern the choice, and reason it from them rather than the
+   nearest pattern (the reckon skill is the move). Dose-proportional — a
+   trivial pass needs no reckon; a real structural choice does.
 
-4. **Verify GREEN — watch it pass.** Run the test: it passes. Run the
-   suite: everything else still passes, output pristine. A failing test
-   means fix the code, not the test.
+4. **Verify GREEN — watch it pass.** Run the check: it passes. Run the
+   suite: everything else still passes, output pristine. A failing check
+   means fix the change, not the check.
 
 5. **REFACTOR — clean up on green.** Remove duplication, improve names,
    extract helpers. Tests stay green throughout; no behavior is added.
+   Documentation outcomes and code-quality projections stay true while the
+   internal form improves.
 
-6. **Repeat** for the next scenario. When every scenario in scope has its
-   cycle evidence, deliver (below).
+6. **Repeat** for the next behavior item. When every behavior item in scope
+   has cycle evidence, and the documentation and code-quality dimensions have
+   been advanced where declared, deliver (below).
 
 Worked good/bad examples for each phase:
 [references/cycle-examples.md](references/cycle-examples.md).
@@ -74,7 +87,8 @@ Worked good/bad examples for each phase:
 1. Root cause unclear? Invoke `debug` first — investigation precedes fixes.
 2. Write the failing test that reproduces the bug, named for the corrected
    behavior. If the bug reveals a behavior the contract missed, add the
-   scenario — the contract stays the source of truth.
+   missing behavior item in the deliverable's behavior form — the contract
+   stays the source of truth.
 3. Run the cycle from step 2 above. The test remains as the regression
    guard.
 
@@ -87,13 +101,14 @@ should be built.
 
 ## Deliver `test-evidence`
 
-The capstone is delivery of the `test-evidence` artifact. Invoke the
-`test-evidence` MCP tool. The object below is MCP tool input, not artifact
-body. `instance_id` is a tool parameter that names the artifact instance; it
-is extracted before validating artifact content, becomes the workspace
-filename, and must not appear in the artifact body. Runa injects `work_unit`
-from session context; the agent does not supply `work_unit`. Do not write
-the workspace JSON file directly:
+For a runtime-behavior work-unit, the capstone is delivery of the
+scenario-keyed `test-evidence` artifact. Invoke the `test-evidence` MCP
+tool. The object below is MCP tool input, not artifact body. `instance_id`
+is a tool parameter that names the artifact instance; it is extracted before
+validating artifact content, becomes the workspace filename, and must not
+appear in the artifact body. Runa injects `work_unit` from session context;
+the agent does not supply `work_unit`. Do not write the workspace JSON file
+directly:
 
 ```
 test-evidence({
@@ -110,8 +125,14 @@ test-evidence({
 Runa validates the remaining artifact body fields against the test-evidence
 schema, persists the artifact, and records it in the artifact store.
 
-This protocol owns per-cycle evidence — each test watched failing, then
-passing. The aggregate completion gate belongs to `verify`.
+For a documentation-deliverable work-unit, report the gate-form cycle as
+committed evidence and state that the runa-backed runtime sequencing of
+gate-form build artifacts is deferred to #454. Do not route a gate-only unit
+through the scenario-keyed `test-evidence` tool or encode gates as
+scenarios.
+
+This protocol owns per-cycle evidence — each behavior item watched failing,
+then passing. The aggregate completion gate belongs to `verify`.
 
 ## When Stuck
 
@@ -132,17 +153,20 @@ Hard to test means hard to use. Listen to the test.
   whether the test catches what it claims.
 - `scope-creep-in-green`: the GREEN implementation does more than the test
   asks.
-- `contract-bypass`: writing tests from implementation convenience ("test
-  this function") instead of from named scenarios.
+- `contract-bypass`: writing checks from implementation convenience ("test
+  this function") instead of from the deliverable's behavior form.
 - `rationalization`: any entry from the
   [anti-rationalization table](references/anti-rationalization.md) accepted
   as valid "just this once."
 
 ## Cross-References
 
-- `contract` (skill): each RED test corresponds to a named scenario; the
-  carrying discipline lives there.
-- `plan` (protocol): supplies the decision-complete design and scenario
+- `contract` (skill): owns the behavior lifecycle, including executable
+  scenarios for runtime behavior and structural, coherence, and conformance
+  gate validation for documentation-deliverable behavior, plus the
+  documentation and code-quality dimensions this protocol carries through the
+  build.
+- `plan` (protocol): supplies the decision-complete design and behavior-item
   ordering this protocol executes.
 - `debug` (skill): owns root-cause investigation; hand off when a failure's
   cause is unclear, receive back a established root cause.

--- a/protocols/plan/PROTOCOL.md
+++ b/protocols/plan/PROTOCOL.md
@@ -6,8 +6,8 @@ description: >-
   before implement. If you are about to start coding with unresolved design
   choices, plan first.
 metadata:
-  version: "2.2.0"
-  updated: "2026-06-17"
+  version: "2.3.0"
+  updated: "2026-06-20"
   origin: "Adapted from OpenAI Codex CLI (Apache-2.0). See LICENSE-UPSTREAM."
 ---
 
@@ -18,9 +18,18 @@ before modifying code. Decision-complete means the implementer makes no
 design choices: approach, interfaces, data flow, edge cases, and test
 strategy are all resolved or recorded as explicit assumptions.
 
-The plan serves the behavior contract: it decides how each scenario will be
-made true. A plan that cannot map its steps to named scenarios is designing
-something other than the contracted work.
+The plan serves the multidimensional contract. It consults the `contract`
+skill (`skills/contract/SKILL.md`) for the behavior lifecycle and the
+dimensions the build must serve: the behavior dimension, the documentation
+dimension, and the code-quality dimension.
+
+For behavior, the plan maps validation defined to implementation steps in
+the deliverable's behavior form: executable scenarios for a
+runtime-behavior work-unit, and structural, coherence, and conformance gates
+for a documentation-deliverable work-unit. The `contract` skill names those
+gate-form checks as documentation-deliverable gates. For documentation and
+code quality, the plan records how the design will satisfy the declared
+documentation outcomes and reviewer-checkable code-quality projections.
 
 ## Constraints
 
@@ -35,38 +44,50 @@ something other than the contracted work.
 
 ## Steps
 
-1. **Ground in the environment.** Read the contract and work-unit; search
-   the entrypoints, configs, schemas, and existing implementations of
-   similar behavior; trace the code paths the change will touch; note the
-   patterns and utilities to reuse — and what remains unknown.
+1. **Ground in the environment.** Read the contract and work-unit; consult
+   the `contract` skill's behavior lifecycle to identify the deliverable's
+   behavior form; read the declared documentation and code-quality
+   dimensions; search the entrypoints, configs, schemas, and existing
+   implementations of similar behavior; trace the code paths the change
+   will touch; note the patterns and utilities to reuse — and what remains
+   unknown.
 
-2. **Resolve intent.** State the goal and success criteria from the contract
-   scenarios. Fix in-scope and out-of-scope boundaries. Surface codebase
-   constraints: dependencies, API contracts, performance budgets, tests that
-   must keep passing. For each remaining ambiguity: a discoverable fact is
-   explored further; a genuine preference or tradeoff is decided on codebase
-   evidence and recorded as an explicit assumption.
+2. **Resolve intent.** State the goal and success criteria from the
+   contract's declared dimensions. For the behavior dimension, name the
+   behavior items in the deliverable's behavior form — scenario or gate —
+   without converting documentation-deliverable gates into scenarios. Fix
+   in-scope and out-of-scope boundaries. Surface codebase constraints:
+   dependencies, API contracts, performance budgets, tests that must keep
+   passing, documentation outcomes, and code-quality projections. For each
+   remaining ambiguity: a discoverable fact is explored further; a genuine
+   preference or tradeoff is decided on codebase evidence and recorded as an
+   explicit assumption.
 
 3. **Converge the design.** First reckon the design: converging a
    decision-complete design is a generative act — open the resolved
    principles corpus at `~/.groundwork/principles/`, select the principles
    that govern this design, read them, and reason the approach from them
-   rather than the nearest pattern or an adjacent example (the reckon skill
-   is the move). Then choose the approach (compare tradeoffs against
-   the constraints when several are valid). Specify interfaces, signatures,
-   and data flow. Decide handling for each edge case and failure mode.
-   Define the test strategy: which scenarios become which tests, what must
-   keep passing, what commands verify. Then check: does any design choice
+   rather than the nearest pattern or adjacent example. This is the point
+   where the reckon skill is the move. Then choose the approach (compare
+   tradeoffs against the constraints when several are valid). Specify
+   interfaces, signatures, and data flow. Decide handling for each edge case
+   and failure mode.
+   Define the test strategy: which behavior items become which checks, what
+   must keep passing, what commands verify, and how documentation and
+   code-quality validation are carried. Then check: does any design choice
    remain for the implementer? Resolve it or record the assumption.
 
 4. **Record the plan.** Title; a 1–3 sentence summary; key changes grouped
    by behavior or subsystem (paths only where ambiguity is dangerous); the
-   scenario-to-steps mapping; the test plan; every assumption with its
-   rationale. Compress — expand only where ambiguity would cause
-   implementation mistakes.
+   behavior-item-to-steps mapping in the deliverable's behavior form; the
+   test plan; the documentation and code-quality dimension coverage; every
+   assumption with its rationale. Compress — expand only where ambiguity
+   would cause implementation mistakes.
 
-5. **Deliver the `implementation-plan`.** Invoke the `implementation-plan`
-   MCP tool. The object below is MCP tool input, not artifact body.
+5. **Deliver the `implementation-plan`.**
+   For a runtime-behavior work-unit, invoke the scenario-keyed
+   `implementation-plan` MCP tool. The object below is MCP tool input, not
+   artifact body.
    `instance_id` is a tool parameter that names the artifact instance; it is
    extracted before validating artifact content, becomes the workspace
    filename, and must not appear in the artifact body. Runa injects
@@ -87,6 +108,12 @@ something other than the contracted work.
    implementation-plan schema, persists the artifact, and records it in the
    artifact store.
 
+   For a documentation-deliverable work-unit, report the gate-form behavior
+   mapping as committed evidence and state that the runa-backed runtime
+   sequencing of gate-form build artifacts is deferred to #454. Do not route
+   a gate-only unit through the scenario-keyed `implementation-plan` tool or
+   encode gates as scenarios.
+
 ## Scale
 
 Depth scales with the change. When the approach is obvious and the change is
@@ -105,18 +132,25 @@ long. Multi-subsystem or interface-changing work earns the full convergence.
   targeted exploration is usually sufficient; decide and move.
 - `file-inventory-plan`: listing files to touch instead of behavioral
   changes. Files are detail; behavior is the contract.
-- `contract-detachment`: plan steps that map to no scenario — designing
-  beside the contract instead of from it.
+- `contract-detachment`: plan steps that map to no behavior item in the
+  deliverable's behavior form — scenario or gate — designing beside the
+  contract instead of from it.
 
 ## Cross-References
 
+- `contract` (skill): owns the behavior lifecycle, including executable
+  scenarios for runtime behavior and structural, coherence, and conformance
+  gate validation for documentation-deliverable behavior, plus the
+  documentation and code-quality dimensions this plan serves.
 - `reckon` (skill): first-principles constraint framing. A decision-complete
   design is a generative act, so reckon fires before the plan converges —
   grounding the design in the navigational principles, not pattern-matching
   the existing system or an adjacent example. Per reckon's own trigger
   (every generative act, not a sequence position); dose proportional to the
   change, the discipline constant.
-- `take` (protocol): produced the behavior contract this plan serves.
-- `implement` (protocol): executes this plan through RED-GREEN-REFACTOR.
+- `take` (protocol): produced validation defined in the contract dimensions
+  this plan serves.
+- `implement` (protocol): executes this plan through RED-GREEN-REFACTOR over
+  each behavior item in the deliverable's behavior form.
 - `research` (skill): external evidence when design decisions depend on
   facts outside the codebase.

--- a/tests/test_build_protocol_contract_dimensions.py
+++ b/tests/test_build_protocol_contract_dimensions.py
@@ -1,0 +1,178 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN_PROTOCOL = ROOT / "protocols" / "plan" / "PROTOCOL.md"
+IMPLEMENT_PROTOCOL = ROOT / "protocols" / "implement" / "PROTOCOL.md"
+CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def step(body: str, number: int) -> str:
+    pattern = re.compile(
+        rf"^{number}\. \*\*.*?\n(?P<section>.*?)(?=^{number + 1}\. \*\*|^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing step {number}")
+    return match.group("section")
+
+
+def section(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^## {re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing section: {heading}")
+    return match.group("section")
+
+
+def lifecycle_rows(body: str) -> dict[str, str]:
+    rows = {}
+    for line in body.splitlines():
+        match = re.match(
+            r"\| \*\*(?P<dimension>Behavior|Documentation|Code quality)\*\* \| (?P<row>.+) \|$",
+            line,
+        )
+        if match:
+            rows[match.group("dimension")] = match.group("row")
+    return rows
+
+
+class BuildProtocolContractDimensionTests(unittest.TestCase):
+    def test_plan_maps_behavior_in_deliverable_form_and_serves_all_dimensions(self) -> None:
+        body = normalized(read(PLAN_PROTOCOL))
+
+        for expected in [
+            "multidimensional contract",
+            "behavior dimension",
+            "documentation dimension",
+            "code-quality dimension",
+            "runtime-behavior work-unit",
+            "executable scenarios",
+            "documentation-deliverable work-unit",
+            "structural, coherence, and conformance gates",
+            "`contract` skill",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+    def test_implement_drives_behavior_items_check_first_in_deliverable_form(self) -> None:
+        cycle = normalized(section(read(IMPLEMENT_PROTOCOL), "Steps"))
+
+        for expected in [
+            "behavior item",
+            "runtime-behavior work-unit",
+            "scenario test",
+            "documentation-deliverable work-unit",
+            "structural, coherence, and conformance gate",
+            "watch the check fail",
+            "all three declared dimensions",
+            "`contract` skill",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, cycle)
+
+    def test_build_protocols_consult_contract_lifecycle_without_reencoding_it(self) -> None:
+        lifecycle_table = re.compile(
+            r"\| \*\*(?:Behavior|Documentation|Code quality)\*\* \| .*?"
+            r"(?:inputs to validation|validation defined|validation performed)",
+            flags=re.IGNORECASE,
+        )
+
+        for path in [PLAN_PROTOCOL, IMPLEMENT_PROTOCOL]:
+            body = read(path)
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertIn("`contract` skill", body)
+                self.assertIn("`skills/contract/SKILL.md`", body)
+                self.assertIn("behavior lifecycle", body)
+                self.assertIsNone(lifecycle_table.search(body))
+
+    def test_named_behavior_forms_agree_with_contract_skill_lifecycle(self) -> None:
+        behavior_row = lifecycle_rows(read(CONTRACT_SKILL))["Behavior"]
+        combined = normalized(read(PLAN_PROTOCOL) + "\n" + read(IMPLEMENT_PROTOCOL))
+
+        for expected in [
+            "executable scenarios",
+            "documentation-deliverable gates",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, behavior_row)
+                self.assertIn(expected, combined)
+
+    def test_gate_form_runtime_artifact_delivery_names_454_deferral(self) -> None:
+        plan_delivery = normalized(step(read(PLAN_PROTOCOL), 5))
+        implement_delivery = normalized(section(read(IMPLEMENT_PROTOCOL), "Deliver `test-evidence`"))
+
+        for delivery, artifact in [
+            (plan_delivery, "`implementation-plan` MCP tool"),
+            (implement_delivery, "`test-evidence` MCP tool"),
+        ]:
+            with self.subTest(artifact=artifact):
+                for expected in [
+                    "runtime-behavior work-unit",
+                    "scenario-keyed",
+                    artifact,
+                    "documentation-deliverable work-unit",
+                    "gate-form",
+                    "committed evidence",
+                    "#454",
+                    "deferred",
+                ]:
+                    self.assertIn(expected, delivery)
+                self.assertNotRegex(delivery, r"documentation-deliverable work-unit[^.]+scenario")
+
+    def test_scenario_only_corruption_modes_and_cross_references_are_generalized(self) -> None:
+        plan_body = read(PLAN_PROTOCOL)
+        implement_body = read(IMPLEMENT_PROTOCOL)
+        corruption_modes = normalized(
+            section(plan_body, "Corruption Modes") + "\n" + section(implement_body, "Corruption Modes")
+        )
+        cross_references = normalized(
+            section(plan_body, "Cross-References") + "\n" + section(implement_body, "Cross-References")
+        )
+
+        for expected in [
+            "behavior item",
+            "deliverable's behavior form",
+            "scenario or gate",
+            "structural, coherence, and conformance gate",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, corruption_modes + " " + cross_references)
+
+        scenario_only_phrases = [
+            r"map to no scenario",
+            r"from named scenarios",
+            r"each RED test corresponds to a named scenario",
+            r"scenario ordering this protocol executes",
+        ]
+        for phrase in scenario_only_phrases:
+            with self.subTest(phrase=phrase):
+                self.assertNotRegex(corruption_modes + " " + cross_references, phrase)
+
+    def test_reckon_invocation_iron_law_and_versions_survive(self) -> None:
+        plan_body = read(PLAN_PROTOCOL)
+        implement_body = read(IMPLEMENT_PROTOCOL)
+
+        self.assertIn("version: \"2.3.0\"", plan_body)
+        self.assertIn("version: \"2.2.0\"", implement_body)
+        self.assertIn("the reckon skill is the move", plan_body)
+        self.assertIn("the reckon skill is the move", implement_body)
+        self.assertIn("NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST", implement_body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -20,6 +20,8 @@ NON_CONTRACT_INSTRUCTION_FILES = [
     path for path in INSTRUCTION_FILES if not path.is_relative_to(ROOT / "skills" / "contract")
 ]
 MIGRATED_LIFECYCLE_CONSUMERS = {
+    ROOT / "protocols" / "plan" / "PROTOCOL.md",
+    ROOT / "protocols" / "implement" / "PROTOCOL.md",
     ROOT / "protocols" / "take" / "PROTOCOL.md",
     ROOT / "protocols" / "verify" / "PROTOCOL.md",
 }


### PR DESCRIPTION
## Summary

- migrate `plan` to map behavior in the deliverable form while serving behavior, documentation, and code-quality dimensions
- migrate `implement` to drive each behavior item check-first in scenario or documentation-gate form
- add coherence gates and update the changelog for #458

## Verification

- `python -m unittest tests.test_build_protocol_contract_dimensions tests.test_contract_skill_lifecycle`
- `python -m unittest discover -s tests`
- `python -m tooling.conformance`
- `git diff --check`
