### PR TITLE
deprecate(install): groundwork-install warns + redirects on canonical-managed targets

### DIFF
--- a/scripts/groundwork-install
+++ b/scripts/groundwork-install
@@ -3,6 +3,9 @@ set -euo pipefail
 
 PROGRAM="groundwork-install"
 MARKER=".groundwork-install"
+CANONICAL_MARKER=".groundwork-managed"
+CANONICAL_INSTALLER="scripts/install"
+DEPRECATION_REF="groundwork#415"
 STATE_FILE_NAME="interactive-install.tsv"
 SESSION_SURFACE_HANDOFF_PATH="scripts/interactive-session-surface-handoff.md"
 
@@ -192,8 +195,29 @@ target_has_marker() {
   [[ -f "$1/$MARKER" ]]
 }
 
+target_has_canonical_marker() {
+  [[ -f "$1/$CANONICAL_MARKER" ]]
+}
+
 target_exists() {
   [[ -e "$1" || -L "$1" ]]
+}
+
+deprecation_notice() {
+  printf '%s: DEPRECATED — superseded by the canonical installer %s (tooling/install.py); see %s.\n' \
+    "$PROGRAM" "$CANONICAL_INSTALLER" "$DEPRECATION_REF" >&2
+  printf '%s: this fallback remains only until the runtime-driven install is acceptance-proven. Prefer %s.\n' \
+    "$PROGRAM" "$CANONICAL_INSTALLER" >&2
+}
+
+report_conflict() {
+  local target="$1"
+  if target_has_canonical_marker "$target"; then
+    printf '%s: %s is owned by the canonical installer %s (marker %s); %s is deprecated (%s). Use %s — to switch, run: %s uninstall\n' \
+      "$PROGRAM" "$target" "$CANONICAL_INSTALLER" "$CANONICAL_MARKER" "$PROGRAM" "$DEPRECATION_REF" "$CANONICAL_INSTALLER" "$CANONICAL_INSTALLER" >&2
+  else
+    printf '%s: unmanaged conflict at %s\n' "$PROGRAM" "$target" >&2
+  fi
 }
 
 desired_name_exists() {
@@ -226,7 +250,7 @@ preflight_conflicts() {
       target="$root/$name"
       if target_exists "$target"; then
         if ! state_owns_target "$target"; then
-          printf '%s: unmanaged conflict at %s\n' "$PROGRAM" "$target" >&2
+          report_conflict "$target"
           conflict=1
         fi
       fi
@@ -235,7 +259,7 @@ preflight_conflicts() {
   if runtime_available; then
     target="$(runtime_root)"
     if target_exists "$target" && ! target_has_marker "$target"; then
-      printf '%s: unmanaged conflict at %s\n' "$PROGRAM" "$target" >&2
+      report_conflict "$target"
       conflict=1
     fi
   fi
@@ -514,6 +538,7 @@ write_state() {
 }
 
 install_or_sync() {
+  deprecation_notice
   validate_source
   preflight_conflicts
   prepare_target_roots

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -547,6 +547,50 @@ class GroundworkInstallTests(unittest.TestCase):
         self.assertTrue(install.target(".agents", "orient").is_dir())
         self.assertEqual(install.state_file().read_text(encoding="utf-8"), before_state)
 
+    def test_install_redirects_skill_target_owned_by_canonical_installer(self) -> None:
+        fixture = self.add_fixture("canonical-skill-conflict")
+        install = InstallRun(self, fixture.root)
+        conflict = install.target(".claude", "orient")
+        conflict.mkdir(parents=True)
+        (conflict / "SKILL.md").write_text("# Canonical\n", encoding="utf-8")
+        (conflict / ".groundwork-managed").write_text("managed-by=groundwork\n", encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        self.assertNotEqual(result.returncode, 0, "command unexpectedly succeeded")
+        self.assertIn("scripts/install", result.stderr)
+        self.assertNotIn("unmanaged conflict at %s" % conflict, result.stderr)
+        self.assertEqual((conflict / "SKILL.md").read_text(encoding="utf-8"), "# Canonical\n")
+        self.assertFalse((install.home / ".agents" / "skills" / "take").exists())
+        self.assertFalse(install.state_file().exists())
+
+    def test_install_redirects_runtime_owned_by_canonical_installer(self) -> None:
+        fixture = self.add_fixture("canonical-runtime-conflict")
+        self.write_runtime_surface(fixture)
+        fixture.commit_new_ref("v2")
+        install = InstallRun(self, fixture.root)
+        runtime = install.runtime_root()
+        runtime.mkdir()
+        (runtime / "manifest.toml").write_text("[methodology]\n", encoding="utf-8")
+        (runtime / ".groundwork-managed").write_text("managed-by=groundwork\n", encoding="utf-8")
+
+        result = install.run_installer("install")
+
+        self.assertNotEqual(result.returncode, 0, "command unexpectedly succeeded")
+        self.assertIn("scripts/install", result.stderr)
+        self.assertTrue((runtime / ".groundwork-managed").is_file())
+        self.assertFalse(install.state_file().exists())
+
+    def test_install_emits_deprecation_notice(self) -> None:
+        fixture = self.add_fixture("deprecation-notice")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertIn("DEPRECATED", result.stderr)
+        self.assertIn("scripts/install", result.stderr)
+
     def test_install_rejects_unmanaged_conflicts_before_changing_targets(self) -> None:
         fixture = self.add_fixture("conflict")
         install = InstallRun(self, fixture.root)


### PR DESCRIPTION
## What

Two honest-signal additions to the legacy `scripts/groundwork-install`, with **no change** to its install/sync/status/uninstall behavior:

1. Every `install`/`sync` emits a loud deprecation notice naming the canonical successor `scripts/install`.
2. `preflight_conflicts` now recognizes the canonical marker `.groundwork-managed`: a target owned by `scripts/install` reports an actionable redirect ("use `scripts/install`; to switch, run: `scripts/install uninstall`") instead of the opaque `unmanaged conflict`. The bare conflict message is retained for genuinely foreign / legacy-marker / no-marker targets.

## Why

`groundwork-install` is the legacy fallback, superseded by `scripts/install` (`tooling/install.py`). #415 explicitly permits a deprecation notice ahead of removal, while removal itself stays gated on the runtime-driven install being acceptance-proven (`pentaxis93/babbie-ops#58`). This lands only the pre-authorized notice + an honest signal; it does **not** retire the fallback.

Surfaced by a babbie clean-room run that invoked the legacy script over a canonical `.groundwork-managed` install and received only `unmanaged conflict` with no redirect — the exact footgun the deprecation notice is meant to close.

## Tests

- `test_install_redirects_skill_target_owned_by_canonical_installer`
- `test_install_redirects_runtime_owned_by_canonical_installer`
- `test_install_emits_deprecation_notice`

Local `tests/test_groundwork_install.py`: 42 passed.

Refs #415.