### PR TITLE
fix(install): ship complete runtime bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Runtime-driven self-install ships the complete methodology layout**
+  (#482). `scripts/install` now derives the `~/.groundwork` runtime bundle
+  from `manifest.toml`, projecting every declared artifact schema and
+  protocol instruction file byte-identically beside the manifest. Missing
+  declared layout files fail before target mutation, complete re-runs leave
+  managed runtime files untouched, stale retired runtime children are pruned
+  without becoming managed content, and the runtime-driven install docs name
+  the complete bundle shape.
+
 - **Forge work now consumes the connector capability** (#440). Groundwork
   vendors Forge Capability v1.1.0 with immutable provenance, derives
   work-unit and change-proposal handles from its `{ id, display }` handle

--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ scripts/install install --corpus-git https://example.org/owner/corpus
   unmodified in `~/.claude/skills/<name>` and `~/.agents/skills/<name>`.
   Skills are agent-invoked by judgment and are not runtime-delivered, so they
   install natively; no projection or rewriting of any kind.
-- **The methodology runtime** — `~/.groundwork` with the manifest. Forge
-  operations are connector capability tools contributed through runa's MCP
-  surface, not local provider mechanics.
+- **The methodology runtime** — `~/.groundwork` with `manifest.toml`,
+  `schemas/{artifact_type}.schema.json` for each declared artifact type, and
+  `protocols/{name}/PROTOCOL.md` for each declared protocol. Forge operations
+  are connector capability tools contributed through runa's MCP surface, not
+  local provider mechanics.
 - **The principles corpus** — the `--corpus-git URL [--corpus-ref REF]`,
   `--corpus-path PATH`, or `--corpus-embedded` operator input is recorded in
   the deployment-owned `${XDG_CONFIG_HOME:-~/.config}/groundwork/principles.toml`

--- a/docs/architecture/decisions/0006-runtime-driven-self-install-surface.md
+++ b/docs/architecture/decisions/0006-runtime-driven-self-install-surface.md
@@ -35,11 +35,12 @@ exactly three surfaces and carries no projection machinery:
    `~/.agents/skills/<name>`, enumerated from the tree at the source
    commit. No transformation of any shipped file; the only added file is
    the ownership marker.
-2. **The methodology runtime.** `~/.groundwork` with `manifest.toml` and
-   the ownership marker. Provider mechanics, forge-operations modules, and
-   resolver binaries are retired runtime children; they are pruned on
-   upgrade rather than projected or replaced. Forge operations are
-   connector capability tools supplied through runa's MCP surface, not
+2. **The methodology runtime.** `~/.groundwork` is a self-contained
+   methodology layout: `manifest.toml`,
+   `schemas/{artifact_type}.schema.json` for each manifest-declared
+   artifact type, `protocols/{name}/PROTOCOL.md` for each
+   manifest-declared protocol, and the ownership marker. Forge operations
+   are connector capability tools supplied through runa's MCP surface, not
    installed runtime children.
 3. **The principles corpus.** The corpus source is an operator input
    (`--corpus-git URL [--corpus-ref REF]` | `--corpus-path PATH` |
@@ -74,7 +75,7 @@ write — including protocol projections it must never manage.
 
 - Re-running converges with exit 0 and leaves every managed inode
   untouched (compare-before-swap on all three surfaces, including the
-  recorded config and the state file).
+  runtime bundle files, recorded config, and state file).
 - An entry installed previously but no longer shipped is removed; removal
   is gated on this installer's own marker, and a missing marker at a
   deletion boundary fails loudly with state intact.

--- a/tests/test_forge_capability.py
+++ b/tests/test_forge_capability.py
@@ -199,9 +199,13 @@ class ForgeCapabilityTests(unittest.TestCase):
         self.assertNotIn("GitHub handles name an issue URL and number", connecting_structure)
         self.assertNotIn("SourceHut handles name a tracker ID and ticket number", connecting_structure)
 
-        self.assertRegex(adr_0006, r"`~/.groundwork` with `manifest\.toml` and\s+the ownership marker")
-        self.assertRegex(adr_0006, r"mechanics, forge-operations modules, and\s+resolver binaries are retired")
-        self.assertRegex(adr_0006, r"pruned on\s+upgrade")
+        self.assertRegex(adr_0006, r"`~/.groundwork` is a self-contained\s+methodology layout")
+        self.assertIn("`schemas/{artifact_type}.schema.json`", adr_0006)
+        self.assertIn("`protocols/{name}/PROTOCOL.md`", adr_0006)
+        self.assertIn("connector capability tools supplied through runa's MCP surface", adr_0006)
+        self.assertNotIn("mechanics, forge-operations modules, and", adr_0006)
+        self.assertNotIn("resolver binaries are retired", adr_0006)
+        self.assertNotIn("pruned on upgrade", adr_0006)
         self.assertNotIn("`mechanics/`, the forge-operations module", adr_0006)
         self.assertNotIn("bin/connector capability tool", adr_0006)
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import tempfile
 import textwrap
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -21,6 +22,27 @@ ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "scripts" / "install"
 MARKER_NAME = ".groundwork-managed"
 LEGACY_MARKER_NAME = ".groundwork-install"
+
+
+def runa_binary() -> Path | None:
+    configured = os.environ.get("GROUNDWORK_RUNA_BIN")
+    if configured:
+        configured_path = Path(configured)
+        if configured_path.is_file():
+            return configured_path
+    discovered = shutil.which("runa")
+    if discovered:
+        return Path(discovered)
+    for candidate in [
+        ROOT.parent / "runa" / "target" / "release" / "runa",
+        ROOT.parent / "runa" / "target" / "debug" / "runa",
+    ]:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+RUNA = runa_binary()
 
 
 def run(
@@ -94,12 +116,50 @@ class MethodologyFixture:
         self.write("skills/reckon/SKILL.md", "---\nname: reckon\n---\n# Reckon\n")
         self.write("skills/reckon/references/example.md", "reckon reference\n")
         self.write("protocols/take/PROTOCOL.md", "---\nname: take\n---\n# Take\n")
+        self.write(
+            "schemas/work-unit.schema.json",
+            """
+            {
+              "type": "object",
+              "required": ["title"],
+              "properties": {"title": {"type": "string"}}
+            }
+            """,
+        )
+        self.write(
+            "schemas/behavior-contract.schema.json",
+            """
+            {
+              "type": "object",
+              "required": ["work_unit", "title"],
+              "properties": {
+                "work_unit": {"type": "string"},
+                "title": {"type": "string"}
+              }
+            }
+            """,
+        )
         self.write("principles/PRINCIPLES.md", "# Principles\n\n1. Understand.\n")
         self.write(
             "manifest.toml",
             """
+            name = "groundwork"
+
+            [[artifact_types]]
+            name = "work-unit"
+
+            [[artifact_types]]
+            name = "behavior-contract"
+
             [[mechanics]]
             name = "read-artifact"
+
+            [[protocols]]
+            name = "take"
+            requires = ["work-unit"]
+            produces = ["behavior-contract"]
+            scoped = true
+            trigger = { type = "on_artifact", name = "work-unit" }
             """,
         )
 
@@ -184,6 +244,26 @@ class SelfInstallTests(unittest.TestCase):
         self.addCleanup(fixture.cleanup)
         return fixture
 
+    def manifest_declared_runtime_paths(self, manifest: Path) -> set[str]:
+        document = tomllib.loads(manifest.read_text(encoding="utf-8"))
+        artifact_paths = {
+            f"schemas/{entry['name']}.schema.json"
+            for entry in document.get("artifact_types", [])
+        }
+        protocol_paths = {
+            f"protocols/{entry['name']}/PROTOCOL.md"
+            for entry in document.get("protocols", [])
+        }
+        return {"manifest.toml"} | artifact_paths | protocol_paths
+
+    def managed_runtime_files(self, runtime: Path) -> dict[str, Path]:
+        return {
+            str(path.relative_to(runtime)): path
+            for path in sorted(runtime.rglob("*"))
+            if path.is_file()
+            and path.relative_to(runtime).parts[0] in {"manifest.toml", "schemas", "protocols", MARKER_NAME}
+        }
+
     def test_install_places_skills_byte_identical_in_both_discovery_roots(self) -> None:
         fixture = self.add_fixture("skills-verbatim")
         install = InstallRun(self, fixture.root)
@@ -213,12 +293,70 @@ class SelfInstallTests(unittest.TestCase):
         result = install.run_installer("install")
 
         assert_success(self, result)
-        self.assertEqual(
-            (install.runtime_root() / "manifest.toml").read_bytes(),
-            (fixture.root / "manifest.toml").read_bytes(),
-        )
+        runtime_payload = tree_payload(install.runtime_root(), exclude=frozenset({MARKER_NAME, "principles"}))
+        for relative in self.manifest_declared_runtime_paths(fixture.root / "manifest.toml"):
+            self.assertEqual(
+                (install.runtime_root() / relative).read_bytes(),
+                (fixture.root / relative).read_bytes(),
+                f"{relative} did not project byte-identically",
+            )
+            self.assertIn(relative, runtime_payload)
         self.assertFalse((install.runtime_root() / "mechanics").exists())
         self.assertFalse((install.runtime_root() / "bin" / "groundwork-mechanic").exists())
+
+    def test_runtime_bundle_projection_is_derived_from_manifest_declarations(self) -> None:
+        fixture = self.add_fixture("manifest-derived-runtime")
+        fixture.write(
+            "schemas/research-record.schema.json",
+            '{"type":"object","required":["topic"],"properties":{"topic":{"type":"string"}}}\n',
+        )
+        fixture.write("protocols/plan/PROTOCOL.md", "# Plan\n")
+        fixture.write(
+            "manifest.toml",
+            """
+            name = "groundwork"
+
+            [[artifact_types]]
+            name = "work-unit"
+
+            [[artifact_types]]
+            name = "behavior-contract"
+
+            [[artifact_types]]
+            name = "research-record"
+
+            [[mechanics]]
+            name = "read-artifact"
+
+            [[outcome_types]]
+            name = "behavior-contract"
+
+            [[protocols]]
+            name = "take"
+            requires = ["work-unit"]
+            produces = ["behavior-contract"]
+            scoped = true
+            trigger = { type = "on_artifact", name = "work-unit" }
+
+            [[protocols]]
+            name = "plan"
+            requires = ["behavior-contract"]
+            produces = ["research-record"]
+            scoped = true
+            trigger = { type = "on_artifact", name = "behavior-contract" }
+            """,
+        )
+        fixture.commit("add declared runtime entries")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        self.assertEqual(
+            self.manifest_declared_runtime_paths(fixture.root / "manifest.toml"),
+            set(self.managed_runtime_files(install.runtime_root())) - {MARKER_NAME},
+        )
+        self.assertFalse((install.runtime_root() / "mechanics").exists())
 
     def test_install_runtime_bundle_has_no_retired_provider_resolver_or_mechanics(self) -> None:
         fixture = self.add_fixture("post-retirement-runtime")
@@ -252,6 +390,8 @@ class SelfInstallTests(unittest.TestCase):
         assert_success(self, result)
         self.assertTrue((runtime / "manifest.toml").is_file())
         self.assertTrue((runtime / MARKER_NAME).is_file())
+        self.assertTrue((runtime / "schemas" / "work-unit.schema.json").is_file())
+        self.assertTrue((runtime / "protocols" / "take" / "PROTOCOL.md").is_file())
         self.assertFalse((runtime / "mechanics").exists())
         self.assertFalse((runtime / "lib" / "tooling" / "forge_operations.py").exists())
         self.assertFalse((runtime / "bin" / "groundwork-mechanic").exists())
@@ -411,6 +551,72 @@ class SelfInstallTests(unittest.TestCase):
         assert_success(self, result)
         self.assertEqual(self.stat_snapshot(install.home, install.state), before)
 
+    def test_second_run_does_not_rewrite_managed_runtime_bundle_files(self) -> None:
+        fixture = self.add_fixture("idempotent-runtime-bundle")
+        install = InstallRun(self, fixture.root)
+        assert_success(self, install.run_installer("install"))
+        fixed_time = 1_700_000_000_000_000_000
+        files = self.managed_runtime_files(install.runtime_root())
+        for path in files.values():
+            os.utime(path, ns=(fixed_time, fixed_time))
+        before = {
+            relative: (path.read_bytes(), path.stat().st_mtime_ns)
+            for relative, path in files.items()
+        }
+
+        result = install.run_installer("install")
+
+        assert_success(self, result)
+        after_files = self.managed_runtime_files(install.runtime_root())
+        self.assertEqual(set(before), set(after_files))
+        self.assertEqual(
+            {
+                relative: (path.read_bytes(), path.stat().st_mtime_ns)
+                for relative, path in after_files.items()
+            },
+            before,
+        )
+
+    def test_missing_manifest_declared_schema_fails_before_target_mutation(self) -> None:
+        fixture = self.add_fixture("missing-declared-schema")
+        fixture.remove("schemas/behavior-contract.schema.json")
+        fixture.commit("drop declared schema")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "schemas/behavior-contract.schema.json")
+        for surface in [".claude", ".agents", ".groundwork"]:
+            self.assertFalse((install.home / surface).exists(), f"{surface} must be untouched")
+
+    def test_missing_manifest_declared_protocol_fails_before_target_mutation(self) -> None:
+        fixture = self.add_fixture("missing-declared-protocol")
+        fixture.remove("protocols/take")
+        fixture.commit("drop declared protocol")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "protocols/take/PROTOCOL.md")
+        for surface in [".claude", ".agents", ".groundwork"]:
+            self.assertFalse((install.home / surface).exists(), f"{surface} must be untouched")
+
+    @unittest.skipUnless(RUNA is not None, "runa binary unavailable")
+    def test_installed_runtime_bundle_initializes_runa_project(self) -> None:
+        assert RUNA is not None
+        fixture = self.add_fixture("runa-init-runtime-bundle")
+        install = InstallRun(self, fixture.root)
+        project = Path(tempfile.mkdtemp(prefix="groundwork-self-install-runa-project-"))
+        self.addCleanup(lambda: shutil.rmtree(project, ignore_errors=True))
+        assert_success(self, install.run_installer("install"))
+
+        result = run(
+            [str(RUNA), "init", "--methodology", str(install.runtime_root() / "manifest.toml")],
+            project,
+        )
+
+        assert_success(self, result)
+        self.assertTrue((project / ".runa" / "config.toml").is_file())
 
     def test_skill_removed_from_tree_is_removed_on_rerun(self) -> None:
         fixture = self.add_fixture("stale-skill")
@@ -548,12 +754,12 @@ class SelfInstallTests(unittest.TestCase):
         result = install.run_installer("uninstall")
 
         assert_success(self, result)
+        self.assertTrue((operator_skill / "SKILL.md").is_file(), "unmanaged content must survive")
         for root in [".claude", ".agents"]:
             for name in ["orient", "reckon"]:
                 self.assertFalse(install.target(root, name).exists())
         self.assertFalse(install.runtime_root().exists())
         self.assertFalse(install.state_file().exists())
-        self.assertTrue((operator_skill / "SKILL.md").is_file(), "unmanaged content must survive")
         self.assertTrue(install.config_file().is_file(), "deployment-owned config must survive")
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -601,6 +601,39 @@ class SelfInstallTests(unittest.TestCase):
         for surface in [".claude", ".agents", ".groundwork"]:
             self.assertFalse((install.home / surface).exists(), f"{surface} must be untouched")
 
+    def test_unsafe_manifest_entry_name_fails_without_staging_escape(self) -> None:
+        fixture = self.add_fixture("unsafe-runtime-name")
+        fixture.write(
+            "manifest.toml",
+            """
+            name = "groundwork"
+
+            [[artifact_types]]
+            name = "../../escaped/work-unit"
+
+            [[protocols]]
+            name = "take"
+            requires = ["work-unit"]
+            produces = ["work-unit"]
+            scoped = true
+            trigger = { type = "on_artifact", name = "work-unit" }
+            """,
+        )
+        fixture.commit("declare unsafe artifact name")
+        install = InstallRun(self, fixture.root)
+
+        result = install.run_installer("install")
+
+        assert_failure_contains(self, result, "safe single path component")
+        assert_failure_contains(self, result, "../../escaped/work-unit")
+        for surface in [".claude", ".agents", ".groundwork", "escaped"]:
+            self.assertFalse((install.home / surface).exists(), f"{surface} must be untouched")
+        self.assertEqual(
+            [],
+            [path for path in install.home.iterdir() if path.name.startswith(".groundwork.bundle.")],
+            "failed projection must not leave staging directories behind",
+        )
+
     @unittest.skipUnless(RUNA is not None, "runa binary unavailable")
     def test_installed_runtime_bundle_initializes_runa_project(self) -> None:
         assert RUNA is not None

--- a/tooling/install.py
+++ b/tooling/install.py
@@ -242,13 +242,16 @@ def show_file(source: Path, sha: str, file_path: str) -> bytes:
 
 def project_runtime_bundle(source: Path, sha: str, target: Path) -> None:
     """Build the methodology runtime bundle into ``target``."""
-    target.mkdir(parents=True, exist_ok=True)
     manifest = show_file(source, sha, "manifest.toml")
+    layout_paths = runtime_layout_paths(manifest)
+    layout_payload = {relative: show_file(source, sha, relative) for relative in layout_paths}
+
+    target.mkdir(parents=True, exist_ok=True)
     (target / "manifest.toml").write_bytes(manifest)
-    for relative in runtime_layout_paths(manifest):
+    for relative, content in layout_payload.items():
         destination = target / relative
         destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_bytes(show_file(source, sha, relative))
+        destination.write_bytes(content)
 
 
 def runtime_layout_paths(manifest: bytes) -> list[str]:
@@ -267,8 +270,23 @@ def runtime_layout_paths(manifest: bytes) -> list[str]:
 
 def manifest_entry_name(entry: object, section: str) -> str:
     if isinstance(entry, dict) and isinstance(entry.get("name"), str):
-        return entry["name"]
+        name = entry["name"]
+        if is_safe_manifest_entry_name(name):
+            return name
+        raise InstallError(
+            f"manifest.toml [[{section}]] name {name!r} must be a safe single path component"
+        )
     raise InstallError(f"manifest.toml [[{section}]] entries must declare string name")
+
+
+def is_safe_manifest_entry_name(name: str) -> bool:
+    return (
+        bool(name)
+        and name != "."
+        and "/" not in name
+        and "\\" not in name
+        and ".." not in name
+    )
 
 
 # The runtime-bundle children this installer manages under `~/.groundwork`.

--- a/tooling/install.py
+++ b/tooling/install.py
@@ -8,7 +8,9 @@ it. It owns exactly what that channel does not deliver:
 - **Skills, verbatim** — every ``skills/<name>/`` carrying a ``SKILL.md``
   installs unmodified into the agent harnesses' native skill-discovery
   locations. No projection, no transformation of any shipped file.
-- **The methodology runtime** — ``~/.groundwork`` with the manifest.
+- **The methodology runtime** — ``~/.groundwork`` with ``manifest.toml``,
+  every manifest-declared artifact schema, and every manifest-declared
+  protocol instruction file.
 - **The principles corpus** — an operator input recorded into the
   deployment-owned config (ADR-0005) and materialized at
   ``~/.groundwork/principles`` through the existing resolution layer.
@@ -25,6 +27,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import tomllib
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
@@ -240,36 +243,75 @@ def show_file(source: Path, sha: str, file_path: str) -> bytes:
 def project_runtime_bundle(source: Path, sha: str, target: Path) -> None:
     """Build the methodology runtime bundle into ``target``."""
     target.mkdir(parents=True, exist_ok=True)
-    (target / "manifest.toml").write_bytes(show_file(source, sha, "manifest.toml"))
+    manifest = show_file(source, sha, "manifest.toml")
+    (target / "manifest.toml").write_bytes(manifest)
+    for relative in runtime_layout_paths(manifest):
+        destination = target / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(show_file(source, sha, relative))
+
+
+def runtime_layout_paths(manifest: bytes) -> list[str]:
+    """Runtime layout files derived from the methodology manifest."""
+    try:
+        document = tomllib.loads(manifest.decode("utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError) as error:
+        raise InstallError(f"cannot parse manifest.toml: {error}") from error
+    paths = []
+    for entry in document.get("artifact_types", []):
+        paths.append(f"schemas/{manifest_entry_name(entry, 'artifact_types')}.schema.json")
+    for entry in document.get("protocols", []):
+        paths.append(f"protocols/{manifest_entry_name(entry, 'protocols')}/PROTOCOL.md")
+    return paths
+
+
+def manifest_entry_name(entry: object, section: str) -> str:
+    if isinstance(entry, dict) and isinstance(entry.get("name"), str):
+        return entry["name"]
+    raise InstallError(f"manifest.toml [[{section}]] entries must declare string name")
 
 
 # The runtime-bundle children this installer manages under `~/.groundwork`.
 # The resolved corpus (`principles/`) lives beside them and is converged
 # separately — bundle convergence never rebuilds the whole root.
-RUNTIME_BUNDLE_CHILDREN = ("manifest.toml", "mechanics", "lib", "bin", MARKER_NAME)
+RUNTIME_BUNDLE_CHILDREN = ("manifest.toml", "schemas", "protocols", MARKER_NAME)
+RETIRED_RUNTIME_BUNDLE_CHILDREN = ("mechanics", "lib", "bin")
 
 
-def converge_runtime_bundle(options: Options, sha: str) -> None:
-    runtime_root = options.home / ".groundwork"
+def stage_runtime_bundle(options: Options, sha: str) -> Path:
     staging = Path(tempfile.mkdtemp(prefix=".groundwork.bundle.", dir=options.home))
     try:
         project_runtime_bundle(options.source, sha, staging)
         write_marker(staging, options.source, sha, "runtime", "groundwork")
-        if runtime_root.is_dir() and tree_payload(staging, include_marker=True) == bundle_payload(
-            runtime_root
-        ):
-            return
-        runtime_root.mkdir(parents=True, exist_ok=True)
-        for child in RUNTIME_BUNDLE_CHILDREN:
-            current = runtime_root / child
-            if current.is_dir():
-                shutil.rmtree(current)
-            elif current.exists():
-                current.unlink()
-        for child in ("manifest.toml", MARKER_NAME):
-            (staging / child).replace(runtime_root / child)
-    finally:
+    except BaseException:
         shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return staging
+
+
+def converge_runtime_bundle(options: Options, staged: Path) -> None:
+    runtime_root = options.home / ".groundwork"
+    if (
+        runtime_root.is_dir()
+        and tree_payload(staged, include_marker=True) == bundle_payload(runtime_root)
+        and not has_retired_runtime_children(runtime_root)
+    ):
+        return
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    for child in (*RUNTIME_BUNDLE_CHILDREN, *RETIRED_RUNTIME_BUNDLE_CHILDREN):
+        current = runtime_root / child
+        if current.is_dir():
+            shutil.rmtree(current)
+        elif current.exists():
+            current.unlink()
+    for child in RUNTIME_BUNDLE_CHILDREN:
+        staged_child = staged / child
+        if staged_child.exists():
+            staged_child.replace(runtime_root / child)
+
+
+def has_retired_runtime_children(runtime_root: Path) -> bool:
+    return any((runtime_root / child).exists() for child in RETIRED_RUNTIME_BUNDLE_CHILDREN)
 
 
 def bundle_payload(runtime_root: Path) -> dict[str, bytes]:
@@ -546,15 +588,21 @@ def install(options: Options) -> None:
     corpus_config = effective_corpus_config(options)
     check_resolvable(corpus_config, embedded_corpus_path(options.source))
     preflight_conflicts(options, skills)
-    staged_corpus = stage_corpus(options, corpus_config)
+    staged_corpus: Path | None = None
+    staged_runtime: Path | None = None
     try:
+        staged_corpus = stage_corpus(options, corpus_config)
+        staged_runtime = stage_runtime_bundle(options, sha)
         record_corpus_config(options)
         remove_obsolete_entries(options, skills)
         converge_skills(options, sha, skills)
-        converge_runtime_bundle(options, sha)
+        converge_runtime_bundle(options, staged_runtime)
         swap_corpus(options, staged_corpus)
     finally:
-        shutil.rmtree(staged_corpus.parent, ignore_errors=True)
+        if staged_corpus is not None:
+            shutil.rmtree(staged_corpus.parent, ignore_errors=True)
+        if staged_runtime is not None:
+            shutil.rmtree(staged_runtime, ignore_errors=True)
     write_state(options, sha, skills)
     print(f"{PROGRAM}: installed {sha}")
 


### PR DESCRIPTION
## Summary

Fixes #482 by making the runtime-driven self-install produce a complete methodology layout under `~/.groundwork`, not just `manifest.toml`.

- Derives projected runtime files from `manifest.toml`: `schemas/{artifact_type}.schema.json` for every declared artifact type and `protocols/{name}/PROTOCOL.md` for every declared protocol.
- Stages the runtime bundle before target mutation so missing declared backing files fail closed with no install surface touched.
- Keeps retired `mechanics`, `lib`, and `bin` as prune-only children while managing `manifest.toml`, `schemas`, `protocols`, and the ownership marker.
- Preserves complete re-run idempotence for every managed runtime bundle file, including marker payload and mtimes.
- Updates README, ADR-0006, changelog, and the connector-model coherence test to name the complete manifest-derived runtime layout.

## Root Cause

`tooling/install.py` projected only `manifest.toml`, while runa resolves a methodology from conventional paths beside the manifest. A clean install therefore produced a runtime root whose manifest declared schemas and protocols that were absent from `~/.groundwork`.

## Validation

- `python -m unittest tests.test_install` (34 passed)
- `python -m unittest discover -s tests` (363 passed before commit)
- `python -m tooling.conformance` (21 passed, 0 failed)
- Focused #482 tests were first observed red against the old manifest-only behavior, then green after implementation.
- Optional local `runa init` acceptance test passed against the freshly installed runtime bundle.

Draft until review confirms the governance-thread contract is fully reflected.
