### PR TITLE
contract v2.4.0: disposition default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Contract disposition default** (#472). The `contract` skill now names
+  regenerate as the default disposition for review-discovered contract
+  defects. A delivery keeps its branch only by proving
+  qualification-to-remain on every declared dimension, using a teeth-style
+  check that rejects patched branches carrying structure a fresh derivation
+  would not. Boundaries are necessary but not sufficient, unclear
+  qualification regenerates, and the new `Refine-default` corruption mode
+  captures the replaced branch-keeps-by-default stance. contract 2.3.0->2.4.0.
 - **Gate-form behavior now runs through the runtime artifact spine** (#454).
   `behavior-contract`, `implementation-plan`, `test-evidence`, and
   `completion-evidence` now require `behavior_form` and accept either

--- a/skills/contract/SKILL.md
+++ b/skills/contract/SKILL.md
@@ -11,8 +11,8 @@ description: >-
   or completion claims must stay traceable to a defined contract instead of
   drifting toward implementation convenience.
 metadata:
-  version: "2.3.0"
-  updated: "2026-06-19"
+  version: "2.4.0"
+  updated: "2026-06-24"
 ---
 
 # Contract
@@ -50,6 +50,39 @@ doc-less delivery fails. Code quality earns them through corpus principles
 projected onto the change, each a locus a careless change fails. Forcing
 one form — a test — onto every dimension is the mistake; the constant is
 the failing-hollow-delivery test, not the apparatus that runs it.
+
+## The disposition default
+
+Teeth governs authoring: a dimension's criterion is real only when a
+hollow delivery fails it. The disposition default governs review: when a
+delivery is reviewed against the contract and a defect is found, the
+delivery does not keep its branch by default. The **default disposition is
+regenerate**. The implementation, planning through submission, carries the
+burden of proof; the contract is corrected at its home and the unit is
+regenerated, unless the delivery proves it qualifies to remain.
+
+**Qualification-to-remain is positive, per-dimension, and conjunctive.** A
+delivery qualifies only when it proves, on every declared contract
+dimension, that correcting the defect leaves the derivation as sound and
+elegant as a fresh derivation from the corrected contract; failing the
+proof on any one dimension regenerates.
+
+The qualification test has teeth form per dimension: *could a patched
+branch pass this dimension while carrying structure a fresh derivation from
+the corrected contract would not?* If yes, the branch fails to qualify and
+the unit regenerates. A reviewer can point at the dimension whose proof
+failed; the test never resolves to an uncheckable judgment.
+
+**A boundary is necessary, not sufficient.** A correction having a boundary
+does not qualify the branch. The boundary must be small enough that the
+in-place fix is indistinguishable from a fresh derivation. When
+qualification is not clear, the default decides: regenerate.
+
+This stance is the review sibling of the teeth principle, not a rewrite of
+the behavioral failing-test classification. `When an existing test fails
+after a change` decides where the defect lives: bug introduced, behavior
+moved, or behavior obsolete. The disposition default decides what survives
+after the defect is known to be a contract defect.
 
 ## The dimensions
 
@@ -355,6 +388,12 @@ hollow delivery that would fail it.
 instead of consulting it — a code-quality rulebook paraphrasing the corpus,
 a documentation checklist re-listing the audience taxonomy `orient` already
 owns. *Recognition:* two homes for one truth, kept in agreement by hand.
+
+**Refine-default.** A defective branch keeps its branch by default, or a
+strictly-bounded-but-large correction is routed to an in-place fix even
+when a fresh derivation would be simpler or sounder. *Recognition:* the
+delivery is patched because a boundary can be named, not because every
+declared dimension proves qualification-to-remain.
 
 ## Principles
 

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -66,9 +66,9 @@ def top_section(body: str, heading: str) -> str:
 
 def nested_section(body: str, heading: str, level: int) -> str:
     marks = "#" * level
-    next_heading = "#" * min(level, 6)
+    parent_or_sibling_heading = rf"#{{1,{min(level, 6)}}}"
     pattern = re.compile(
-        rf"^{marks} {re.escape(heading)}\n(?P<section>.*?)(?=^{next_heading}#* |\Z)",
+        rf"^{marks} {re.escape(heading)}\n(?P<section>.*?)(?=^{parent_or_sibling_heading} |\Z)",
         flags=re.MULTILINE | re.DOTALL,
     )
     match = pattern.search(body)
@@ -87,6 +87,23 @@ def lifecycle_rows(body: str) -> dict[str, str]:
 
 
 class ContractSkillLifecycleTests(unittest.TestCase):
+    def test_nested_section_stops_at_parent_heading(self) -> None:
+        body = """## Parent
+### Sibling
+#### Target
+target content
+##### Child
+child content
+## Next Parent
+outside content
+"""
+
+        result = nested_section(body, "Target", 4)
+
+        self.assertIn("target content", result)
+        self.assertIn("child content", result)
+        self.assertNotIn("outside content", result)
+
     def test_contract_version_and_changelog_record_disposition_default(self) -> None:
         body = read(CONTRACT_SKILL)
         changelog = read(CHANGELOG)

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+CHANGELOG = ROOT / "CHANGELOG.md"
 CONTRACT_SURFACE = [
     CONTRACT_SKILL,
     ROOT / "skills" / "contract" / "references" / "documentation-contract.md",
@@ -52,6 +53,30 @@ def section(body: str, heading: str) -> str:
     return match.group("section")
 
 
+def top_section(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^## {re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing section: {heading}")
+    return match.group("section")
+
+
+def nested_section(body: str, heading: str, level: int) -> str:
+    marks = "#" * level
+    next_heading = "#" * min(level, 6)
+    pattern = re.compile(
+        rf"^{marks} {re.escape(heading)}\n(?P<section>.*?)(?=^{next_heading}#* |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing section: {heading}")
+    return match.group("section")
+
+
 def lifecycle_rows(body: str) -> dict[str, str]:
     rows = {}
     for line in body.splitlines():
@@ -62,6 +87,96 @@ def lifecycle_rows(body: str) -> dict[str, str]:
 
 
 class ContractSkillLifecycleTests(unittest.TestCase):
+    def test_contract_version_and_changelog_record_disposition_default(self) -> None:
+        body = read(CONTRACT_SKILL)
+        changelog = read(CHANGELOG)
+
+        self.assertIn('version: "2.4.0"', body)
+        self.assertIn('updated: "2026-06-24"', body)
+        self.assertEqual(1, changelog.splitlines().count("## [Unreleased]"))
+        self.assertIn("**Contract disposition default** (#472)", changelog)
+        self.assertIn("contract 2.3.0->2.4.0", changelog)
+
+    def test_disposition_default_is_sibling_of_teeth_principle(self) -> None:
+        body = read(CONTRACT_SKILL)
+
+        self.assertIn("## The disposition default", body)
+        teeth_index = body.index("## The teeth principle")
+        disposition_index = body.index("## The disposition default")
+        dimensions_index = body.index("## The dimensions")
+
+        self.assertLess(teeth_index, disposition_index)
+        self.assertLess(disposition_index, dimensions_index)
+        self.assertNotIn("## The dimensions", body[teeth_index:disposition_index])
+
+    def test_disposition_default_defines_regenerate_as_the_review_default(self) -> None:
+        disposition = normalized(top_section(read(CONTRACT_SKILL), "The disposition default"))
+
+        for expected in [
+            "default disposition is regenerate",
+            "implementation, planning through submission, carries the burden of proof",
+            "contract is corrected",
+            "unit is regenerated",
+            "unless the delivery proves it qualifies to remain",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, disposition)
+
+    def test_qualification_to_remain_is_positive_per_dimension_and_conjunctive(self) -> None:
+        disposition = normalized(top_section(read(CONTRACT_SKILL), "The disposition default"))
+
+        for expected in [
+            "Qualification-to-remain is positive, per-dimension, and conjunctive",
+            "every declared contract dimension",
+            "as sound and elegant as a fresh derivation from the corrected contract",
+            "failing the proof on any one dimension regenerates",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, disposition)
+
+        self.assertNotRegex(disposition, r"preference|feels bounded|clearly bounded")
+
+    def test_qualification_test_uses_teeth_form_and_boundary_default(self) -> None:
+        disposition = normalized(top_section(read(CONTRACT_SKILL), "The disposition default"))
+
+        for expected in [
+            "could a patched branch pass this dimension while carrying structure a fresh derivation from the corrected contract would not",
+            "A boundary is necessary, not sufficient",
+            "small enough that the in-place fix is indistinguishable from a fresh derivation",
+            "When qualification is not clear, the default decides: regenerate",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, disposition)
+
+    def test_disposition_default_stays_distinct_from_failing_test_classification(self) -> None:
+        body = read(CONTRACT_SKILL)
+        disposition = normalized(top_section(body, "The disposition default"))
+        failing_test = normalized(nested_section(body, "When an existing test fails after a change", 4))
+
+        for expected in [
+            "where the defect lives",
+            "what survives",
+            "`When an existing test fails after a change`",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, disposition)
+
+        self.assertNotIn("qualifies to remain", failing_test)
+        self.assertNotIn("default disposition is regenerate", failing_test)
+
+    def test_refine_default_corruption_mode_is_named(self) -> None:
+        corruption_modes = normalized(top_section(read(CONTRACT_SKILL), "Corruption Modes"))
+
+        for expected in [
+            "**Refine-default.**",
+            "defective branch keeps its branch by default",
+            "strictly-bounded-but-large correction",
+            "in-place fix",
+            "fresh derivation would be simpler or sounder",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, corruption_modes)
+
     def test_lifecycle_matrix_covers_every_dimension_stage_cell(self) -> None:
         rows = lifecycle_rows(read(CONTRACT_SKILL))
         expected_cells = {


### PR DESCRIPTION
## Summary

- Add the contract skill's disposition default as the review sibling of the teeth principle: review-discovered contract defects default to regenerate.
- Define qualification-to-remain as positive, per-dimension, conjunctive, and teeth-style, with boundaries necessary but not sufficient.
- Add lifecycle gates for the new contract surface and record the contract 2.3.0->2.4.0 changelog entry.

Closes #472.

## Verification

- RED: `python -m unittest tests.test_contract_skill_lifecycle` failed on the missing v2.4.0 disposition surface before the contract/changelog edits.
- GREEN focused: `python -m unittest tests.test_contract_skill_lifecycle tests.test_reference_links tests.test_principles_coherence` passed 21 tests.
- Full: `python -m unittest discover -s tests` passed 402 tests.
- Plan-review gate: `python -m tooling.conformance` passed 36/36.
- Plan-review gate: `./scripts/release-check metadata` passed.
