### PR TITLE
task(close): carry multidimensional contract through closure

### DIFF
--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -5,8 +5,8 @@ description: >-
   out the work unit, and deliver the completion-record. The closing bookend
   of the scoped pipeline.
 metadata:
-  version: "3.0.0"
-  updated: "2026-06-11"
+  version: "3.1.0"
+  updated: "2026-06-20"
 ---
 
 # Land
@@ -15,6 +15,12 @@ Land is the approved-disposition gate and the pipeline's closing bookend:
 take established what done means; land records that it was done. It
 activates only from `change-approved`, applies exactly the proposal version
 that approval names, reflects the disposition, and records completion.
+
+Land closes the multidimensional contract. It consults the `contract` skill
+(`skills/contract/SKILL.md`) for the lifecycle and records validation
+performed for the behavior dimension in the deliverable's behavior form, the
+documentation dimension's audience-outcome review, and the code-quality
+dimension's projected-universal findings.
 
 The protocol is not a forge operation. It must not activate from a raw
 `change-proposal` — an unreviewed proposal is not a release gate — and
@@ -39,11 +45,22 @@ The protocol is not a forge operation. It must not activate from a raw
    collaboration surface records that the approval was acted on.
 
 4. **Close out.** Resolve and run `close-out`: the work unit's tracker
-   record carries its completion context — criteria met, gaps named, the
-   merge reference.
+   record carries its completion context — behavior coverage in scenario or
+   gate form, documentation outcomes, code-quality findings, gaps named,
+   and the merge reference.
 
-5. **Deliver the `completion-record`.** Invoke the `completion-record` MCP
-   tool. The object below is MCP tool input, not artifact body.
+5. **Deliver the `completion-record`.**
+   For a runtime-behavior work-unit, follow the scenario-keyed runtime close
+   path and invoke the `completion-record` MCP tool. The behavior dimension
+   is recorded in `criterion_summary`; the documentation dimension is
+   recorded in `documentation_status`; the code-quality dimension is
+   recorded as committed evidence in the close-out context, using the diff
+   loci and findings from the projected-universals audit. A typed
+   code-quality `completion-record` field is the schema expansion deferred
+   to #454; do not assert a field the completion-record schema does not
+   define.
+
+   The object below is MCP tool input, not artifact body.
    `instance_id` is a tool parameter that names the artifact instance; it is
    extracted before validating artifact content, becomes the workspace
    filename, and must not appear in the artifact body. Runa injects
@@ -63,8 +80,18 @@ The protocol is not a forge operation. It must not activate from a raw
    Runa validates the remaining artifact body fields against the
    completion-record schema, persists the artifact, and records it in the
    artifact store. The record distills the contract's closure: the
-   criterion summary and documentation status derive from the behavior
-   contract and completion evidence in context.
+   criterion summary and documentation status derive from the performed
+   validation in context, while code-quality validation remains committed
+   close-out evidence until the typed field exists.
+
+   For a documentation-deliverable work-unit, record the gate-form behavior
+   coverage as committed evidence. Structural, coherence, and conformance
+   gate coverage satisfies the behavior dimension in the deliverable's
+   behavior form, and the record still carries documentation and
+   code-quality validation-performed. Runa-backed runtime sequencing of
+   gate-form close artifacts — and any `completion-record` schema change it
+   would require — is deferred to #454; name that boundary honestly rather
+   than implying the gate-form runtime path closes end to end today.
 
 ## Failure Policy
 
@@ -84,6 +111,9 @@ The protocol is not a forge operation. It must not activate from a raw
   version review approved.
 - `forge-leakage`: embedding forge-specific apply or close-out procedure in
   the protocol rather than in mechanics.
+- `dimension-drop`: recording behavior-only completion while omitting a
+  declared dimension. Dropping documentation or code-quality evidence from
+  close-out breaks the contract even when `criterion_summary` is complete.
 
 ## Cross-References
 
@@ -91,5 +121,11 @@ The protocol is not a forge operation. It must not activate from a raw
 - `schemas/change-approved.schema.json` defines the approval disposition.
 - `schemas/change-proposal.schema.json` defines the proposal detail land
   resolves and applies.
+- `schemas/completion-record.schema.json` defines the existing record fields:
+  behavior closes through `criterion_summary`, documentation through
+  `documentation_status`, and typed code-quality record expansion is
+  deferred to #454.
+- `contract` (skill): owns the lifecycle and behavior forms this protocol
+  consults while recording validation-performed.
 - `take` (protocol): the opening bookend — the contract established there
   is what this record closes.

