### PR TITLE
feat(reckon): add Ascent purpose ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Ascent in reckon** (#327). `reckon` now names Ascent, the Purpose
+  Ladder, as the upward counterpart to Recursive Why: structural choices
+  made during Reconstruct climb back through purpose to the exigence before
+  they commit to a dependency, artifact, or mechanism. The skill now carries
+  the `Purpose drift` corruption mode, recognition-index trigger, excavation
+  reference, and upward-anchor language across the reckon surface.
+
 - **Multi-dimensional contract.** The `contract` skill is now Contract-First
   given concrete form across dimensions, not behavior alone. A contract
   declares the dimensions a change demands — behavior (BDD, unchanged),

--- a/skills/reckon/SKILL.md
+++ b/skills/reckon/SKILL.md
@@ -11,8 +11,8 @@ description: >-
   earning its chain (momentum). Dead reckoning: advance from an established
   fix using trusted constants.
 metadata:
-  version: "5.3.0"
-  updated: "2026-06-17"
+  version: "5.4.0"
+  updated: "2026-06-20"
 ---
 
 # Reckon
@@ -72,10 +72,13 @@ defaulting to pattern-matching.
 constraints, establish what is true — for design, ground in *normative*
 truth (what's needed), never in descriptive truth (what exists). Momentum
 (dynamic): reason forward with every inference tracing back to ground or
-principle. Position without momentum never reaches a conclusion; momentum
-without position is fluent reasoning from an unverified start. Dead
-reckoning — advance from an established fix using trusted constants — is
-both faces as one act.
+principle, and hold structural choices to the upward purpose anchor set by
+Orient. Position without momentum never reaches a conclusion; momentum
+without position is fluent reasoning from an unverified start. A chain
+anchored only downward can stay factual while drifting from what it is for;
+Ascent returns to purpose before a load-bearing structure is committed.
+Dead reckoning — advance from an established fix using trusted constants —
+is both faces as one act.
 
 **The chain.** A conclusion is trustworthy only when its path back to
 ground or principle is explicit. The chain breaks by drift (links trace
@@ -142,10 +145,12 @@ static error — inherited assumptions accepted as constraints).
 | Audience assumption | Designing for the voice in the prompt. |
 | Abstraction gravity | The adjacent system's abstraction level, inherited. |
 | Local coherence | A locally-valid detail that defeats the Orient purpose. |
+| Purpose drift | A locally sound structure stops serving purpose, unlike a locally-valid detail caught by Local coherence. |
 | Preservation variants | Fabricated migration costs · compatibility layering · risk asymmetry · "it works" as sufficient. |
 
 To actively drill to bedrock rather than wait for a signal — Socratic
-drilling and recursive why: [references/excavation.md](references/excavation.md).
+drilling, recursive why, and Ascent to climb to the exigence:
+[references/excavation.md](references/excavation.md).
 
 ## When to Reckon
 
@@ -187,7 +192,13 @@ answered with "the plan excluded this" instead of fresh reckoning);
 **premature termination** (a valid chain closed before its consequence
 surface was traced); **principle as decoration** (remove the citation and
 the reasoning doesn't change); **untraceable chain** (the conclusion may be
-right, but a chain that cannot be shown cannot be trusted).
+right, but a chain that cannot be shown cannot be trusted); **purpose
+drift** (a structural choice is committed on downward-sound links, so the
+reckoning feels complete, but the structure has stopped serving Orient's
+purpose and nothing climbed back). Local coherence catches a detail that
+defeats the purpose and is correctable by restating Orient; purpose drift
+catches structure, and its corrective is to run Ascent at the structural
+choice before committing.
 
 ---
 
@@ -196,4 +207,5 @@ accepted costs, unquestioned structures, precedent as constraint,
 descriptions of what is, and analogical reasoning from correct ground.
 Orient returns you to what is needed. Verify returns you to what is
 true. The selected principles give you direction. The chain keeps you
