### PR TITLE
task(contract/runa): carry gate-form behavior through runtime artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,21 +48,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Gate-form behavior now runs through the runtime artifact spine** (#454).
+  `behavior-contract`, `implementation-plan`, `test-evidence`, and
+  `completion-evidence` now require `behavior_form` and accept either
+  scenario form or documentation-deliverable gate form. Gate form carries
+  structural/coherence/conformance gates through the existing MCP artifact
+  tools without fabricating scenarios, while close artifacts keep their
+  existing schemas and carry gate-form context through summaries and close-out
+  evidence. take 3.3.0->3.4.0, plan 2.3.0->2.4.0,
+  implement 2.2.0->2.3.0, verify 2.0.0->2.1.0,
+  submit 3.1.0->3.2.0, review 2.1.0->2.2.0, land 3.1.0->3.2.0.
 - **plan and implement work against the multidimensional contract** (#458).
   The build stations now consult the `contract` skill for the behavior
   lifecycle and declared dimensions: `plan` maps behavior in the deliverable's
   form (runtime scenarios or documentation-deliverable structural/coherence/
   conformance gates) while designing against documentation and code-quality
   validation, and `implement` drives each behavior item check-first in that
-  same form while carrying all three dimensions. Runtime delivery of
-  gate-form `implementation-plan` and `test-evidence` artifacts remains
-  deferred to #454. plan 2.2.0->2.3.0, implement 2.1.0->2.2.0.
+  same form while carrying all three dimensions. plan 2.2.0->2.3.0,
+  implement 2.1.0->2.2.0.
 - **verify reports documentation-deliverable behavior as gate coverage**
   (#456). The `verify` protocol now performs behavior coverage in the form
   the `contract` skill names for the deliverable: scenario coverage for
   runtime-behavior work-units, and structural/coherence/conformance gate
-  coverage for documentation-deliverable work-units. Runtime delivery of
-  gate-keyed `completion-evidence` remains deferred to #454.
+  coverage for documentation-deliverable work-units.
 - **work-unit-craft invokes reckon in its primary workflow** (#447). The
   `work-unit-craft` skill now points authors to `reckon` as the cognitive
   process for establishing a record's verified constraints before shaping the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `completion-evidence` now require `behavior_form` and accept either
   scenario form or documentation-deliverable gate form. Gate form carries
   structural/coherence/conformance gates through the existing MCP artifact
-  tools without fabricating scenarios, while close artifacts keep their
-  existing schemas and carry gate-form context through summaries and close-out
-  evidence. take 3.3.0->3.4.0, plan 2.3.0->2.4.0,
+  tools without fabricating scenarios. `completion-evidence` enforces the
+  same status-to-evidence conditional for both forms: `covered` and `partial`
+  criteria require at least one scenario or gate result, while `uncovered`
+  criteria may omit evidence. Close artifacts keep their existing schemas and
+  carry gate-form context through summaries and close-out evidence.
+  take 3.3.0->3.4.0, plan 2.3.0->2.4.0,
   implement 2.2.0->2.3.0, verify 2.0.0->2.1.0,
   submit 3.1.0->3.2.0, review 2.1.0->2.2.0, land 3.1.0->3.2.0.
 - **plan and implement work against the multidimensional contract** (#458).

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -576,6 +576,7 @@ agent inside a take session producing a behavior-contract calls:
 ```
 behavior-contract({
   instance_id: "work-unit-221",
+  behavior_form: "scenario",
   title: "User authentication",
   scenarios: [
     { name: "valid login",
@@ -966,23 +967,24 @@ not switch deployment identity because a handle points somewhere else.
 ### Traceability Thread
 
 Acceptance criteria on the work-unit are the high-level "done" statements.
-Behavior-contract scenarios are the precise behavioral refinement of
-those criteria into Given/When/Then. The traceability thread runs the
-full length of the execution chain:
+Behavior-contract entries are the precise behavioral refinement of
+those criteria: scenarios for executable Given/When/Then behavior, or gates
+for documentation-deliverable behavior. The traceability thread runs the full
+length of the execution chain:
 
 ```
 work-unit (acceptance_criteria)
-  → behavior-contract (scenarios trace to acceptance criteria)
-    → test-evidence (results trace to scenarios)
+  → behavior-contract (scenarios or gates trace to acceptance criteria)
+    → test-evidence (results trace to scenarios or gates)
       → completion-evidence (coverage at acceptance-criterion level,
         plus documentation impact)
 ```
 
 Schema implications:
-- behavior-contract scenarios carry a reference to which acceptance
-  criterion they refine
+- behavior-contract scenarios and gates carry a reference to which
+  acceptance criterion they refine
 - completion-evidence reports coverage at the acceptance-criterion
-  level, not just the scenario level — so verify can answer "are all
+  level, not just the scenario or gate level — so verify can answer "are all
   acceptance criteria covered?"
 
 ### Context Injection Is Not Transitive
@@ -998,11 +1000,12 @@ scoped artifact identifies the work-unit but does not carry its content.
 **Producer:** take — the contract-first entry.
 **Consumers:** plan, implement, verify, submit, review (requires); land
 (accepts).
-**What consumers need:** behavioral scenarios that trace to acceptance
-criteria, structured as executable Given/When/Then.
+**What consumers need:** behavior entries that trace to acceptance criteria:
+scenarios for executable Given/When/Then work, or gates for
+documentation-deliverable structural/coherence/conformance checks.
 
-Each scenario carries a `criterion` reference for traceability, and the
-common `work_unit` field threads it to the work-unit.
+Each scenario or gate carries a `criterion` reference for traceability, and
+the common `work_unit` field threads it to the work-unit.
 
 The existing `metadata` block (produced_by, date) is eliminated.
 Runa knows the producing protocol from the manifest. It tracks
@@ -1012,8 +1015,10 @@ already knows. By sufficiency, it has no place in the schema.
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
 | work_unit | string (work-unit ref) | yes | Common envelope — threads to work-unit |
+| behavior_form | enum: scenario, gate | yes | Selects the behavior contract form |
 | title | string | yes | Human-readable title for the contract |
-| scenarios | array of scenario | yes (min 1) | Behavioral scenarios |
+| scenarios | array of scenario | yes for scenario form | Executable Given/When/Then scenarios |
+| gates | array of gate | yes for gate form | Documentation-deliverable gates |
 
 **Scenario fields:**
 
@@ -1024,6 +1029,15 @@ already knows. By sufficiency, it has no place in the schema.
 | given | string | yes | Initial context or state |
 | when | string | yes | Action or event |
 | then | string | yes | Expected outcome |
+
+**Gate fields:**
+
+| Field | Type | Required | Purpose |
+|-------|------|----------|---------|
+| name | string | yes | Human-readable gate name |
+| criterion | string | yes | Which acceptance criterion this refines |
+| category | enum: structural, coherence, conformance | yes | Gate category |
+| check | string | yes | Concrete check that determines whether the gate passes |
 
 ### Metadata Elimination Principle
 
@@ -1037,10 +1051,10 @@ from its own state does not belong in artifact content. This eliminates
 
 **Consumers:** implement (requires); verify, review (accepts).
 **What implement needs:** the design approach — what to change, how, and which
-behavioral scenarios map to which implementation steps. **What verify needs:**
-the affected-files list, to map the change to the documentation it touches.
-**What review needs:** the recorded design decisions, as context for judging
-the proposal.
+behavior entries map to which implementation steps. **What verify needs:** the
+affected-files list, to map the change to the documentation it touches. **What
+review needs:** the recorded design decisions, as context for judging the
+proposal.
 
 The plan bridges behavior (from the contract) to code (in implement). Without
 the plan, the agent implements without design — which is what the plan
@@ -1049,10 +1063,11 @@ exists to prevent.
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
 | work_unit | string (work-unit ref) | yes | Common envelope |
+| behavior_form | enum: scenario, gate | yes | Selects scenario or gate mappings |
 | summary | string | yes | What the plan accomplishes |
 | design_decisions | array of decision | yes (min 1) | Decisions with rationale |
 | affected_files | array of strings | yes (min 1) | Files or modules that get changed |
-| behavior_mapping | array of mapping | yes (min 1) | How scenarios map to implementation steps |
+| behavior_mapping | array of mapping | yes (min 1) | How scenarios or gates map to implementation steps |
 
 **decision:**
 
@@ -1061,27 +1076,36 @@ exists to prevent.
 | decision | string | yes | What was decided |
 | rationale | string | yes | Why — traces to constraints or principles |
 
-**mapping:**
+**Scenario mapping:**
 
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
 | scenario | string | yes | Scenario name from behavior-contract |
 | steps | array of strings | yes (min 1) | Implementation steps for this scenario |
 
+**Gate mapping:**
+
+| Field | Type | Required | Purpose |
+|-------|------|----------|---------|
+| name | string | yes | Gate name from behavior-contract |
+| criterion | string | yes | Acceptance criterion this gate maps to |
+| category | enum: structural, coherence, conformance | yes | Gate category |
+| steps | array of strings | yes (min 1) | Implementation steps for this gate |
+
 ### test-evidence
 
 **Consumer:** verify (requires).
-**What verify needs:** proof that each scenario was tested and the result.
-Verify joins test-evidence with behavior-contract to roll up coverage at
-the acceptance-criterion level — no need to duplicate criterion references
-here.
+**What verify needs:** proof that each scenario or gate was checked and the
+result. Verify joins test-evidence with behavior-contract to roll up coverage
+at the acceptance-criterion level.
 
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
 | work_unit | string (work-unit ref) | yes | Common envelope |
-| evidence | array of evidence-entry | yes (min 1) | Test results per scenario |
+| behavior_form | enum: scenario, gate | yes | Selects scenario or gate evidence |
+| evidence | array of evidence-entry | yes (min 1) | Results per scenario or gate |
 
-**Evidence-entry fields:**
+**Scenario evidence-entry fields:**
 
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
@@ -1090,6 +1114,17 @@ here.
 | command | string | yes | The command that was executed |
 | output_summary | string | yes | Summary of command output — proof the test ran |
 
+**Gate evidence-entry fields:**
+
+| Field | Type | Required | Purpose |
+|-------|------|----------|---------|
+| name | string | yes | Gate name from behavior-contract |
+| criterion | string | yes | Acceptance criterion this gate covers |
+| category | enum: structural, coherence, conformance | yes | Gate category |
+| result | enum: pass, fail | yes | Gate outcome |
+| command | string | yes | The command that was executed |
+| output_summary | string | yes | Summary of command output — proof the check ran |
+
 ### completion-evidence
 
 **Consumers:** submit (requires), review (accepts), land (accepts).
@@ -1097,25 +1132,50 @@ here.
 review needs: the evidence-quality basis for judgment. What land needs:
 coverage context for the final record.
 
-Verify produces this by joining work-unit (acceptance criteria), behavior-
-contract (scenario-to-criterion mapping), and test-evidence (results), and
-by reviewing the documentation impact of the change. The output reports
-coverage at the acceptance-criterion level plus the documentation outcome.
+Verify produces this by joining work-unit (acceptance criteria),
+behavior-contract (scenario- or gate-to-criterion mapping), and test-evidence
+(results), and by reviewing the documentation impact of the change. The output
+reports coverage at the acceptance-criterion level plus the documentation
+outcome.
 
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
 | work_unit | string (work-unit ref) | yes | Common envelope |
+| behavior_form | enum: scenario, gate | yes | Selects scenario or gate coverage |
 | criterion_coverage | array of coverage-entry | yes (min 1) | Per-criterion coverage status |
 | documentation | object | yes | Documentation impact: `updated`, `verified_accurate`, `follow_up_work_units` |
 
-**Coverage-entry fields:**
+**Scenario coverage-entry fields:**
 
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|
 | criterion | string | yes | Acceptance criterion from the work-unit |
 | status | enum: covered, partial, uncovered | yes | Coverage status |
-| scenarios | array of strings | no | Scenario names that cover this criterion |
-| failures | array of strings | no | Scenario names that failed for this criterion |
+| scenarios | array of strings | required for covered/partial; empty or absent for uncovered | Scenario names that cover this criterion |
+| failures | array of strings | empty/absent for covered/uncovered; non-empty for partial | Scenario names that failed for this criterion |
+
+**Gate coverage-entry fields:**
+
+| Field | Type | Required | Purpose |
+|-------|------|----------|---------|
+| criterion | string | yes | Acceptance criterion from the work-unit |
+| status | enum: covered, partial, uncovered | yes | Coverage status |
+| gates | array of gate-result | required for covered/partial; empty or absent for uncovered | Gates that cover this criterion |
+| failures | array of strings | empty/absent for covered/uncovered; non-empty can make partial valid | Gate names that failed for this criterion |
+
+For `covered`, every gate result must be `pass` and `failures` must be empty
+or absent. For `partial`, gate coverage must include either a failed gate
+result or a non-empty `failures` list. For `uncovered`, gate evidence and
+failures must both be empty or absent.
+
+**Gate-result fields:**
+
+| Field | Type | Required | Purpose |
+|-------|------|----------|---------|
+| name | string | yes | Gate name |
+| criterion | string | yes | Acceptance criterion this gate covers |
+| category | enum: structural, coherence, conformance | yes | Gate category |
+| result | enum: pass, fail | yes | Gate result |
 
 ### change-proposal
 

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -61,7 +61,7 @@ documentation impact.
 | decompose | work-unit | Work-units decomposed from requirements |
 | take      | behavior-contract | Contract-first entry: the executable definition of done that threads every downstream artifact |
 | plan      | implementation-plan | Design decisions informing execution |
-| implement | test-evidence | Proof of correct implementation — passing tests mapped to scenarios |
+| implement | test-evidence | Proof of correct implementation — results mapped to scenarios or gates |
 | verify    | completion-evidence | Criterion coverage plus documentation impact |
 | submit    | change-proposal | Forge-neutral proposal ready for review |
 | review    | change-approved or change-needs-revision | Typed review disposition |
@@ -654,30 +654,31 @@ This means the agent's tool interface can be as simple as
 ### Structured queries replace context parsing
 
 Instead of the agent parsing injected context, the MCP server exposes
-query tools: what are my acceptance criteria, what scenarios exist, what
-tests passed. Structured queries against the artifact store, returned
+query tools: what are my acceptance criteria, what behavior entries exist,
+what checks passed. Structured queries against the artifact store, returned
 in natural language or structured data.
 
 ### Cross-reference validation at write time
 
-When the agent references an acceptance criterion in a scenario, the
-MCP server verifies it exists in the work-unit artifact. Not just schema
+When the agent references an acceptance criterion in a scenario or gate,
+the MCP server verifies it exists in the work-unit artifact. Not just schema
 validation — semantic validation. The traceability thread is enforced
 mechanically.
 
 ### Progressive authoring
 
 Instead of one atomic `deliver()` call, the MCP server can support
-incremental building: add a scenario, get immediate feedback, add
-another, finalize. The agent discovers errors as it works, not after
+incremental building: add a scenario or gate, get immediate feedback,
+add another, finalize. The agent discovers errors as it works, not after
 producing the full artifact.
 
 ### Pre-population and cognitive scaffolding
 
 The MCP server can present pre-assembled data to reduce the agent's
 mechanical work. Verify's agent receives a pre-filled coverage matrix
-(criteria × scenarios × test results) and does judgment work — confirm,
-amend, flag gaps — not data assembly.
+in the deliverable's behavior form — criteria × scenarios × test results,
+or criteria × gates × check results — and does judgment work: confirm,
+amend, flag gaps, not data assembly.
 
 ### Observability from the start
 
@@ -692,7 +693,7 @@ chokepoint between agent and system. This enables:
   criterion. Measured, not estimated.
 - **Anomaly detection** — the server sees patterns across many work
   units. An implement protocol completing in two minutes when the
-  median is forty is a signal. A behavior-contract with one scenario
+  median is forty is a signal. A behavior-contract with one behavior entry
   for eight acceptance criteria is a signal.
 - **Replay and audit** — the full sequence of tool calls for a work
   unit is a structured trace. Debugging agent behavior means reading
@@ -719,8 +720,9 @@ The topology has two specification artifacts at different scales:
   This is the project-level specification.
 
 - **behavior-contract** (produced by take, the scoped-pipeline entry) —
-  declares how a single work-unit should behave as Given/When/Then
-  scenarios. This is the implementation-level specification.
+  declares how a single work-unit should be validated: Given/When/Then
+  scenarios for executable behavior, or gates for documentation-deliverable
+  behavior. This is the implementation-level specification.
 
 Decompose bridges the two levels. It consumes requirements and produces
 work-unit artifacts — the work-units that take picks up.
@@ -774,19 +776,22 @@ flow produces artifacts that runa tracks and threads by work-unit identity.
 ### implement
 
 - **requires:** behavior-contract, implementation-plan. The behavior
-  scenarios ARE the tests (authored at take). The plan provides the
-  design approach. Implement does RED-GREEN-REFACTOR: write failing
-  tests from scenarios, write code to pass them, refactor.
+  entries define the checks (authored at take): scenarios for executable
+  behavior, gates for documentation-deliverable behavior. The plan provides
+  the design approach. Implement drives each scenario or gate through the
+  same RED-GREEN-REFACTOR discipline: establish the failing check, make the
+  smallest change that passes it, refactor.
 - **accepts:** nothing currently identified.
 - **trigger:** `on_artifact("implementation-plan")`
 
 ### verify
 
 - **requires:** behavior-contract, test-evidence, work-unit. Verify checks
-  behavior coverage against the contract using test results as evidence.
+  behavior coverage against the contract using test-evidence results.
   The work-unit is required because verify must detect acceptance criteria
-  that have no scenario coverage — gaps that only the original criteria
-  list reveals.
+  that have no scenario or gate coverage — gaps that only the original
+  criteria list reveals. Verify reports coverage in the deliverable's
+  behavior form.
 - **accepts:** implementation-plan. The affected-files list helps map the
   change to the documentation it touches.
 - **trigger:** `on_artifact("test-evidence")`
@@ -902,8 +907,8 @@ decomposition.
 **What take needs:** the work to frame and the acceptance criteria the
 contract refines — what to do, how to know it's done, and whether it's
 ready to start. **What verify needs:** the criteria list, to detect
-acceptance criteria with no scenario coverage. The accepting consumers read
-scope boundaries (plan, review) and closure context (land).
+acceptance criteria with no scenario or gate coverage. The accepting
+consumers read scope boundaries (plan, review) and closure context (land).
 
 | Field | Type | Required | Purpose |
 |-------|------|----------|---------|

--- a/protocols/implement/PROTOCOL.md
+++ b/protocols/implement/PROTOCOL.md
@@ -6,7 +6,7 @@ description: >-
   production code is about to be written — implementing contracted
   behaviors, fixing bugs, or refactoring.
 metadata:
-  version: "2.2.0"
+  version: "2.3.0"
   updated: "2026-06-20"
   origin: "Adapted from obra/superpowers (MIT). See LICENSE-UPSTREAM."
 ---
@@ -101,18 +101,23 @@ should be built.
 
 ## Deliver `test-evidence`
 
-For a runtime-behavior work-unit, the capstone is delivery of the
-scenario-keyed `test-evidence` artifact. Invoke the `test-evidence` MCP
-tool. The object below is MCP tool input, not artifact body. `instance_id`
-is a tool parameter that names the artifact instance; it is extracted before
-validating artifact content, becomes the workspace filename, and must not
-appear in the artifact body. Runa injects `work_unit` from session context;
-the agent does not supply `work_unit`. Do not write the workspace JSON file
-directly:
+The capstone is delivery of the `test-evidence` artifact through the
+`test-evidence` MCP tool in the deliverable's behavior form. For a
+runtime-behavior work-unit, deliver scenario-keyed evidence. For a
+documentation-deliverable work-unit, deliver gate-form evidence for
+structural, coherence, and conformance gates. The object below is MCP tool
+input, not artifact body. `instance_id` is a tool parameter that names the
+artifact instance; it is extracted before validating artifact content,
+becomes the workspace filename, and must not appear in the artifact body.
+Runa injects `work_unit` from session context; the agent does not supply
+`work_unit`. Do not write the workspace JSON file directly.
+
+Scenario form:
 
 ```
 test-evidence({
   instance_id: "<slug>",
+  behavior_form: "scenario",
   evidence: [{
     scenario: "<scenario name from behavior-contract>",
     result: "pass",
@@ -122,14 +127,25 @@ test-evidence({
 })
 ```
 
+Gate form:
+
+```
+test-evidence({
+  instance_id: "<slug>",
+  behavior_form: "gate",
+  evidence: [{
+    name: "<gate name from behavior-contract>",
+    criterion: "<acceptance criterion this gate covers>",
+    category: "structural" | "coherence" | "conformance",
+    result: "pass",
+    command: "<verification command>",
+    output_summary: "<proof the check ran>"
+  }]
+})
+```
+
 Runa validates the remaining artifact body fields against the test-evidence
 schema, persists the artifact, and records it in the artifact store.
-
-For a documentation-deliverable work-unit, report the gate-form cycle as
-committed evidence and state that the runa-backed runtime sequencing of
-gate-form build artifacts is deferred to #454. Do not route a gate-only unit
-through the scenario-keyed `test-evidence` tool or encode gates as
-scenarios.
 
 This protocol owns per-cycle evidence — each behavior item watched failing,
 then passing. The aggregate completion gate belongs to `verify`.

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -5,7 +5,7 @@ description: >-
   out the work unit, and deliver the completion-record. The closing bookend
   of the scoped pipeline.
 metadata:
-  version: "3.1.0"
+  version: "3.2.0"
   updated: "2026-06-20"
 ---
 
@@ -50,15 +50,16 @@ The protocol is not a forge operation. It must not activate from a raw
    and the merge reference.
 
 5. **Deliver the `completion-record`.**
-   For a runtime-behavior work-unit, follow the scenario-keyed runtime close
-   path and invoke the `completion-record` MCP tool. The behavior dimension
-   is recorded in `criterion_summary`; the documentation dimension is
-   recorded in `documentation_status`; the code-quality dimension is
-   recorded as committed evidence in the close-out context, using the diff
-   loci and findings from the projected-universals audit. A typed
-   code-quality `completion-record` field is the schema expansion deferred
-   to #454; do not assert a field the completion-record schema does not
-   define.
+   Invoke the `completion-record` MCP tool through the existing schema
+   fields. For a runtime-behavior work-unit, the scenario-keyed runtime
+   close path records the behavior dimension in `criterion_summary`. For a
+   documentation-deliverable work-unit, gate-form behavior coverage is
+   recorded in `criterion_summary` and close-out context as committed
+   evidence. The documentation dimension is recorded in
+   `documentation_status`; the code-quality dimension is recorded as
+   committed evidence in the close-out context, using the diff loci and
+   findings from the projected-universals audit. Do not assert a field the
+   completion-record schema does not define.
 
    The object below is MCP tool input, not artifact body.
    `instance_id` is a tool parameter that names the artifact instance; it is
@@ -71,7 +72,7 @@ The protocol is not a forge operation. It must not activate from a raw
    completion-record({
      instance_id: "<slug>",
      criterion_summary: "<how acceptance criteria were met>",
-     gaps: ["<known gaps or deferred work - empty array if none>"],
+     gaps: ["<known gaps or follow-up work - empty array if none>"],
      merge_reference: "<applied proposal reference>",
      documentation_status: "<documentation coverage summary>"
    })
@@ -82,16 +83,7 @@ The protocol is not a forge operation. It must not activate from a raw
    artifact store. The record distills the contract's closure: the
    criterion summary and documentation status derive from the performed
    validation in context, while code-quality validation remains committed
-   close-out evidence until the typed field exists.
-
-   For a documentation-deliverable work-unit, record the gate-form behavior
-   coverage as committed evidence. Structural, coherence, and conformance
-   gate coverage satisfies the behavior dimension in the deliverable's
-   behavior form, and the record still carries documentation and
-   code-quality validation-performed. Runa-backed runtime sequencing of
-   gate-form close artifacts — and any `completion-record` schema change it
-   would require — is deferred to #454; name that boundary honestly rather
-   than implying the gate-form runtime path closes end to end today.
+   close-out evidence in the existing schema fields and context.
 
 ## Failure Policy
 
@@ -123,8 +115,8 @@ The protocol is not a forge operation. It must not activate from a raw
   resolves and applies.
 - `schemas/completion-record.schema.json` defines the existing record fields:
   behavior closes through `criterion_summary`, documentation through
-  `documentation_status`, and typed code-quality record expansion is
-  deferred to #454.
+  `documentation_status`, and code quality remains close-out context and
+  committed evidence.
 - `contract` (skill): owns the lifecycle and behavior forms this protocol
   consults while recording validation-performed.
 - `take` (protocol): the opening bookend — the contract established there

--- a/protocols/plan/PROTOCOL.md
+++ b/protocols/plan/PROTOCOL.md
@@ -6,7 +6,7 @@ description: >-
   before implement. If you are about to start coding with unresolved design
   choices, plan first.
 metadata:
-  version: "2.3.0"
+  version: "2.4.0"
   updated: "2026-06-20"
   origin: "Adapted from OpenAI Codex CLI (Apache-2.0). See LICENSE-UPSTREAM."
 ---
@@ -85,18 +85,23 @@ documentation outcomes and reviewer-checkable code-quality projections.
    would cause implementation mistakes.
 
 5. **Deliver the `implementation-plan`.**
-   For a runtime-behavior work-unit, invoke the scenario-keyed
-   `implementation-plan` MCP tool. The object below is MCP tool input, not
-   artifact body.
+   Invoke the `implementation-plan` MCP tool in the deliverable's behavior
+   form. For a runtime-behavior work-unit, deliver scenario-keyed mappings.
+   For a documentation-deliverable work-unit, deliver gate-form mappings for
+   structural, coherence, and conformance gates. The object below is MCP
+   tool input, not artifact body.
    `instance_id` is a tool parameter that names the artifact instance; it is
    extracted before validating artifact content, becomes the workspace
    filename, and must not appear in the artifact body. Runa injects
    `work_unit` from session context; the agent does not supply `work_unit`.
-   Do not write the workspace JSON file directly:
+   Do not write the workspace JSON file directly.
+
+   Scenario form:
 
    ```
    implementation-plan({
      instance_id: "<slug>",
+     behavior_form: "scenario",
      summary: "<what the plan accomplishes>",
      design_decisions: [{decision: "...", rationale: "..."}, ...],
      affected_files: ["..."],
@@ -104,15 +109,27 @@ documentation outcomes and reviewer-checkable code-quality projections.
    })
    ```
 
+   Gate form:
+
+   ```
+   implementation-plan({
+     instance_id: "<slug>",
+     behavior_form: "gate",
+     summary: "<what the plan accomplishes>",
+     design_decisions: [{decision: "...", rationale: "..."}, ...],
+     affected_files: ["..."],
+     behavior_mapping: [{
+       name: "<gate name>",
+       criterion: "<acceptance criterion this maps to>",
+       category: "structural" | "coherence" | "conformance",
+       steps: ["..."]
+     }]
+   })
+   ```
+
    Runa validates the remaining artifact body fields against the
    implementation-plan schema, persists the artifact, and records it in the
    artifact store.
-
-   For a documentation-deliverable work-unit, report the gate-form behavior
-   mapping as committed evidence and state that the runa-backed runtime
-   sequencing of gate-form build artifacts is deferred to #454. Do not route
-   a gate-only unit through the scenario-keyed `implementation-plan` tool or
-   encode gates as scenarios.
 
 ## Scale
 

--- a/protocols/review/PROTOCOL.md
+++ b/protocols/review/PROTOCOL.md
@@ -6,7 +6,7 @@ description: >-
   through `change-approved` and blocking findings through
   `change-needs-revision`.
 metadata:
-  version: "2.1.0"
+  version: "2.2.0"
   updated: "2026-06-20"
 ---
 
@@ -63,15 +63,12 @@ dimension's projected-universal findings.
    produced artifact type; a review run that emits zero or two dispositions
    is invalid.
 
-   For a runtime-behavior work-unit, the disposition remains in the
-   scenario-keyed runtime close path. For a documentation-deliverable
-   work-unit, judge the gate-form packaging as committed evidence. The
-   structural, coherence, and conformance coverage is reviewable behavior
-   evidence, alongside documentation and code-quality validation-performed.
-   Runa-backed runtime sequencing of gate-form close artifacts — and any
-   review artifact schema change it would require — is deferred to #454;
-   name that boundary honestly rather than implying the gate-form runtime
-   path closes end to end today.
+   For a runtime-behavior work-unit, judge the scenario-keyed runtime close
+   path. For a documentation-deliverable work-unit, judge the gate-form
+   packaging through the existing proposal, completion evidence, and review
+   disposition context. The structural, coherence, and conformance coverage
+   is committed evidence and reviewable behavior evidence, alongside
+   documentation and code-quality validation-performed.
 
 ## The Independence of the Gate
 

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -5,7 +5,7 @@ description: >-
   completion evidence exists, and re-fires from change-needs-revision;
   preserves immutable proposal version history.
 metadata:
-  version: "3.1.0"
+  version: "3.2.0"
   updated: "2026-06-20"
 ---
 
@@ -62,16 +62,19 @@ carries the forge-tagged reference downstream.
    forge-specific delivery language.
 
 5. **Deliver the `change-proposal`.**
-   For a runtime-behavior work-unit, follow the scenario-keyed runtime close
-   path and invoke the `change-proposal` MCP tool. The proposal summary
-   carries the multidimensional claim: executable scenarios or scenario
-   coverage for behavior, documentation outcomes, and code-quality findings.
-   The object below is MCP tool input, not artifact body. `instance_id` is a
-   tool parameter that names the artifact instance; it is extracted before
-   validating artifact content, becomes the workspace filename, and must not
-   appear in the artifact body. Runa injects `work_unit` from session
-   context; the agent does not supply `work_unit`. Do not write the
-   workspace JSON file directly:
+   Invoke the `change-proposal` MCP tool through the existing
+   `change-proposal` schema. For a runtime-behavior work-unit, the proposal
+   summary carries scenario-keyed coverage. For a documentation-deliverable
+   work-unit, the same existing artifact carries gate-form behavior as
+   committed evidence in the summary and proposal context: structural,
+   coherence, and conformance coverage for the behavior dimension,
+   documentation outcomes, and code-quality findings. The object below is
+   MCP tool input, not artifact body. `instance_id` is a tool parameter that
+   names the artifact instance; it is extracted before validating artifact
+   content, becomes the workspace filename, and must not appear in the
+   artifact body. Runa injects `work_unit` from session context; the agent
+   does not supply `work_unit`. Do not write the workspace JSON file
+   directly:
 
    ```
    change-proposal({
@@ -91,16 +94,6 @@ carries the forge-tagged reference downstream.
    Runa validates the remaining artifact body fields against the
    change-proposal schema, persists the artifact, and records it in the
    artifact store.
-
-   For a documentation-deliverable work-unit, report the gate-form
-   packaging as committed evidence. The structural, coherence, and
-   conformance coverage is the behavior dimension in the deliverable's
-   behavior form, and the proposal still carries documentation and
-   code-quality validation-performed for review. Runa-backed runtime
-   sequencing of gate-form close artifacts — and any `change-proposal`
-   schema change it would require — is deferred to #454; name that boundary
-   honestly rather than routing this path through a runtime shape it cannot
-   satisfy today.
 
 A revision round never mutates an earlier proposal artifact: it creates a
 new valid `change-proposal` whose `version` advances for this work unit.

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -8,8 +8,8 @@ description: >-
   carries to land; until the runtime sequences the stations autonomously,
   take carries it. Trigger on: 'take', 'take work', 'start work-unit'.
 metadata:
-  version: "3.3.0"
-  updated: "2026-06-17"
+  version: "3.4.0"
+  updated: "2026-06-20"
 ---
 
 # Take — Contract-First Entry
@@ -91,19 +91,25 @@ proves it, or records it.
    consideration is equal. Silence is valid only after you can say the
    general contract is enough for that dimension.
 
-5. **Deliver the behavior spine.** For a runtime-behavior work-unit, invoke
-   the `behavior-contract` MCP tool to deliver the scenario artifact. The
-   runtime-behavior work-unit path is the only path that invokes this tool.
-   The object below is MCP tool input, not artifact body. `instance_id` is
-   a tool parameter that names the artifact instance; it is extracted before
+5. **Deliver the behavior spine.** Invoke the `behavior-contract` MCP tool
+   in the deliverable's behavior form. For a runtime-behavior work-unit,
+   deliver scenario form. For a documentation-deliverable work-unit, deliver
+   gate form: structural, coherence, and conformance gates that are realized
+   as committed structural, coherence, and conformance tests. The object
+   below is MCP tool input, not artifact body. The `behavior-contract` MCP
+   tool accepts both forms through `behavior_form`. `instance_id` is a tool
+   parameter that names the artifact instance; it is extracted before
    validating artifact content, becomes the workspace filename, and must not
    appear in the artifact body. Runa injects `work_unit` from session
    context; the agent does not supply `work_unit`. Do not write the
-   workspace JSON file directly:
+   workspace JSON file directly.
+
+   Scenario form:
 
    ```
    behavior-contract({
      instance_id: "<slug>",
+     behavior_form: "scenario",
      title: "<human-readable contract title>",
      scenarios: [{
        name: "<sentence-named scenario>",
@@ -115,6 +121,22 @@ proves it, or records it.
    })
    ```
 
+   Gate form:
+
+   ```
+   behavior-contract({
+     instance_id: "<slug>",
+     behavior_form: "gate",
+     title: "<human-readable contract title>",
+     gates: [{
+       name: "<gate name>",
+       criterion: "<acceptance criterion this refines>",
+       category: "structural" | "coherence" | "conformance",
+       check: "<reviewer-checkable gate>"
+     }]
+   })
+   ```
+
    Runa validates the remaining artifact body fields against the
    behavior-contract schema, persists the artifact, and records it in the
    artifact store. Where no runtime is present to accept the MCP tool — a
@@ -122,14 +144,6 @@ proves it, or records it.
    contract as a committed workspace artifact (the behavior-contract JSON,
    or the work-unit issue if there is no workspace store) so the spine
    exists and binds the test-first cycle either way.
-
-   For a documentation-deliverable work-unit, the agent does not invoke the
-   scenario-only `behavior-contract` tool. Its behavior spine is delivered
-   as committed structural, coherence, and conformance tests that realize
-   the documentation-deliverable gates. Runa-backed runtime sequencing of
-   gate-form behavior is deferred to #454; name that boundary honestly
-   rather than implying the documentation-only runtime path advances end to
-   end today.
 
 6. **Carry the contract through to a submitted change.** Take does not end
    at contract delivery. When the runtime sequences the pipeline
@@ -165,7 +179,8 @@ proves it, or records it.
    separate agent that is not yet wired, and the work stalls; until it is
    wired, you drive the session directly. Do not stop at a boundary waiting
    to be carried. Review and land — the independent-judgment gate and the
-   governance close — follow once every scenario is green and verify passes.
+   governance close — follow once every scenario or gate is green and verify
+   passes.
 
 ## Scale
 
@@ -177,24 +192,24 @@ begins — the dose is proportional.
 ## Operating Principles
 
 - **The contract is the spine.** Every downstream artifact traces to the
-  scenarios named here. Vague scenarios at entry become unanchored work at
-  every later stage.
+  behavior items named here. Vague scenarios or gates at entry become
+  unanchored work at every later stage.
 - **Plan from the work-unit graph, not from memory.** Sessions end and
   context windows close; the work-unit graph and the artifact store are the
   working memory that survives. Read them; do not reconstruct from
   recollection.
 - **Dependencies are hard blockers.** Work whose dependencies are open
   produces partial results that complicate the graph.
-- **Direction over prediction.** Scenarios state observable outcomes, not
-  implementation forecasts. Implementation sharpens inside the contract's
-  boundaries, not around them.
+- **Direction over prediction.** Behavior items state observable outcomes or
+  reviewer-checkable gates, not implementation forecasts. Implementation
+  sharpens inside the contract's boundaries, not around them.
 
 ## Corruption Modes
 
 - `contract-after-code`: deferring contract authoring to implementation —
   the defining failure this protocol exists to prevent. Done gets defined by
   what was built instead of the work-unit's intent.
-- `scope-creep`: scenarios that exceed the work-unit's boundaries. The
+- `scope-creep`: behavior items that exceed the work-unit's boundaries. The
   contract covers the acceptance criteria — nearby work belongs in other
   work-units.
 - `criteria-parroting`: copying acceptance criteria verbatim as scenarios

--- a/protocols/verify/PROTOCOL.md
+++ b/protocols/verify/PROTOCOL.md
@@ -7,8 +7,8 @@ description: >-
   running the verification and reading the output — evidence before
   assertions, always.
 metadata:
-  version: "2.0.0"
-  updated: "2026-06-11"
+  version: "2.1.0"
+  updated: "2026-06-20"
   origin: "Adapted from obra/superpowers (MIT). See LICENSE-UPSTREAM."
 ---
 
@@ -78,19 +78,23 @@ documentation-deliverable work-unit, coverage is gate coverage.
    [references/code-quality-review.md](references/code-quality-review.md).
 
 5. **Deliver `completion-evidence`.**
-   A runtime-behavior work-unit invokes the scenario-keyed
-   `completion-evidence` MCP tool. The
-   `completion-evidence` MCP tool is the runtime delivery path for scenario
-   coverage today. The object below is MCP tool input, not artifact body.
+   Invoke the `completion-evidence` MCP tool in the deliverable's behavior
+   form. For a runtime-behavior work-unit, deliver scenario-keyed coverage.
+   For a documentation-deliverable work-unit, deliver gate coverage for
+   structural, coherence, and conformance gates. The object below is MCP
+   tool input, not artifact body.
    `instance_id` is a tool parameter that names the artifact instance; it is
    extracted before validating artifact content, becomes the workspace
    filename, and must not appear in the artifact body. Runa injects
    `work_unit` from session context; the agent does not supply `work_unit`.
-   Do not write the workspace JSON file directly:
+   Do not write the workspace JSON file directly.
+
+   Scenario form:
 
    ```
    completion-evidence({
      instance_id: "<slug>",
+     behavior_form: "scenario",
      criterion_coverage: [{
        criterion: "<acceptance criterion>",
        status: "covered",
@@ -105,17 +109,34 @@ documentation-deliverable work-unit, coverage is gate coverage.
    })
    ```
 
+   Gate form:
+
+   ```
+   completion-evidence({
+     instance_id: "<slug>",
+     behavior_form: "gate",
+     criterion_coverage: [{
+       criterion: "<acceptance criterion>",
+       status: "covered",
+       gates: [{
+         name: "<gate name>",
+         criterion: "<acceptance criterion this gate covers>",
+         category: "structural" | "coherence" | "conformance",
+         result: "pass"
+       }],
+       failures: []
+     }],
+     documentation: {
+       updated: ["<docs updated in this change>"],
+       verified_accurate: ["<docs reviewed, confirmed accurate>"],
+       follow_up_work_units: ["<work-units filed for deeper doc work>"]
+     }
+   })
+   ```
+
    Runa validates the remaining artifact body fields against the
    completion-evidence schema, persists the artifact, and records it in the
    artifact store.
-
-   For a documentation-deliverable work-unit, report gate coverage as
-   committed evidence. The structural, coherence, and conformance gate
-   results name the covered criteria and any failures. Runa-backed runtime
-   sequencing of gate-keyed completion evidence is deferred to #454; name
-   that boundary honestly rather than routing this path through the
-   scenario-keyed tool or implying the documentation-only runtime path
-   advances end to end today.
 
 The evidence is honest, not aspirational: gaps and failures are recorded as
 gaps and failures. Review consumes this evidence and blocks on it — an
@@ -139,9 +160,6 @@ uncovered criterion shipped to review is a blocking finding, not a secret.
   the behavior form for that deliverable, not a scenario disguise.
 - `lifecycle-modeling`: re-encoding the behavior lifecycle in `verify`
   instead of consulting the `contract` skill as the single home.
-- `false-runtime-advance`: implying a documentation-deliverable unit can
-  deliver gate-keyed runtime `completion-evidence` before #454 supplies that
-  path.
 
 ## Cross-References
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -53,8 +53,13 @@ The behavior artifact spine uses one artifact type per station and a required
 behavior through `scenarios`, scenario-keyed mappings, scenario-keyed evidence,
 and scenario coverage. Gate form carries documentation-deliverable behavior
 through structural/coherence/conformance `gates`, gate mappings, gate evidence,
-and gate coverage. Root schemas remain ordinary top-level object schemas with
-no root `oneOf`, `anyOf`, `allOf`, or `$ref`, so runtime tool advertisement
+and gate coverage. In `completion-evidence`, both forms enforce the same
+status-to-evidence invariant: `covered` criteria carry passing evidence and no
+failures, `partial` criteria carry evidence plus at least one failure signal,
+and `uncovered` criteria carry no evidence or failures. Gate coverage treats a
+failed gate result and a non-empty `failures` list as the two valid partial
+failure channels. Root schemas remain ordinary top-level object schemas with no
+root `oneOf`, `anyOf`, `allOf`, or `$ref`, so runtime tool advertisement
 continues to expose them as MCP artifact tools.
 
 Downstream consumers that build against a Groundwork schema contract pin a

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -45,6 +45,18 @@ Manifest `[[mechanics]]` entries may declare `forge_tags = [...]` to bind an
 operation handle to forge-specific C-3 mechanics; conformance requires exactly
 one matching `mechanics/**/*.toml` file for each declared operation/tag pair.
 
+The behavior artifact spine uses one artifact type per station and a required
+`behavior_form` discriminator instead of parallel scenario/gate artifact types:
+`behavior-contract`, `implementation-plan`, `test-evidence`, and
+`completion-evidence` each require `behavior_form: "scenario"` or
+`behavior_form: "gate"`. Scenario form carries executable Given/When/Then
+behavior through `scenarios`, scenario-keyed mappings, scenario-keyed evidence,
+and scenario coverage. Gate form carries documentation-deliverable behavior
+through structural/coherence/conformance `gates`, gate mappings, gate evidence,
+and gate coverage. Root schemas remain ordinary top-level object schemas with
+no root `oneOf`, `anyOf`, `allOf`, or `$ref`, so runtime tool advertisement
+continues to expose them as MCP artifact tools.
+
 Downstream consumers that build against a Groundwork schema contract pin a
 release tag or the merged full commit SHA. They do not pin a branch name or
 pre-merge ref.

--- a/schemas/behavior-contract.schema.json
+++ b/schemas/behavior-contract.schema.json
@@ -2,15 +2,20 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/behavior-contract.schema.json",
   "title": "Behavior Contract",
-  "description": "Validates the content of a behavior-contract artifact. Defines expected system behavior as Given/When/Then scenarios that trace to acceptance criteria.",
+  "description": "Validates the content of a behavior-contract artifact. Defines expected system behavior as Given/When/Then scenarios or documentation-deliverable gates that trace to acceptance criteria.",
   "type": "object",
-  "required": ["work_unit", "title", "scenarios"],
+  "required": ["work_unit", "behavior_form", "title"],
   "additionalProperties": false,
   "properties": {
     "work_unit": {
       "type": "string",
       "description": "Common envelope — threads to work unit.",
       "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
+    },
+    "behavior_form": {
+      "type": "string",
+      "description": "Behavior contract form. Use scenario for executable Given/When/Then behavior, or gate for documentation-deliverable quality gates.",
+      "enum": ["scenario", "gate"]
     },
     "title": {
       "type": "string",
@@ -24,6 +29,34 @@
       "items": {
         "$ref": "#/$defs/scenario"
       }
+    },
+    "gates": {
+      "type": "array",
+      "description": "Documentation-deliverable gates that trace to acceptance criteria.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/gate"
+      }
+    }
+  },
+  "if": {
+    "properties": {
+      "behavior_form": {
+        "const": "scenario"
+      }
+    },
+    "required": ["behavior_form"]
+  },
+  "then": {
+    "required": ["scenarios"],
+    "properties": {
+      "gates": false
+    }
+  },
+  "else": {
+    "required": ["gates"],
+    "properties": {
+      "scenarios": false
     }
   },
   "$defs": {
@@ -56,6 +89,34 @@
         "then": {
           "type": "string",
           "description": "The expected outcome.",
+          "minLength": 1
+        }
+      }
+    },
+    "gate": {
+      "type": "object",
+      "description": "A documentation-deliverable quality gate tracing to an acceptance criterion.",
+      "required": ["name", "criterion", "category", "check"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable gate name.",
+          "minLength": 1
+        },
+        "criterion": {
+          "type": "string",
+          "description": "Which acceptance criterion this gate refines.",
+          "minLength": 1
+        },
+        "category": {
+          "type": "string",
+          "description": "Gate category.",
+          "enum": ["structural", "coherence", "conformance"]
+        },
+        "check": {
+          "type": "string",
+          "description": "The concrete check that determines whether the gate passes.",
           "minLength": 1
         }
       }

--- a/schemas/completion-evidence.schema.json
+++ b/schemas/completion-evidence.schema.json
@@ -88,7 +88,7 @@
     "gate-coverage-entry": {
       "type": "object",
       "description": "Gate coverage status for a single acceptance criterion.",
-      "required": ["criterion", "status", "gates"],
+      "required": ["criterion", "status"],
       "additionalProperties": false,
       "properties": {
         "criterion": {

--- a/schemas/completion-evidence.schema.json
+++ b/schemas/completion-evidence.schema.json
@@ -2,9 +2,9 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/completion-evidence.schema.json",
   "title": "Completion Evidence",
-  "description": "Validates the content of a completion-evidence artifact. Reports coverage at the acceptance-criterion level by joining work-unit criteria, behavior-contract scenarios, and test results, and records the documentation impact of the change.",
+  "description": "Validates the content of a completion-evidence artifact. Reports coverage at the acceptance-criterion level by joining work-unit criteria, behavior-contract entries, and test results, and records the documentation impact of the change.",
   "type": "object",
-  "required": ["work_unit", "criterion_coverage", "documentation"],
+  "required": ["work_unit", "behavior_form", "criterion_coverage", "documentation"],
   "additionalProperties": false,
   "properties": {
     "work_unit": {
@@ -12,20 +12,48 @@
       "description": "Common envelope — threads to work unit.",
       "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
     },
+    "behavior_form": {
+      "type": "string",
+      "description": "Behavior form this completion evidence carries forward.",
+      "enum": ["scenario", "gate"]
+    },
     "criterion_coverage": {
       "type": "array",
       "description": "Per-criterion coverage status.",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/$defs/coverage-entry"
-      }
+      "minItems": 1
     },
     "documentation": {
       "$ref": "#/$defs/documentation-impact"
     }
   },
+  "if": {
+    "properties": {
+      "behavior_form": {
+        "const": "scenario"
+      }
+    },
+    "required": ["behavior_form"]
+  },
+  "then": {
+    "properties": {
+      "criterion_coverage": {
+        "items": {
+          "$ref": "#/$defs/scenario-coverage-entry"
+        }
+      }
+    }
+  },
+  "else": {
+    "properties": {
+      "criterion_coverage": {
+        "items": {
+          "$ref": "#/$defs/gate-coverage-entry"
+        }
+      }
+    }
+  },
   "$defs": {
-    "coverage-entry": {
+    "scenario-coverage-entry": {
       "type": "object",
       "description": "Coverage status for a single acceptance criterion.",
       "required": ["criterion", "status"],
@@ -54,6 +82,67 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "gate-coverage-entry": {
+      "type": "object",
+      "description": "Gate coverage status for a single acceptance criterion.",
+      "required": ["criterion", "status", "gates"],
+      "additionalProperties": false,
+      "properties": {
+        "criterion": {
+          "type": "string",
+          "description": "Acceptance criterion from the work unit.",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "description": "Coverage status.",
+          "enum": ["covered", "partial", "uncovered"]
+        },
+        "gates": {
+          "type": "array",
+          "description": "Gates that cover this criterion.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/gate-result"
+          }
+        },
+        "failures": {
+          "type": "array",
+          "description": "Gate names that failed for this criterion.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "gate-result": {
+      "type": "object",
+      "description": "A gate result included in criterion coverage.",
+      "required": ["name", "criterion", "category", "result"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gate name.",
+          "minLength": 1
+        },
+        "criterion": {
+          "type": "string",
+          "description": "Acceptance criterion this gate covers.",
+          "minLength": 1
+        },
+        "category": {
+          "type": "string",
+          "description": "Gate category.",
+          "enum": ["structural", "coherence", "conformance"]
+        },
+        "result": {
+          "type": "string",
+          "description": "Gate result.",
+          "enum": ["pass", "fail"]
         }
       }
     },

--- a/schemas/completion-evidence.schema.json
+++ b/schemas/completion-evidence.schema.json
@@ -58,6 +58,81 @@
       "description": "Coverage status for a single acceptance criterion.",
       "required": ["criterion", "status"],
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "enum": ["covered", "partial"]
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "required": ["scenarios"],
+            "properties": {
+              "scenarios": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "covered"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "failures": {
+                "maxItems": 0
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "partial"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "required": ["failures"],
+            "properties": {
+              "failures": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "uncovered"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "scenarios": {
+                "maxItems": 0
+              },
+              "failures": {
+                "maxItems": 0
+              }
+            }
+          }
+        }
+      ],
       "properties": {
         "criterion": {
           "type": "string",
@@ -90,6 +165,109 @@
       "description": "Gate coverage status for a single acceptance criterion.",
       "required": ["criterion", "status"],
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "enum": ["covered", "partial"]
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "required": ["gates"],
+            "properties": {
+              "gates": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "covered"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "gates": {
+                "items": {
+                  "properties": {
+                    "result": {
+                      "const": "pass"
+                    }
+                  },
+                  "required": ["result"]
+                }
+              },
+              "failures": {
+                "maxItems": 0
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "partial"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": {
+                  "gates": {
+                    "contains": {
+                      "properties": {
+                        "result": {
+                          "const": "fail"
+                        }
+                      },
+                      "required": ["result"]
+                    }
+                  }
+                }
+              },
+              {
+                "required": ["failures"],
+                "properties": {
+                  "failures": {
+                    "minItems": 1
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "uncovered"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "gates": {
+                "maxItems": 0
+              },
+              "failures": {
+                "maxItems": 0
+              }
+            }
+          }
+        }
+      ],
       "properties": {
         "criterion": {
           "type": "string",
@@ -104,7 +282,6 @@
         "gates": {
           "type": "array",
           "description": "Gates that cover this criterion.",
-          "minItems": 1,
           "items": {
             "$ref": "#/$defs/gate-result"
           }

--- a/schemas/implementation-plan.schema.json
+++ b/schemas/implementation-plan.schema.json
@@ -2,15 +2,20 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/implementation-plan.schema.json",
   "title": "Implementation Plan",
-  "description": "Validates the content of an implementation-plan artifact. Bridges behavior (from specify) to code (in implement) with design decisions and scenario-to-step mappings.",
+  "description": "Validates the content of an implementation-plan artifact. Bridges behavior to code with design decisions and behavior-to-step mappings.",
   "type": "object",
-  "required": ["work_unit", "summary", "design_decisions", "affected_files", "behavior_mapping"],
+  "required": ["work_unit", "behavior_form", "summary", "design_decisions", "affected_files", "behavior_mapping"],
   "additionalProperties": false,
   "properties": {
     "work_unit": {
       "type": "string",
       "description": "Common envelope — threads to work unit.",
       "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
+    },
+    "behavior_form": {
+      "type": "string",
+      "description": "Behavior form this plan carries forward.",
+      "enum": ["scenario", "gate"]
     },
     "summary": {
       "type": "string",
@@ -35,10 +40,33 @@
     },
     "behavior_mapping": {
       "type": "array",
-      "description": "How scenarios map to implementation steps.",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/$defs/mapping"
+      "description": "How behavior contract entries map to implementation steps.",
+      "minItems": 1
+    }
+  },
+  "if": {
+    "properties": {
+      "behavior_form": {
+        "const": "scenario"
+      }
+    },
+    "required": ["behavior_form"]
+  },
+  "then": {
+    "properties": {
+      "behavior_mapping": {
+        "items": {
+          "$ref": "#/$defs/scenario-mapping"
+        }
+      }
+    }
+  },
+  "else": {
+    "properties": {
+      "behavior_mapping": {
+        "items": {
+          "$ref": "#/$defs/gate-mapping"
+        }
       }
     }
   },
@@ -61,7 +89,7 @@
         }
       }
     },
-    "mapping": {
+    "scenario-mapping": {
       "type": "object",
       "description": "Mapping from a behavior-contract scenario to implementation steps.",
       "required": ["scenario", "steps"],
@@ -75,6 +103,37 @@
         "steps": {
           "type": "array",
           "description": "Implementation steps for this scenario.",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "gate-mapping": {
+      "type": "object",
+      "description": "Mapping from a behavior-contract gate to implementation steps.",
+      "required": ["name", "criterion", "category", "steps"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gate name from behavior-contract.",
+          "minLength": 1
+        },
+        "criterion": {
+          "type": "string",
+          "description": "Acceptance criterion this gate maps to.",
+          "minLength": 1
+        },
+        "category": {
+          "type": "string",
+          "description": "Gate category.",
+          "enum": ["structural", "coherence", "conformance"]
+        },
+        "steps": {
+          "type": "array",
+          "description": "Implementation steps for this gate.",
           "minItems": 1,
           "items": {
             "type": "string"

--- a/schemas/test-evidence.schema.json
+++ b/schemas/test-evidence.schema.json
@@ -2,9 +2,9 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/test-evidence.schema.json",
   "title": "Test Evidence",
-  "description": "Validates the content of a test-evidence artifact. Records test results against behavior-contract scenarios.",
+  "description": "Validates the content of a test-evidence artifact. Records test results against behavior-contract scenarios or gates.",
   "type": "object",
-  "required": ["work_unit", "evidence"],
+  "required": ["work_unit", "behavior_form", "evidence"],
   "additionalProperties": false,
   "properties": {
     "work_unit": {
@@ -12,17 +12,45 @@
       "description": "Common envelope — threads to work unit.",
       "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
     },
+    "behavior_form": {
+      "type": "string",
+      "description": "Behavior form this evidence carries forward.",
+      "enum": ["scenario", "gate"]
+    },
     "evidence": {
       "type": "array",
-      "description": "Test result entries, each referencing a behavior-contract scenario.",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/$defs/evidence-entry"
+      "description": "Test result entries, each referencing a behavior-contract scenario or gate.",
+      "minItems": 1
+    }
+  },
+  "if": {
+    "properties": {
+      "behavior_form": {
+        "const": "scenario"
+      }
+    },
+    "required": ["behavior_form"]
+  },
+  "then": {
+    "properties": {
+      "evidence": {
+        "items": {
+          "$ref": "#/$defs/scenario-evidence-entry"
+        }
+      }
+    }
+  },
+  "else": {
+    "properties": {
+      "evidence": {
+        "items": {
+          "$ref": "#/$defs/gate-evidence-entry"
+        }
       }
     }
   },
   "$defs": {
-    "evidence-entry": {
+    "scenario-evidence-entry": {
       "type": "object",
       "description": "A single test result for a scenario.",
       "required": ["scenario", "result", "command", "output_summary"],
@@ -32,6 +60,44 @@
           "type": "string",
           "description": "The scenario name from the behavior contract.",
           "minLength": 1
+        },
+        "result": {
+          "type": "string",
+          "description": "Test outcome.",
+          "enum": ["pass", "fail"]
+        },
+        "command": {
+          "type": "string",
+          "description": "The command that was executed.",
+          "minLength": 1
+        },
+        "output_summary": {
+          "type": "string",
+          "description": "Summary of the command output — proof the test ran.",
+          "minLength": 1
+        }
+      }
+    },
+    "gate-evidence-entry": {
+      "type": "object",
+      "description": "A single test result for a gate.",
+      "required": ["name", "criterion", "category", "result", "command", "output_summary"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gate name from behavior contract.",
+          "minLength": 1
+        },
+        "criterion": {
+          "type": "string",
+          "description": "Acceptance criterion this gate covers.",
+          "minLength": 1
+        },
+        "category": {
+          "type": "string",
+          "description": "Gate category.",
+          "enum": ["structural", "coherence", "conformance"]
         },
         "result": {
           "type": "string",

--- a/tests/fixtures/artifacts/invalid-behavior-contract-gate-with-scenarios.json
+++ b/tests/fixtures/artifacts/invalid-behavior-contract-gate-with-scenarios.json
@@ -1,0 +1,14 @@
+{
+  "work_unit": "work-unit-454-runtime-gate-form",
+  "title": "Documentation-deliverable gate-form behavior",
+  "behavior_form": "gate",
+  "scenarios": [
+    {
+      "name": "fabricated scenario",
+      "criterion": "A runtime-backed documentation-deliverable work-unit delivers its behavior dimension without scenarios.",
+      "given": "a documentation deliverable",
+      "when": "the contract is delivered",
+      "then": "a scenario-shaped artifact exists"
+    }
+  ]
+}

--- a/tests/fixtures/artifacts/invalid-behavior-contract.json
+++ b/tests/fixtures/artifacts/invalid-behavior-contract.json
@@ -1,6 +1,7 @@
 {
   "work_unit": "work-unit-178-test-fixtures",
   "title": "Schema validation at ingestion entry point",
+  "behavior_form": "scenario",
   "scenarios": [
     {
       "name": "reject-missing-required-field",

--- a/tests/fixtures/artifacts/invalid-completion-evidence-gate-covered-with-failed-gate.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-gate-covered-with-failed-gate.json
@@ -1,0 +1,23 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "gate",
+  "criterion_coverage": [
+    {
+      "criterion": "Covered gate-form criteria reject failed gate results.",
+      "status": "covered",
+      "gates": [
+        {
+          "name": "gate failed",
+          "criterion": "Covered gate-form criteria reject failed gate results.",
+          "category": "coherence",
+          "result": "fail"
+        }
+      ]
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-gate-covered-with-failures.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-gate-covered-with-failures.json
@@ -1,0 +1,24 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "gate",
+  "criterion_coverage": [
+    {
+      "criterion": "Covered gate-form criteria reject listed failures.",
+      "status": "covered",
+      "gates": [
+        {
+          "name": "gate passed",
+          "criterion": "Covered gate-form criteria reject listed failures.",
+          "category": "coherence",
+          "result": "pass"
+        }
+      ],
+      "failures": ["gate failed"]
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-gate-covered-without-gates.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-gate-covered-without-gates.json
@@ -1,0 +1,15 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "gate",
+  "criterion_coverage": [
+    {
+      "criterion": "Covered gate-form criteria carry gate evidence.",
+      "status": "covered"
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-gate-partial-without-failure-signal.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-gate-partial-without-failure-signal.json
@@ -1,0 +1,24 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "gate",
+  "criterion_coverage": [
+    {
+      "criterion": "Partially covered gate-form criteria require a failure signal.",
+      "status": "partial",
+      "gates": [
+        {
+          "name": "gate passed",
+          "criterion": "Partially covered gate-form criteria require a failure signal.",
+          "category": "coherence",
+          "result": "pass"
+        }
+      ],
+      "failures": []
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-gate-partial-without-gates.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-gate-partial-without-gates.json
@@ -1,0 +1,16 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "gate",
+  "criterion_coverage": [
+    {
+      "criterion": "Partially covered gate-form criteria carry gate evidence.",
+      "status": "partial",
+      "failures": ["structural gate failed"]
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-gate-uncovered-with-failures.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-gate-uncovered-with-failures.json
@@ -1,0 +1,16 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "gate",
+  "criterion_coverage": [
+    {
+      "criterion": "Uncovered gate-form criteria reject listed failures.",
+      "status": "uncovered",
+      "failures": ["gate failed"]
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-gate-uncovered-with-gates.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-gate-uncovered-with-gates.json
@@ -1,0 +1,23 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "gate",
+  "criterion_coverage": [
+    {
+      "criterion": "Uncovered gate-form criteria reject gate evidence.",
+      "status": "uncovered",
+      "gates": [
+        {
+          "name": "gate passed",
+          "criterion": "Uncovered gate-form criteria reject gate evidence.",
+          "category": "coherence",
+          "result": "pass"
+        }
+      ]
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-gate-with-scenarios.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-gate-with-scenarios.json
@@ -1,0 +1,16 @@
+{
+  "work_unit": "work-unit-454-runtime-gate-form",
+  "behavior_form": "gate",
+  "criterion_coverage": [
+    {
+      "criterion": "A runtime-backed documentation-deliverable work-unit delivers its behavior dimension without scenarios.",
+      "status": "covered",
+      "scenarios": ["fabricated scenario"]
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": [],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-scenario-covered-with-failures.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-scenario-covered-with-failures.json
@@ -1,0 +1,17 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "scenario",
+  "criterion_coverage": [
+    {
+      "criterion": "Covered scenario-form criteria reject listed failures.",
+      "status": "covered",
+      "scenarios": ["scenario passed"],
+      "failures": ["scenario failed"]
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-scenario-covered-without-scenarios.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-scenario-covered-without-scenarios.json
@@ -1,0 +1,15 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "scenario",
+  "criterion_coverage": [
+    {
+      "criterion": "Covered scenario-form criteria carry scenario evidence.",
+      "status": "covered"
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-scenario-partial-without-failures.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-scenario-partial-without-failures.json
@@ -1,0 +1,17 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "scenario",
+  "criterion_coverage": [
+    {
+      "criterion": "Partially covered scenario-form criteria require listed failures.",
+      "status": "partial",
+      "scenarios": ["scenario passed"],
+      "failures": []
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-scenario-partial-without-scenarios.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-scenario-partial-without-scenarios.json
@@ -1,0 +1,16 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "scenario",
+  "criterion_coverage": [
+    {
+      "criterion": "Partially covered scenario-form criteria carry scenario evidence.",
+      "status": "partial",
+      "failures": ["scenario failed"]
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-scenario-uncovered-with-failures.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-scenario-uncovered-with-failures.json
@@ -1,0 +1,16 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "scenario",
+  "criterion_coverage": [
+    {
+      "criterion": "Uncovered scenario-form criteria reject listed failures.",
+      "status": "uncovered",
+      "failures": ["scenario failed"]
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-scenario-uncovered-with-scenarios.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-scenario-uncovered-with-scenarios.json
@@ -1,0 +1,16 @@
+{
+  "work_unit": "work-unit-463-completion-evidence-conditionals",
+  "behavior_form": "scenario",
+  "criterion_coverage": [
+    {
+      "criterion": "Uncovered scenario-form criteria reject scenario evidence.",
+      "status": "uncovered",
+      "scenarios": ["scenario passed"]
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence.json
@@ -1,5 +1,6 @@
 {
   "work_unit": "work-unit-178-test-fixtures",
+  "behavior_form": "scenario",
   "criterion_coverage": [
     {
       "criterion": "Records missing required fields are rejected with a 400 status",

--- a/tests/fixtures/artifacts/invalid-implementation-plan-gate-with-scenario-mapping.json
+++ b/tests/fixtures/artifacts/invalid-implementation-plan-gate-with-scenario-mapping.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-454-runtime-gate-form",
+  "behavior_form": "gate",
+  "summary": "Invalidly map gates through scenario fields.",
+  "design_decisions": [
+    {
+      "decision": "Use scenario mapping for a gate artifact.",
+      "rationale": "This should fail because gate form must not fabricate scenarios."
+    }
+  ],
+  "affected_files": ["schemas/implementation-plan.schema.json"],
+  "behavior_mapping": [
+    {
+      "scenario": "fabricated scenario",
+      "steps": ["Pretend a gate is a scenario."]
+    }
+  ]
+}

--- a/tests/fixtures/artifacts/invalid-implementation-plan.json
+++ b/tests/fixtures/artifacts/invalid-implementation-plan.json
@@ -1,5 +1,6 @@
 {
   "work_unit": "work-unit-178-test-fixtures",
+  "behavior_form": "scenario",
   "summary": "Add a JSON Schema validation middleware to the ingestion endpoint",
   "affected_files": [
     "src/ingestion/handler.py"

--- a/tests/fixtures/artifacts/invalid-test-evidence-gate-with-scenario-evidence.json
+++ b/tests/fixtures/artifacts/invalid-test-evidence-gate-with-scenario-evidence.json
@@ -1,0 +1,12 @@
+{
+  "work_unit": "work-unit-454-runtime-gate-form",
+  "behavior_form": "gate",
+  "evidence": [
+    {
+      "scenario": "fabricated scenario",
+      "result": "pass",
+      "command": "python -m unittest tests.test_artifact_schemas",
+      "output_summary": "This should fail because gate evidence must be gate-keyed."
+    }
+  ]
+}

--- a/tests/fixtures/artifacts/invalid-test-evidence.json
+++ b/tests/fixtures/artifacts/invalid-test-evidence.json
@@ -1,5 +1,6 @@
 {
   "work_unit": "work-unit-178-test-fixtures",
+  "behavior_form": "scenario",
   "evidence": [
     {
       "scenario": "reject-missing-required-field",

--- a/tests/fixtures/artifacts/valid-behavior-contract-gate.json
+++ b/tests/fixtures/artifacts/valid-behavior-contract-gate.json
@@ -1,0 +1,19 @@
+{
+  "work_unit": "work-unit-454-runtime-gate-form",
+  "title": "Documentation-deliverable gate-form behavior",
+  "behavior_form": "gate",
+  "gates": [
+    {
+      "name": "gate-form behavior artifacts stay schema-valid",
+      "criterion": "A runtime-backed documentation-deliverable work-unit delivers its behavior dimension without scenarios.",
+      "category": "structural",
+      "check": "Validate the gate-form behavior-contract artifact against the schema."
+    },
+    {
+      "name": "gate-form sequencing does not fabricate scenarios",
+      "criterion": "Plan, implement, and verify sequence on the gate form.",
+      "category": "coherence",
+      "check": "Drive the scoped runtime session with gate-form artifacts only."
+    }
+  ]
+}

--- a/tests/fixtures/artifacts/valid-behavior-contract.json
+++ b/tests/fixtures/artifacts/valid-behavior-contract.json
@@ -1,6 +1,7 @@
 {
   "work_unit": "work-unit-178-test-fixtures",
   "title": "Schema validation at ingestion entry point",
+  "behavior_form": "scenario",
   "scenarios": [
     {
       "name": "reject-missing-required-field",

--- a/tests/fixtures/artifacts/valid-completion-evidence-gate-uncovered.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-gate-uncovered.json
@@ -1,0 +1,15 @@
+{
+  "work_unit": "work-unit-454-runtime-gate-form",
+  "behavior_form": "gate",
+  "criterion_coverage": [
+    {
+      "criterion": "A documentation-deliverable criterion with no gate evidence is recorded honestly as uncovered.",
+      "status": "uncovered"
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["protocols/verify/PROTOCOL.md"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/valid-completion-evidence-gate.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-gate.json
@@ -1,0 +1,23 @@
+{
+  "work_unit": "work-unit-454-runtime-gate-form",
+  "behavior_form": "gate",
+  "criterion_coverage": [
+    {
+      "criterion": "A runtime-backed documentation-deliverable work-unit delivers its behavior dimension without scenarios.",
+      "status": "covered",
+      "gates": [
+        {
+          "name": "gate-form behavior artifacts stay schema-valid",
+          "criterion": "A runtime-backed documentation-deliverable work-unit delivers its behavior dimension without scenarios.",
+          "category": "structural",
+          "result": "pass"
+        }
+      ]
+    }
+  ],
+  "documentation": {
+    "updated": ["schemas/README.md", "CHANGELOG.md"],
+    "verified_accurate": ["protocols/take/PROTOCOL.md", "protocols/verify/PROTOCOL.md"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/valid-completion-evidence-gate.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-gate.json
@@ -13,6 +13,31 @@
           "result": "pass"
         }
       ]
+    },
+    {
+      "criterion": "Gate-form partial coverage records a failed gate result as the failure signal.",
+      "status": "partial",
+      "gates": [
+        {
+          "name": "gate-form partial with failed gate",
+          "criterion": "Gate-form partial coverage records a failed gate result as the failure signal.",
+          "category": "coherence",
+          "result": "fail"
+        }
+      ]
+    },
+    {
+      "criterion": "Gate-form partial coverage records a listed failure as the failure signal.",
+      "status": "partial",
+      "gates": [
+        {
+          "name": "gate-form partial with listed failure",
+          "criterion": "Gate-form partial coverage records a listed failure as the failure signal.",
+          "category": "coherence",
+          "result": "pass"
+        }
+      ],
+      "failures": ["gate-form partial with listed failure"]
     }
   ],
   "documentation": {

--- a/tests/fixtures/artifacts/valid-completion-evidence.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence.json
@@ -1,5 +1,6 @@
 {
   "work_unit": "work-unit-178-test-fixtures",
+  "behavior_form": "scenario",
   "criterion_coverage": [
     {
       "criterion": "Records missing required fields are rejected with a 400 status",

--- a/tests/fixtures/artifacts/valid-implementation-plan-gate.json
+++ b/tests/fixtures/artifacts/valid-implementation-plan-gate.json
@@ -1,0 +1,28 @@
+{
+  "work_unit": "work-unit-454-runtime-gate-form",
+  "behavior_form": "gate",
+  "summary": "Carry documentation-deliverable behavior through the runtime artifact chain as gates.",
+  "design_decisions": [
+    {
+      "decision": "Keep gate behavior on the existing artifact types.",
+      "rationale": "The behavior-contract surface is the single home for behavior validation across both forms."
+    }
+  ],
+  "affected_files": [
+    "schemas/behavior-contract.schema.json",
+    "schemas/implementation-plan.schema.json",
+    "schemas/test-evidence.schema.json",
+    "schemas/completion-evidence.schema.json"
+  ],
+  "behavior_mapping": [
+    {
+      "name": "gate-form behavior artifacts stay schema-valid",
+      "criterion": "A runtime-backed documentation-deliverable work-unit delivers its behavior dimension without scenarios.",
+      "category": "structural",
+      "steps": [
+        "Add gate-form schema variants to the existing behavior artifacts.",
+        "Reject gate artifacts that use scenario fields."
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/artifacts/valid-implementation-plan.json
+++ b/tests/fixtures/artifacts/valid-implementation-plan.json
@@ -1,5 +1,6 @@
 {
   "work_unit": "work-unit-178-test-fixtures",
+  "behavior_form": "scenario",
   "summary": "Add a JSON Schema validation middleware to the ingestion endpoint that checks records against the expected schema before forwarding to the pipeline",
   "design_decisions": [
     {

--- a/tests/fixtures/artifacts/valid-test-evidence-gate.json
+++ b/tests/fixtures/artifacts/valid-test-evidence-gate.json
@@ -1,0 +1,14 @@
+{
+  "work_unit": "work-unit-454-runtime-gate-form",
+  "behavior_form": "gate",
+  "evidence": [
+    {
+      "name": "gate-form behavior artifacts stay schema-valid",
+      "criterion": "A runtime-backed documentation-deliverable work-unit delivers its behavior dimension without scenarios.",
+      "category": "structural",
+      "result": "pass",
+      "command": "python -m unittest tests.test_artifact_schemas",
+      "output_summary": "Gate-form behavior-contract, implementation-plan, test-evidence, and completion-evidence fixtures validated."
+    }
+  ]
+}

--- a/tests/fixtures/artifacts/valid-test-evidence.json
+++ b/tests/fixtures/artifacts/valid-test-evidence.json
@@ -1,5 +1,6 @@
 {
   "work_unit": "work-unit-178-test-fixtures",
+  "behavior_form": "scenario",
   "evidence": [
     {
       "scenario": "reject-missing-required-field",

--- a/tests/test_artifact_schemas.py
+++ b/tests/test_artifact_schemas.py
@@ -96,6 +96,16 @@ class ArtifactSchemaTests(unittest.TestCase):
                 with self.assertRaises(ArtifactSchemaError):
                     load_artifact(artifact_type, self.fixture(fixture_name))
 
+    def test_gate_form_completion_evidence_accepts_uncovered_criteria_without_gates(self) -> None:
+        artifact = load_artifact(
+            "completion-evidence",
+            self.fixture("valid-completion-evidence-gate-uncovered.json"),
+        )
+
+        self.assertEqual("gate", artifact["behavior_form"])
+        self.assertEqual("uncovered", artifact["criterion_coverage"][0]["status"])
+        self.assertNotIn("gates", artifact["criterion_coverage"][0])
+
     def test_runtime_behavior_artifact_schemas_remain_mcp_advertisable(self) -> None:
         for schema_name in [
             "behavior-contract.schema.json",

--- a/tests/test_artifact_schemas.py
+++ b/tests/test_artifact_schemas.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from pathlib import Path
 
@@ -46,6 +47,67 @@ class ArtifactSchemaTests(unittest.TestCase):
                 artifact = load_artifact("change-proposal", self.fixture(name))
 
                 self.assertIn(artifact["handle"]["forge_tag"], {"github", "sourcehut"})
+
+    def test_behavior_artifacts_require_behavior_form(self) -> None:
+        fixtures = {
+            "behavior-contract": "valid-behavior-contract.json",
+            "implementation-plan": "valid-implementation-plan.json",
+            "test-evidence": "valid-test-evidence.json",
+            "completion-evidence": "valid-completion-evidence.json",
+        }
+
+        for artifact_type, fixture_name in fixtures.items():
+            with self.subTest(artifact_type=artifact_type):
+                artifact = load_artifact(artifact_type, self.fixture(fixture_name))
+                self.assertEqual("scenario", artifact["behavior_form"])
+                artifact.pop("behavior_form")
+
+                with self.assertRaises(ArtifactSchemaError) as context:
+                    validate_artifact(artifact_type, artifact)
+
+                self.assertIn("behavior_form", context.exception.paths)
+
+    def test_gate_form_behavior_artifacts_validate_without_scenarios(self) -> None:
+        fixtures = {
+            "behavior-contract": "valid-behavior-contract-gate.json",
+            "implementation-plan": "valid-implementation-plan-gate.json",
+            "test-evidence": "valid-test-evidence-gate.json",
+            "completion-evidence": "valid-completion-evidence-gate.json",
+        }
+
+        for artifact_type, fixture_name in fixtures.items():
+            with self.subTest(artifact_type=artifact_type):
+                artifact = load_artifact(artifact_type, self.fixture(fixture_name))
+                serialized = json.dumps(artifact)
+                self.assertEqual("gate", artifact["behavior_form"])
+                self.assertNotIn('"scenarios"', serialized)
+                self.assertNotIn('"scenario"', serialized)
+
+    def test_gate_form_behavior_artifacts_reject_scenario_shaped_payloads(self) -> None:
+        fixtures = {
+            "behavior-contract": "invalid-behavior-contract-gate-with-scenarios.json",
+            "implementation-plan": "invalid-implementation-plan-gate-with-scenario-mapping.json",
+            "test-evidence": "invalid-test-evidence-gate-with-scenario-evidence.json",
+            "completion-evidence": "invalid-completion-evidence-gate-with-scenarios.json",
+        }
+
+        for artifact_type, fixture_name in fixtures.items():
+            with self.subTest(artifact_type=artifact_type):
+                with self.assertRaises(ArtifactSchemaError):
+                    load_artifact(artifact_type, self.fixture(fixture_name))
+
+    def test_runtime_behavior_artifact_schemas_remain_mcp_advertisable(self) -> None:
+        for schema_name in [
+            "behavior-contract.schema.json",
+            "implementation-plan.schema.json",
+            "test-evidence.schema.json",
+            "completion-evidence.schema.json",
+        ]:
+            with self.subTest(schema=schema_name):
+                schema = json.loads((SCHEMAS / schema_name).read_text(encoding="utf-8"))
+                self.assertEqual("object", schema.get("type"))
+                for keyword in ["oneOf", "anyOf", "allOf", "$ref"]:
+                    self.assertNotIn(keyword, schema)
 
     def test_change_proposal_schema_accepts_sourcehut_proposal_ref_handle(self) -> None:
         artifact = load_artifact("change-proposal", self.fixture("valid-change-proposal-sourcehut-v2.json"))

--- a/tests/test_artifact_schemas.py
+++ b/tests/test_artifact_schemas.py
@@ -106,6 +106,67 @@ class ArtifactSchemaTests(unittest.TestCase):
         self.assertEqual("uncovered", artifact["criterion_coverage"][0]["status"])
         self.assertNotIn("gates", artifact["criterion_coverage"][0])
 
+    def test_scenario_form_completion_evidence_accepts_uncovered_criteria_without_scenarios(self) -> None:
+        artifact = load_artifact("completion-evidence", self.fixture("valid-completion-evidence.json"))
+        uncovered_entries = [
+            entry for entry in artifact["criterion_coverage"] if entry["status"] == "uncovered"
+        ]
+
+        self.assertGreaterEqual(len(uncovered_entries), 1)
+        self.assertNotIn("scenarios", uncovered_entries[0])
+
+    def test_completion_evidence_requires_status_evidence_for_covered_or_partial_criteria(self) -> None:
+        fixtures = [
+            "invalid-completion-evidence-gate-covered-without-gates.json",
+            "invalid-completion-evidence-gate-partial-without-gates.json",
+            "invalid-completion-evidence-scenario-covered-without-scenarios.json",
+            "invalid-completion-evidence-scenario-partial-without-scenarios.json",
+        ]
+
+        for fixture_name in fixtures:
+            with self.subTest(fixture=fixture_name):
+                with self.assertRaises(ArtifactSchemaError):
+                    load_artifact("completion-evidence", self.fixture(fixture_name))
+
+    def test_completion_evidence_rejects_status_evidence_contradictions(self) -> None:
+        fixtures = [
+            "invalid-completion-evidence-gate-covered-with-failed-gate.json",
+            "invalid-completion-evidence-gate-covered-with-failures.json",
+            "invalid-completion-evidence-scenario-covered-with-failures.json",
+            "invalid-completion-evidence-gate-partial-without-failure-signal.json",
+            "invalid-completion-evidence-scenario-partial-without-failures.json",
+            "invalid-completion-evidence-gate-uncovered-with-gates.json",
+            "invalid-completion-evidence-gate-uncovered-with-failures.json",
+            "invalid-completion-evidence-scenario-uncovered-with-scenarios.json",
+            "invalid-completion-evidence-scenario-uncovered-with-failures.json",
+        ]
+
+        for fixture_name in fixtures:
+            with self.subTest(fixture=fixture_name):
+                with self.assertRaises(ArtifactSchemaError):
+                    load_artifact("completion-evidence", self.fixture(fixture_name))
+
+    def test_completion_evidence_accepts_coherent_status_evidence(self) -> None:
+        fixtures = [
+            "valid-completion-evidence.json",
+            "valid-completion-evidence-gate.json",
+            "valid-completion-evidence-gate-uncovered.json",
+        ]
+
+        for fixture_name in fixtures:
+            with self.subTest(fixture=fixture_name):
+                artifact = load_artifact("completion-evidence", self.fixture(fixture_name))
+                partial_entries = [
+                    entry for entry in artifact["criterion_coverage"] if entry["status"] == "partial"
+                ]
+                for entry in partial_entries:
+                    if artifact["behavior_form"] == "scenario":
+                        self.assertGreaterEqual(len(entry.get("failures", [])), 1)
+                    else:
+                        has_failed_gate = any(gate["result"] == "fail" for gate in entry.get("gates", []))
+                        has_listed_failure = len(entry.get("failures", [])) >= 1
+                        self.assertTrue(has_failed_gate or has_listed_failure)
+
     def test_runtime_behavior_artifact_schemas_remain_mcp_advertisable(self) -> None:
         for schema_name in [
             "behavior-contract.schema.json",

--- a/tests/test_build_protocol_contract_dimensions.py
+++ b/tests/test_build_protocol_contract_dimensions.py
@@ -112,7 +112,7 @@ class BuildProtocolContractDimensionTests(unittest.TestCase):
                 self.assertIn(expected, behavior_row)
                 self.assertIn(expected, combined)
 
-    def test_gate_form_runtime_artifact_delivery_names_454_deferral(self) -> None:
+    def test_gate_form_runtime_artifact_delivery_uses_existing_mcp_tools(self) -> None:
         plan_delivery = normalized(step(read(PLAN_PROTOCOL), 5))
         implement_delivery = normalized(section(read(IMPLEMENT_PROTOCOL), "Deliver `test-evidence`"))
 
@@ -127,11 +127,13 @@ class BuildProtocolContractDimensionTests(unittest.TestCase):
                     artifact,
                     "documentation-deliverable work-unit",
                     "gate-form",
-                    "committed evidence",
-                    "#454",
-                    "deferred",
+                    "behavior_form",
+                    "gate",
+                    "structural, coherence, and conformance",
                 ]:
                     self.assertIn(expected, delivery)
+                self.assertNotIn("#454", delivery)
+                self.assertNotIn("deferred", delivery)
                 self.assertNotRegex(delivery, r"documentation-deliverable work-unit[^.]+scenario")
 
     def test_scenario_only_corruption_modes_and_cross_references_are_generalized(self) -> None:
@@ -167,8 +169,8 @@ class BuildProtocolContractDimensionTests(unittest.TestCase):
         plan_body = read(PLAN_PROTOCOL)
         implement_body = read(IMPLEMENT_PROTOCOL)
 
-        self.assertIn("version: \"2.3.0\"", plan_body)
-        self.assertIn("version: \"2.2.0\"", implement_body)
+        self.assertIn("version: \"2.4.0\"", plan_body)
+        self.assertIn("version: \"2.3.0\"", implement_body)
         self.assertIn("the reckon skill is the move", plan_body)
         self.assertIn("the reckon skill is the move", implement_body)
         self.assertIn("NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST", implement_body)

--- a/tests/test_close_protocol_contract_dimensions.py
+++ b/tests/test_close_protocol_contract_dimensions.py
@@ -103,14 +103,14 @@ class CloseProtocolContractDimensionTests(unittest.TestCase):
             "documentation_status",
             "code-quality dimension",
             "committed evidence",
-            "typed code-quality",
             "completion-record",
-            "#454",
-            "deferred",
+            "existing schema fields",
         ]:
             with self.subTest(expected=expected):
                 self.assertIn(expected, delivery)
 
+        self.assertNotIn("#454", delivery)
+        self.assertNotIn("deferred", delivery)
         self.assertNotRegex(delivery, r"code_quality[\":]")
 
     def test_close_protocols_carry_behavior_in_the_deliverable_form(self) -> None:
@@ -157,7 +157,7 @@ class CloseProtocolContractDimensionTests(unittest.TestCase):
                 self.assertIn(expected, behavior_row)
                 self.assertIn(expected, combined)
 
-    def test_gate_form_runtime_close_artifact_delivery_names_454_deferral(self) -> None:
+    def test_gate_form_close_artifact_delivery_uses_existing_schema_context(self) -> None:
         for path, expected_artifact in [
             (SUBMIT_PROTOCOL, "`change-proposal`"),
             (LAND_PROTOCOL, "`completion-record`"),
@@ -171,10 +171,11 @@ class CloseProtocolContractDimensionTests(unittest.TestCase):
                     "documentation-deliverable work-unit",
                     "gate-form",
                     "committed evidence",
-                    "#454",
-                    "deferred",
+                    "existing",
                 ]:
                     self.assertIn(expected, delivery)
+                self.assertNotIn("#454", delivery)
+                self.assertNotIn("deferred", delivery)
 
         review_disposition = normalized(step(read(REVIEW_PROTOCOL), 4))
         for expected in [
@@ -183,11 +184,12 @@ class CloseProtocolContractDimensionTests(unittest.TestCase):
             "documentation-deliverable work-unit",
             "gate-form",
             "committed evidence",
-            "#454",
-            "deferred",
+            "existing",
         ]:
             with self.subTest(expected=expected):
                 self.assertIn(expected, review_disposition)
+        self.assertNotIn("#454", review_disposition)
+        self.assertNotIn("deferred", review_disposition)
 
     def test_dimension_omission_corruption_modes_and_invariants_survive(self) -> None:
         corruption_modes = normalized(

--- a/tests/test_interactive_session_surface.py
+++ b/tests/test_interactive_session_surface.py
@@ -121,7 +121,7 @@ class InteractiveSessionSurfaceTests(unittest.TestCase):
                     printf '%s\\n' '{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"2024-11-05","capabilities":{{}},"clientInfo":{{"name":"groundwork-go-smoke","version":"1.0.0"}}}}}}'
                     printf '%s\\n' '{{"jsonrpc":"2.0","method":"notifications/initialized"}}'
                     printf '%s\\n' '{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"next-protocol-context","arguments":{{}}}}}}'
-                    printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"behavior-contract","arguments":{{"instance_id":"contract-1","title":"Interactive sessions use the session surface","scenarios":[{{"name":"records output through the session surface","criterion":"Interactive sessions reach take through the runa session surface","given":"a scoped interactive session","when":"the agent records the protocol output","then":"the artifact is validated and persisted by runa"}}]}}}}}}'
+                    printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"behavior-contract","arguments":{{"instance_id":"contract-1","title":"Interactive sessions use the session surface","behavior_form":"scenario","scenarios":[{{"name":"records output through the session surface","criterion":"Interactive sessions reach take through the runa session surface","given":"a scoped interactive session","when":"the agent records the protocol output","then":"the artifact is validated and persisted by runa"}}]}}}}}}'
                     printf '%s\\n' '{{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{{"name":"advance","arguments":{{}}}}}}'
                     sleep 1
                 }} | "$3" --session --work-unit {WORK_UNIT_ID} > "$4"
@@ -159,10 +159,127 @@ class InteractiveSessionSurfaceTests(unittest.TestCase):
                 (workspace / "behavior-contract" / "contract-1.json").read_text(encoding="utf-8")
             )
             self.assertEqual(contract["work_unit"], WORK_UNIT_ID)
+            self.assertEqual(contract["behavior_form"], "scenario")
             self.assertEqual(
                 contract["scenarios"][0]["criterion"],
                 "Interactive sessions reach take through the runa session surface",
             )
+
+    def test_session_sequences_documentation_deliverable_gate_form_behavior(self) -> None:
+        runa = runa_bin()
+        self.assertIsNotNone(runa)
+        runa_mcp = runa_mcp_bin(runa)
+        if runa_mcp is None:
+            self.skipTest("runa-mcp binary not available")
+
+        work_unit_id = "work-unit-454-runtime-gate-form-behavior"
+        with tempfile.TemporaryDirectory(prefix="groundwork-runa-gate-form-") as tmp:
+            root = Path(tmp)
+            project_dir = root / "project"
+            project_dir.mkdir()
+
+            init = run([str(runa), "init", "--methodology", str(ROOT / "manifest.toml")], project_dir)
+            self.assertEqual(init.returncode, 0, f"stdout:\n{init.stdout}\nstderr:\n{init.stderr}")
+
+            workspace = project_dir / ".runa" / "workspace"
+            (workspace / "work-unit").mkdir(parents=True)
+            criterion = "A runtime-backed documentation-deliverable work-unit delivers its behavior dimension without scenarios."
+            (workspace / "work-unit" / f"{work_unit_id}.json").write_text(
+                json.dumps(
+                    {
+                        "title": "task(contract/runa): carry gate-form behavior through runtime artifacts",
+                        "description": "Make a documentation-deliverable work-unit sequence on gate-form behavior.",
+                        "acceptance_criteria": [criterion],
+                        "handle": {
+                            "forge_tag": "github",
+                            "url": "https://github.com/tesserine/groundwork/issues/454",
+                            "number": 454,
+                        },
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+            agent_path = root / "agent.sh"
+            prompt_path = root / "prompt.txt"
+            config_capture_path = root / "mcp-config.json"
+            mcp_log_path = root / "mcp.log"
+            write_executable(
+                agent_path,
+                f"""
+                #!/bin/sh
+                set -eu
+                cat > "$1"
+                printf '%s' "$RUNA_MCP_CONFIG" > "$2"
+                protocol="${{GROUNDWORK_GATE_PROTOCOL:?}}"
+                {{
+                    printf '%s\\n' '{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"2024-11-05","capabilities":{{}},"clientInfo":{{"name":"groundwork-gate-form-smoke","version":"1.0.0"}}}}}}'
+                    printf '%s\\n' '{{"jsonrpc":"2.0","method":"notifications/initialized"}}'
+                    printf '%s\\n' '{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"next-protocol-context","arguments":{{}}}}}}'
+                    case "$protocol" in
+                      take)
+                        printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"behavior-contract","arguments":{{"instance_id":"contract-1","title":"Gate-form behavior stays on the behavior-contract surface","behavior_form":"gate","gates":[{{"name":"gate-form behavior artifacts stay schema-valid","criterion":{json.dumps(criterion)},"category":"structural","check":"Validate gate-form artifacts through the runtime MCP tool."}}]}}}}}}'
+                        ;;
+                      plan)
+                        printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"implementation-plan","arguments":{{"instance_id":"plan-1","behavior_form":"gate","summary":"Map gate-form behavior without scenarios.","design_decisions":[{{"decision":"Use gate-keyed mappings for documentation deliverables.","rationale":"Gate behavior is the behavior form the contract defines for documentation deliverables."}}],"affected_files":["schemas/behavior-contract.schema.json"],"behavior_mapping":[{{"name":"gate-form behavior artifacts stay schema-valid","criterion":{json.dumps(criterion)},"category":"structural","steps":["Validate the gate artifact.","Advance to implement on the produced artifact."]}}]}}}}}}'
+                        ;;
+                      implement)
+                        printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"test-evidence","arguments":{{"instance_id":"evidence-1","behavior_form":"gate","evidence":[{{"name":"gate-form behavior artifacts stay schema-valid","criterion":{json.dumps(criterion)},"category":"structural","result":"pass","command":"python -m unittest tests.test_artifact_schemas","output_summary":"Gate-form artifact fixtures validated."}}]}}}}}}'
+                        ;;
+                      verify)
+                        printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"completion-evidence","arguments":{{"instance_id":"completion-1","behavior_form":"gate","criterion_coverage":[{{"criterion":{json.dumps(criterion)},"status":"covered","gates":[{{"name":"gate-form behavior artifacts stay schema-valid","criterion":{json.dumps(criterion)},"category":"structural","result":"pass"}}]}}],"documentation":{{"updated":["schemas/README.md","CHANGELOG.md"],"verified_accurate":["protocols/take/PROTOCOL.md"],"follow_up_work_units":[]}}}}}}}}'
+                        ;;
+                      *)
+                        printf 'unexpected protocol: %s\\n' "$protocol" >&2
+                        exit 24
+                        ;;
+                    esac
+                    printf '%s\\n' '{{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{{"name":"advance","arguments":{{}}}}}}'
+                    sleep 1
+                }} | "$3" --session --work-unit {work_unit_id} > "$4"
+                if grep -q '"error"' "$4"; then
+                    cat "$4" >&2
+                    exit 23
+                fi
+                """,
+            )
+            append_agent_command_config(
+                project_dir,
+                [agent_path, prompt_path, config_capture_path, runa_mcp, mcp_log_path],
+            )
+
+            for expected_protocol in ["take", "plan", "implement", "verify"]:
+                with self.subTest(protocol=expected_protocol):
+                    env = groundwork_env()
+                    env["GROUNDWORK_GATE_PROTOCOL"] = expected_protocol
+                    output = run(
+                        [str(runa), "go", "--work-unit", work_unit_id],
+                        project_dir,
+                        env=env,
+                    )
+
+                    self.assertEqual(
+                        output.returncode,
+                        0,
+                        f"stdout:\n{output.stdout}\nstderr:\n{output.stderr}\nmcp log:\n{mcp_log_path.read_text(encoding='utf-8') if mcp_log_path.exists() else '<missing>'}",
+                    )
+
+            for artifact_type, instance_id in [
+                ("behavior-contract", "contract-1"),
+                ("implementation-plan", "plan-1"),
+                ("test-evidence", "evidence-1"),
+                ("completion-evidence", "completion-1"),
+            ]:
+                with self.subTest(artifact_type=artifact_type):
+                    artifact = json.loads(
+                        (workspace / artifact_type / f"{instance_id}.json").read_text(encoding="utf-8")
+                    )
+                    serialized = json.dumps(artifact)
+                    self.assertEqual(artifact["work_unit"], work_unit_id)
+                    self.assertEqual(artifact["behavior_form"], "gate")
+                    self.assertNotIn('"scenarios"', serialized)
+                    self.assertNotIn('"scenario"', serialized)
 
 
 if __name__ == "__main__":

--- a/tests/test_take_protocol_contract_dimensions.py
+++ b/tests/test_take_protocol_contract_dimensions.py
@@ -128,27 +128,25 @@ class TakeProtocolContractDimensionTests(unittest.TestCase):
                     self.assertIn(form, rows[dimension])
                     self.assertIn(form, take_body)
 
-    def test_behavior_contract_delivery_is_conditional_on_deliverable_type(self) -> None:
+    def test_behavior_contract_delivery_supports_both_behavior_forms(self) -> None:
         delivery = normalized(step(read(TAKE_PROTOCOL), 5))
 
         for expected in [
             "runtime-behavior work-unit",
             "documentation-deliverable work-unit",
-            "scenario artifact",
-            "scenario-only",
-            "does not invoke",
+            "`behavior-contract` MCP tool",
+            "behavior_form",
+            "scenario",
+            "gate",
+            "structural, coherence, and conformance",
             "committed structural, coherence, and conformance tests",
-            "#454",
-            "deferred",
         ]:
             with self.subTest(expected=expected):
                 self.assertIn(expected, delivery)
 
-        unconditional = re.compile(
-            r"^Invoke the `behavior-contract` MCP tool\.",
-            flags=re.MULTILINE,
-        )
-        self.assertIsNone(unconditional.search(read(TAKE_PROTOCOL)))
+        self.assertNotIn("#454", delivery)
+        self.assertNotIn("deferred", delivery)
+        self.assertNotRegex(delivery, r"documentation-deliverable work-unit[^.]+scenarios")
 
     def test_documentation_deliverable_gates_thread_to_carry_through_without_scenarios(self) -> None:
         carry = normalized(step(read(TAKE_PROTOCOL), 6))

--- a/tests/test_verify_protocol_gate_coverage.py
+++ b/tests/test_verify_protocol_gate_coverage.py
@@ -113,7 +113,7 @@ class VerifyProtocolGateCoverageTests(unittest.TestCase):
         )
         self.assertIsNone(lifecycle_table.search(body))
 
-    def test_gate_keyed_completion_evidence_runtime_delivery_names_454_deferral(self) -> None:
+    def test_gate_keyed_completion_evidence_runtime_delivery_uses_existing_mcp_tool(self) -> None:
         delivery = normalized(step(read(VERIFY_PROTOCOL), 5))
 
         for expected in [
@@ -122,13 +122,15 @@ class VerifyProtocolGateCoverageTests(unittest.TestCase):
             "`completion-evidence` MCP tool",
             "documentation-deliverable work-unit",
             "gate coverage",
-            "committed evidence",
-            "#454",
-            "deferred",
+            "behavior_form",
+            "gate",
+            "structural, coherence, and conformance",
         ]:
             with self.subTest(expected=expected):
                 self.assertIn(expected, delivery)
 
+        self.assertNotIn("#454", delivery)
+        self.assertNotIn("deferred", delivery)
         self.assertNotRegex(delivery, r"documentation-deliverable work-unit[^.]+scenarios")
 
     def test_named_gate_form_agrees_with_contract_skill_lifecycle(self) -> None:


### PR DESCRIPTION
## Summary

- Require `behavior_form` on behavior-contract, implementation-plan, test-evidence, and completion-evidence artifacts.
- Add gate-form schema support and fixtures for documentation-deliverable behavior without encoding gates as scenarios.
- Update the take/plan/implement/verify/submit/review/land protocol docs, schema README, and CHANGELOG for gate-form runtime delivery.
- Add Runa session-surface coverage showing gate-form artifacts advance through runtime MCP tools through completion-evidence.
- Complete the final architecture prose pass so protocol-flow summaries consistently describe scenario-or-gate behavior coverage.

## Verification

- `python -m unittest discover -s tests` — 382 tests passed
- `python -m tooling.conformance` — 36 passed, 0 failed
- `git diff --check` — clean

Closes #454.