--- a/protocols/review/PROTOCOL.md
+++ b/protocols/review/PROTOCOL.md
@@ -1,25 +1,29 @@
 ---
 name: review
 description: >-
-  Review a submitted change proposal against the behavior contract and
-  evidence, and produce exactly one disposition outcome. Routes approval
+  Review a submitted change proposal against the multidimensional contract
+  and evidence, and produce exactly one disposition outcome. Routes approval
   through `change-approved` and blocking findings through
   `change-needs-revision`.
 metadata:
-  version: "2.0.0"
-  updated: "2026-06-11"
+  version: "2.1.0"
+  updated: "2026-06-20"
 ---
 
 # Review
 
 Review is the judgment gate between a submitted change proposal and
 landing. It is where the pipeline's one act of independent judgment about
-the change happens: the proposal is examined against the behavior contract,
-the work-unit, and the evidence — then the decision is recorded as exactly
-one typed outcome artifact.
+the change happens: the proposal is examined against the multidimensional
+contract, the work-unit, and the evidence — then the decision is recorded as
+exactly one typed outcome artifact.
 
 The protocol is not a forge operation. The `code-review` skill supplies the
 evaluation discipline; this protocol supplies the routing obligation.
+It consults the `contract` skill (`skills/contract/SKILL.md`) for the
+lifecycle, the behavior dimension's deliverable's behavior form, the
+documentation dimension's audience-outcome review, and the code-quality
+dimension's projected-universal findings.
 
 ## Steps
 
@@ -29,10 +33,19 @@ evaluation discipline; this protocol supplies the routing obligation.
 
 2. **Inspect against the contract.** Evaluate the proposed change with the
    `code-review` skill's discipline: scope honesty against the work-unit,
-   correctness, semantic-shift detection, evidence quality against the
-   behavior contract and completion evidence, documentation impact. The
-   contract is the measure — a change is judged by whether the contracted
-   behaviors are delivered and proven, not by whether commands passed.
+   correctness, semantic-shift detection, and evidence quality against the
+   multidimensional contract and completion evidence. The contract is the
+   measure — a change is judged by whether every declared dimension's
+   performed validation is delivered and proven, not by whether commands
+   passed. For the behavior dimension, review the performed validation in
+   the deliverable's behavior form: executable scenarios for a
+   runtime-behavior work-unit and documentation-deliverable gates for a
+   documentation-deliverable work-unit. In either case, review scenario or
+   gate coverage as the behavior dimension's performed validation. For the
+   documentation dimension, review the audience-outcome review. For the
+   code-quality dimension, review the code-quality findings and diff loci
+   from the projected-universals audit. Consult the `contract` skill for the
+   lifecycle and forms; this protocol judges them, it does not restate them.
 
 3. **Classify findings.** Each observation is `blocking` or `non-blocking`
    at the point of review. Blocking findings prevent approval. Non-blocking
@@ -49,6 +62,16 @@ evaluation discipline; this protocol supplies the routing obligation.
    triage step between review and land. Downstream protocols route on the
    produced artifact type; a review run that emits zero or two dispositions
    is invalid.
+
+   For a runtime-behavior work-unit, the disposition remains in the
+   scenario-keyed runtime close path. For a documentation-deliverable
+   work-unit, judge the gate-form packaging as committed evidence. The
+   structural, coherence, and conformance coverage is reviewable behavior
+   evidence, alongside documentation and code-quality validation-performed.
+   Runa-backed runtime sequencing of gate-form close artifacts — and any
+   review artifact schema change it would require — is deferred to #454;
+   name that boundary honestly rather than implying the gate-form runtime
+   path closes end to end today.
 
 ## The Independence of the Gate
 
@@ -71,7 +94,9 @@ reviewer is independent of the author is the invariant.
   asking later steps to infer approval from fields instead of routing by
   outcome type.
 - `rubber-stamp-review`: approving because commands passed without checking
-  whether the evidence proves the contracted behavior.
+  whether the evidence proves every declared dimension. A behavior-only
+  approval that ignores documentation or code-quality validation is a rubber
+  stamp even when the behavior evidence passes.
 - `semantic-shift-dismissal`: treating meaning changes as harmless cleanup
   without reviewing their effect on contracts, schemas, or routing.
 - `forge-mechanic-leakage`: embedding forge-specific commands or
@@ -82,6 +107,8 @@ reviewer is independent of the author is the invariant.
 - `workflow-contracts/review.toml` defines the C-2 review flow and its two
   disposition terminals.
 - `skills/code-review/SKILL.md` defines the evaluation discipline.