-honest. Reckon from there.*
+honest. Ascent names purpose as an anchor you return to before structure
+sets. Reckon from there.*

--- a/skills/reckon/SKILL.md
+++ b/skills/reckon/SKILL.md
@@ -123,11 +123,14 @@ recognition-and-corrective machinery — not the principle definitions.
 ## Recognition Index
 
 When any of these fires, stop and re-derive. Full expositions with
-recognition and corrective for each:
+recognition and corrective for the analogical and assumed-constraint
+signals:
 [references/analogical-signals.md](references/analogical-signals.md) (the
 dynamic error — analogy from correct ground) and
 [references/assumed-constraints.md](references/assumed-constraints.md) (the
 static error — inherited assumptions accepted as constraints).
+Purpose drift is a dynamic-face corruption whose full exposition is in the
+Corruption Modes section below.
 
 | Signal | One-line trigger |
 |---|---|

--- a/skills/reckon/SKILL.md
+++ b/skills/reckon/SKILL.md
@@ -205,7 +205,7 @@ choice before committing.
 *The default is to float — in inherited frames, borrowed categories,
 accepted costs, unquestioned structures, precedent as constraint,
 descriptions of what is, and analogical reasoning from correct ground.
-Orient returns you to what is needed. Verify returns you to what is
-true. The selected principles give you direction. The chain keeps you
-honest. Ascent names purpose as an anchor you return to before structure
-sets. Reckon from there.*
+Orient returns you to what is needed and, through Ascent, back upward to
+purpose before structure sets. Verify returns you to what is true. The
+selected principles give you direction. The chain keeps you honest. Reckon
+from there.*

--- a/skills/reckon/references/excavation.md
+++ b/skills/reckon/references/excavation.md
@@ -1,8 +1,10 @@
 # Active Excavation
 
 The recognition patterns are passive — they catch drift. These techniques
-actively drill to bedrock. Apply them during Orient and Decompose to reach
-ground; apply navigational principles during Reconstruct to reason forward.
+actively move along both purpose-directions: down to bedrock-fact and up to
+bedrock-purpose. Apply Socratic drilling and Recursive Why during Orient and
+Decompose to reach ground; apply Ascent during Reconstruct when a structural
+choice must be checked against the purpose it serves.
 
 ## Socratic Drilling
 
@@ -24,9 +26,38 @@ verified user need.
 
 ***Recognition that you have overshot:*** You are questioning constraints that are independently verified (physics, contracts, measured data). Stop. That is ground.
 
+## Ascent (the Purpose Ladder)
+
+Climb back up the purpose chain when a structural choice can be locally sound
+in more than one way. The upward purpose anchor is the exigence the choice
+serves; Ascent asks whether the structure still serves that purpose before
+the structure is committed.
+
+The ladder:
+
+```
+issue -> epic -> application-as-is -> application-as-envisioned -> ecosystem -> the exigence
+```
+
+At each rung, ask: "does this choice still serve that?" The climb terminates
+at the exigence, the bedrock-purpose that gives the choice its direction.
+
+Ascent fires during Reconstruct, at the moment of a structural choice: when
+the local exigence admits multiple locally-valid solutions with different
+structural characteristics, and the decision introduces a dependency, creates
+an artifact, or commits to a mechanism. Not every decision gets this climb;
+a load-bearing structural commit does.
+
+Recursive Why and Ascent can both reach a verified user need, but they reach
+it along different axes. Recursive Why reaches the verified user need as a
+fact: the bedrock that makes an assumption real. Ascent reaches it as the
+teleology a choice must serve: the purpose that keeps a locally sound
+structure from drifting away from what it is for.
+
 ## Chains and Techniques
 