+- `contract` (skill): owns the lifecycle, dimensions, and behavior forms
+  this protocol consults while judging validation-performed.
 - `schemas/change-approved.schema.json` and
   `schemas/change-needs-revision.schema.json` define the typed disposition
   artifacts.

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -5,8 +5,8 @@ description: >-
   completion evidence exists, and re-fires from change-needs-revision;
   preserves immutable proposal version history.
 metadata:
-  version: "3.0.0"
-  updated: "2026-06-11"
+  version: "3.1.0"
+  updated: "2026-06-20"
 ---
 
 # Submit
@@ -15,6 +15,12 @@ Submit is the gate between verified work and review. It produces the
 forge-neutral `change-proposal` artifact that review consumes — whether this
 is the first proposal version or a revised version answering review
 findings.
+
+Submit packages the multidimensional contract for review. It consults the
+`contract` skill (`skills/contract/SKILL.md`) for the lifecycle and carries
+the performed validation from `verify`: the behavior dimension in the
+deliverable's behavior form, the documentation dimension's audience-outcome
+review, and the code-quality dimension's projected-universal findings.
 
 The protocol is not a forge operation. It names the methodology obligation:
 collect the verified change, deliver it through the configured mechanics,
@@ -33,14 +39,20 @@ carries the forge-tagged reference downstream.
 
 2. **Address findings (revision rounds only).** Resolve each blocking
    finding with the same discipline the original work used: behavior-level