-Active excavation establishes ground. Navigational principles govern what
-you build from it. At every step of reconstruction, the chain of inference
-must be explicit — each conclusion traces through the techniques that
-established its ground and the principles that governed its derivation.
+Active excavation establishes ground and purpose. Navigational principles
+govern what you build from them. At every step of reconstruction, the chain
+of inference must be explicit — each conclusion traces through the techniques
+that established its ground, the purpose ladder that held structural choices
+to their exigence, and the principles that governed derivation.

--- a/tests/test_reckon_ascent.py
+++ b/tests/test_reckon_ascent.py
@@ -94,7 +94,13 @@ class ReckonAscentTests(unittest.TestCase):
 
         self.assertIn("upward purpose anchor", prose(section(excavation, "## Ascent (the Purpose Ladder)")))
         self.assertIn("upward purpose anchor", prose(two_faces))
-        self.assertIn("purpose as an anchor you return to", closing)
+        closing_prose = prose(closing)
+
+        self.assertIn(
+            "Orient returns you to what is needed and, through Ascent, back upward to purpose before structure sets.",
+            closing_prose,
+        )
+        self.assertNotIn("Ascent names purpose as an anchor you return to", closing_prose)
         self.assertIn("Purpose drift", prose(recognition))
         self.assertIn("Ascent", prose(recognition))
 

--- a/tests/test_reckon_ascent.py
+++ b/tests/test_reckon_ascent.py
@@ -1,0 +1,113 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RECKON = ROOT / "skills" / "reckon" / "SKILL.md"
+EXCAVATION = ROOT / "skills" / "reckon" / "references" / "excavation.md"
+CHANGELOG = ROOT / "CHANGELOG.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def prose(body: str) -> str:
+    return re.sub(r"\s+", " ", body)
+
+
+def section(body: str, heading: str) -> str:
+    start = body.index(heading)
+    next_heading = re.search(r"^##\s+", body[start + len(heading) :], re.MULTILINE)
+    if next_heading is None:
+        return body[start:]
+    return body[start : start + len(heading) + next_heading.start()]
+
+
+class ReckonAscentTests(unittest.TestCase):
+    def test_excavation_intro_names_both_purpose_directions(self) -> None:
+        intro = prose(read(EXCAVATION).split("## Socratic Drilling", 1)[0])
+
+        self.assertIn("both purpose-directions", intro)
+        self.assertIn("down to bedrock-fact", intro)
+        self.assertIn("up to bedrock-purpose", intro)
+        self.assertNotIn("actively drill to bedrock. Apply them during Orient and Decompose", intro)
+
+    def test_ascent_section_defines_the_purpose_ladder(self) -> None:
+        ascent = prose(section(read(EXCAVATION), "## Ascent (the Purpose Ladder)"))
+
+        for expected in [
+            "issue -> epic -> application-as-is -> application-as-envisioned -> ecosystem -> the exigence",
+            "does this choice still serve that?",
+            "terminates at the exigence",
+            "bedrock-purpose",
+            "fires during Reconstruct",
+            "Recursive Why reaches the verified user need as a fact",
+            "Ascent reaches it as the teleology a choice must serve",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, ascent)
+
+    def test_ascent_trigger_is_a_verifiable_structural_condition(self) -> None:
+        ascent = prose(section(read(EXCAVATION), "## Ascent (the Purpose Ladder)"))
+
+        self.assertIn("local exigence admits multiple locally-valid solutions", ascent)
+        self.assertIn("different structural characteristics", ascent)
+        for structural_action in [
+            "introduces a dependency",
+            "creates an artifact",
+            "commits to a mechanism",
+        ]:
+            with self.subTest(structural_action=structural_action):
+                self.assertIn(structural_action, ascent)
+
+    def test_purpose_drift_is_declared_as_a_dynamic_corruption_mode(self) -> None:
+        corruption_modes = prose(read(RECKON).split("Dynamic face:", 1)[1])
+
+        self.assertIn("**purpose drift**", corruption_modes)
+        self.assertIn("structural choice", corruption_modes)
+        self.assertIn("downward-sound links", corruption_modes)
+        self.assertIn("stopped serving Orient's purpose", corruption_modes)
+        self.assertIn("run Ascent", corruption_modes)
+        self.assertIn("Local coherence", corruption_modes)
+        self.assertIn("detail", corruption_modes)
+        self.assertIn("structure", corruption_modes)
+
+    def test_recognition_index_and_pointer_reach_ascent(self) -> None:
+        body = read(RECKON)
+        recognition = prose(section(body, "## Recognition Index"))
+
+        self.assertIn("| Purpose drift |", recognition)
+        self.assertIn("locally sound structure", recognition)
+        self.assertIn("locally-valid detail", recognition)
+        self.assertIn("Ascent", recognition)
+        self.assertIn("climb to the exigence", recognition)
+        self.assertIn("[references/excavation.md](references/excavation.md)", recognition)
+
+    def test_upward_anchor_is_woven_through_the_skill_surface(self) -> None:
+        reckon = read(RECKON)
+        excavation = read(EXCAVATION)
+        two_faces = section(reckon, "## The Discipline Beneath the Move")
+        recognition = section(reckon, "## Recognition Index")
+        closing = reckon.rsplit("---", 1)[1]
+
+        self.assertIn("upward purpose anchor", prose(section(excavation, "## Ascent (the Purpose Ladder)")))
+        self.assertIn("upward purpose anchor", prose(two_faces))
+        self.assertIn("purpose as an anchor you return to", closing)
+        self.assertIn("Purpose drift", prose(recognition))
+        self.assertIn("Ascent", prose(recognition))
+
+    def test_reckon_version_and_changelog_record_the_addition(self) -> None:
+        reckon = read(RECKON)
+        changelog = prose(read(CHANGELOG).split("## [Unreleased]", 1)[1].split("### Changed", 1)[0])
+
+        self.assertIn('version: "5.4.0"', reckon)
+        self.assertIn('updated: "2026-06-20"', reckon)
+        self.assertIn("Ascent", changelog)
+        self.assertIn("Purpose Ladder", changelog)
+        self.assertIn("Purpose drift", changelog)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reckon_ascent.py
+++ b/tests/test_reckon_ascent.py
@@ -84,6 +84,10 @@ class ReckonAscentTests(unittest.TestCase):
         self.assertIn("Ascent", recognition)
         self.assertIn("climb to the exigence", recognition)
         self.assertIn("[references/excavation.md](references/excavation.md)", recognition)
+        self.assertIn(
+            "Purpose drift is a dynamic-face corruption whose full exposition is in the Corruption Modes section below.",
+            recognition,
+        )
 
     def test_upward_anchor_is_woven_through_the_skill_surface(self) -> None:
         reckon = read(RECKON)


### PR DESCRIPTION
## Summary

Refs #327.

This change adds Ascent, the Purpose Ladder, to the authoritative `reckon` skill:

- generalizes active excavation to cover both down-to-bedrock-fact and up-to-bedrock-purpose movement
- adds the Ascent section with ladder, trigger, Reconstruct timing, and Recursive Why axis distinction
- wires the upward purpose anchor through the two-faces exposition, Recognition Index, Purpose drift corruption mode, and closing metaphor
- bumps `reckon` to 5.4.0 and records the addition in the changelog

## Contract coverage

- Structural: `excavation.md` now includes the Ascent section and generalized intro.
- Coherence: the upward anchor appears across the Ascent section, two-faces exposition, closing metaphor, Recognition Index row, and excavation pointer.
- Conformance: `tests/test_reckon_ascent.py` gates the verifiable structural trigger, metadata bump, and changelog entry.

## Verification

- `python -m unittest discover -s tests` -> 389 tests passed
- `python -m tooling.conformance` -> 36 passed, 0 failed
- `./scripts/release-check metadata` -> passed
- `git diff --check` -> clean