-   findings get failing tests first (`implement`'s cycle), evidence gaps get
+   findings get failing tests first (`implement`'s cycle), documentation or
+   code-quality findings update the affected dimension and evidence gaps get
    the gate re-run (`verify`), contract gaps update the contract. Commit the
    revision to the proposal branch.
 
 3. **Prepare the proposal.** Fix the branch, commit, and base that carry the
-   change, and write a summary that names the contracted behaviors the
-   change ships. The summary is the proposal's public claim; it derives from
-   the behavior contract and the completion evidence, not from memory.
+   change, and write a summary that names the declared dimensions the change
+   ships. The summary is the proposal's public claim; it derives from the
+   completion evidence, not from memory: behavior coverage in scenario or
+   gate form, documentation outcomes from the audience-outcome review, and
+   code-quality findings from the projected-universals audit. The
+   `contract` skill supplies the lifecycle and the behavior form; this
+   protocol packages the validation-performed, it does not restate the
+   lifecycle.
 
 4. **Deliver through the forge mechanic.** Initial delivery resolves the
    invariant `deliver-change-proposal` operation; revision delivery resolves
@@ -49,7 +61,11 @@ carries the forge-tagged reference downstream.
    runs the active-forge mechanic it returns. The protocol encodes no
    forge-specific delivery language.
 
-5. **Deliver the `change-proposal`.** Invoke the `change-proposal` MCP tool.
+5. **Deliver the `change-proposal`.**
+   For a runtime-behavior work-unit, follow the scenario-keyed runtime close
+   path and invoke the `change-proposal` MCP tool. The proposal summary
+   carries the multidimensional claim: executable scenarios or scenario
+   coverage for behavior, documentation outcomes, and code-quality findings.
    The object below is MCP tool input, not artifact body. `instance_id` is a
    tool parameter that names the artifact instance; it is extracted before
    validating artifact content, becomes the workspace filename, and must not
@@ -76,6 +92,16 @@ carries the forge-tagged reference downstream.
    change-proposal schema, persists the artifact, and records it in the
    artifact store.
 
+   For a documentation-deliverable work-unit, report the gate-form
+   packaging as committed evidence. The structural, coherence, and
+   conformance coverage is the behavior dimension in the deliverable's
+   behavior form, and the proposal still carries documentation and
+   code-quality validation-performed for review. Runa-backed runtime
+   sequencing of gate-form close artifacts — and any `change-proposal`
+   schema change it would require — is deferred to #454; name that boundary
+   honestly rather than routing this path through a runtime shape it cannot
+   satisfy today.
+
 A revision round never mutates an earlier proposal artifact: it creates a
 new valid `change-proposal` whose `version` advances for this work unit.
 Review re-runs through its `on_change` trigger on the new version.
@@ -98,7 +124,9 @@ Review re-runs through its `on_change` trigger on the new version.
 - `forge-leakage`: embedding forge-specific delivery procedure in the
   protocol rather than in mechanics and handles.
 - `summary-drift`: a proposal summary that names work the evidence does not
-  support, or omits behaviors the contract requires.
+  support, or omits a declared dimension the contract requires. A
+  behavior-only summary that drops documentation or code-quality validation
+  is drift even when behavior coverage is green.
 
 ## Cross-References
 
@@ -107,4 +135,7 @@ Review re-runs through its `on_change` trigger on the new version.
 - `schemas/change-proposal.schema.json` defines the proposal artifact.
 - `protocols/review/PROTOCOL.md` consumes the proposal and produces exactly
   one typed review disposition.
-- `verify` (protocol): supplies the completion evidence this gate requires.
+- `contract` (skill): owns the lifecycle and behavior forms this protocol
+  consults while packaging validation-performed.
+- `verify` (protocol): supplies the completion evidence this gate requires
+  across behavior, documentation, and code quality.

--- a/tests/test_close_protocol_contract_dimensions.py
+++ b/tests/test_close_protocol_contract_dimensions.py
@@ -1,0 +1,224 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SUBMIT_PROTOCOL = ROOT / "protocols" / "submit" / "PROTOCOL.md"
+REVIEW_PROTOCOL = ROOT / "protocols" / "review" / "PROTOCOL.md"
+LAND_PROTOCOL = ROOT / "protocols" / "land" / "PROTOCOL.md"
+CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def step(body: str, number: int) -> str:
+    pattern = re.compile(
+        rf"^{number}\. \*\*.*?\n(?P<section>.*?)(?=^{number + 1}\. \*\*|^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing step {number}")
+    return match.group("section")
+
+
+def section(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^## {re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing section: {heading}")
+    return match.group("section")
+
+
+def lifecycle_rows(body: str) -> dict[str, str]:
+    rows = {}
+    for line in body.splitlines():
+        match = re.match(
+            r"\| \*\*(?P<dimension>Behavior|Documentation|Code quality)\*\* \| (?P<row>.+) \|$",
+            line,
+        )
+        if match:
+            rows[match.group("dimension")] = match.group("row")
+    return rows
+
+
+class CloseProtocolContractDimensionTests(unittest.TestCase):
+    def test_submit_packages_every_declared_dimension(self) -> None:
+        body = normalized(read(SUBMIT_PROTOCOL))
+        prepare = normalized(step(read(SUBMIT_PROTOCOL), 3))
+
+        for expected in [
+            "multidimensional contract",
+            "behavior dimension",
+            "documentation dimension",
+            "code-quality dimension",
+            "validation-performed",
+            "`contract` skill",
+            "completion evidence",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+        for expected in [
+            "behavior coverage",
+            "documentation outcomes",
+            "code-quality findings",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, prepare)
+
+    def test_review_judges_every_declared_dimension(self) -> None:
+        inspection = normalized(step(read(REVIEW_PROTOCOL), 2))
+
+        for expected in [
+            "multidimensional contract",
+            "behavior dimension",
+            "documentation dimension",
+            "code-quality dimension",
+            "performed validation",
+            "audience-outcome review",
+            "code-quality findings",
+            "`contract` skill",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, inspection)
+
+    def test_land_records_all_dimensions_without_claiming_new_schema_fields(self) -> None:
+        delivery = normalized(step(read(LAND_PROTOCOL), 5))
+
+        for expected in [
+            "behavior dimension",
+            "criterion_summary",
+            "documentation dimension",
+            "documentation_status",
+            "code-quality dimension",
+            "committed evidence",
+            "typed code-quality",
+            "completion-record",
+            "#454",
+            "deferred",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, delivery)
+
+        self.assertNotRegex(delivery, r"code_quality[\":]")
+
+    def test_close_protocols_carry_behavior_in_the_deliverable_form(self) -> None:
+        for path in [SUBMIT_PROTOCOL, REVIEW_PROTOCOL, LAND_PROTOCOL]:
+            body = normalized(read(path))
+            with self.subTest(path=path.relative_to(ROOT)):
+                for expected in [
+                    "runtime-behavior work-unit",
+                    "documentation-deliverable work-unit",
+                    "deliverable's behavior form",
+                    "scenario or gate",
+                    "gate-form",
+                ]:
+                    self.assertIn(expected, body)
+                self.assertNotRegex(body, r"documentation-deliverable work-unit[^.]+scenarios")
+
+    def test_close_protocols_consult_contract_lifecycle_without_reencoding_it(self) -> None:
+        lifecycle_table = re.compile(
+            r"\| \*\*(?:Behavior|Documentation|Code quality)\*\* \| .*?"
+            r"(?:inputs to validation|validation defined|validation performed)",
+            flags=re.IGNORECASE,
+        )
+
+        for path in [SUBMIT_PROTOCOL, REVIEW_PROTOCOL, LAND_PROTOCOL]:
+            body = read(path)
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertIn("`contract` skill", body)
+                self.assertIn("`skills/contract/SKILL.md`", body)
+                self.assertIn("lifecycle", body)
+                self.assertIsNone(lifecycle_table.search(body))
+
+    def test_named_behavior_forms_agree_with_contract_skill_lifecycle(self) -> None:
+        behavior_row = lifecycle_rows(read(CONTRACT_SKILL))["Behavior"]
+        combined = normalized(
+            read(SUBMIT_PROTOCOL) + "\n" + read(REVIEW_PROTOCOL) + "\n" + read(LAND_PROTOCOL)
+        )
+
+        for expected in [
+            "executable scenarios",
+            "documentation-deliverable gates",
+            "scenario or gate coverage",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, behavior_row)
+                self.assertIn(expected, combined)
+
+    def test_gate_form_runtime_close_artifact_delivery_names_454_deferral(self) -> None:
+        for path, expected_artifact in [
+            (SUBMIT_PROTOCOL, "`change-proposal`"),
+            (LAND_PROTOCOL, "`completion-record`"),
+        ]:
+            delivery = normalized(step(read(path), 5))
+            with self.subTest(path=path.relative_to(ROOT)):
+                for expected in [
+                    "runtime-behavior work-unit",
+                    "scenario-keyed",
+                    expected_artifact,
+                    "documentation-deliverable work-unit",
+                    "gate-form",
+                    "committed evidence",
+                    "#454",
+                    "deferred",
+                ]:
+                    self.assertIn(expected, delivery)
+
+        review_disposition = normalized(step(read(REVIEW_PROTOCOL), 4))
+        for expected in [
+            "runtime-behavior work-unit",
+            "scenario-keyed",
+            "documentation-deliverable work-unit",
+            "gate-form",
+            "committed evidence",
+            "#454",
+            "deferred",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, review_disposition)
+
+    def test_dimension_omission_corruption_modes_and_invariants_survive(self) -> None:
+        corruption_modes = normalized(
+            section(read(SUBMIT_PROTOCOL), "Corruption Modes")
+            + "\n"
+            + section(read(REVIEW_PROTOCOL), "Corruption Modes")
+            + "\n"
+            + section(read(LAND_PROTOCOL), "Corruption Modes")
+        )
+        combined = normalized(read(SUBMIT_PROTOCOL) + "\n" + read(REVIEW_PROTOCOL) + "\n" + read(LAND_PROTOCOL))
+
+        for expected in [
+            "summary-drift",
+            "rubber-stamp-review",
+            "declared dimension",
+            "behavior-only",
+            "documentation or code-quality",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, corruption_modes)
+
+        for expected in [
+            "new valid `change-proposal` whose `version` advances",
+            "exactly one typed outcome artifact",
+            "independence from the author",
+            "change-approved",
+            "whose `version` equals `change-approved.against_version`",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -20,8 +20,11 @@ NON_CONTRACT_INSTRUCTION_FILES = [
     path for path in INSTRUCTION_FILES if not path.is_relative_to(ROOT / "skills" / "contract")
 ]
 MIGRATED_LIFECYCLE_CONSUMERS = {
+    ROOT / "protocols" / "land" / "PROTOCOL.md",
     ROOT / "protocols" / "plan" / "PROTOCOL.md",
     ROOT / "protocols" / "implement" / "PROTOCOL.md",
+    ROOT / "protocols" / "review" / "PROTOCOL.md",
+    ROOT / "protocols" / "submit" / "PROTOCOL.md",
     ROOT / "protocols" / "take" / "PROTOCOL.md",
     ROOT / "protocols" / "verify" / "PROTOCOL.md",
 }


### PR DESCRIPTION
## Summary

- Update `submit`, `review`, and `land` so close stations package, judge, and record every declared contract dimension.
- Carry behavior in the deliverable's form, including gate-form documentation-deliverable units, while keeping schema/runtime expansion deferred to #454.
- Add a close-station coherence suite and mark the close protocols as migrated lifecycle consumers.

## Validation

- RED: `python -m unittest tests.test_close_protocol_contract_dimensions` failed against the previous close protocol text.
- GREEN/final: `python -m unittest discover -s tests` passed, 372 tests.

Closes #461.