### PR TITLE
Contract skill states uniform dimension structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Uniform contract form** (#493). The `contract` skill now states the
+  invariant behind the #492 surfaces: every dimension uses the same
+  contract structure and the same performed-evidence obligation, while
+  checking apparatus varies only per criterion through `check_kind`
+  (`executable` or `attested`). Behavior is documented as one dimension
+  among N rather than the pipeline spine; documentation and code quality
+  now explicitly emit typed criteria into `contract.criteria[]`, and
+  attested judgment is recorded as findings in `completion-evidence.results[]`.
+  The contract skill moves from contract 2.4.0->2.5.0.
+
 - **One contract machine** (#492). The live `behavior-contract` artifact is
   renamed to `contract` and now carries dimension-agnostic `criteria[]` with
   criterion-level `check_kind`, `hollow_delivery`, and check descriptors.

--- a/protocols/verify/references/code-quality-review.md
+++ b/protocols/verify/references/code-quality-review.md
@@ -33,8 +33,13 @@ contract declared for this change; those are what this audit decides.
    is friction on the corpus — record it so the code-quality projection can
    grow. The corpus is the bounded asset the spiral acts on.
 
-The outcome — per-universal disposition and any follow-ups — is recorded in
-the verify report alongside the documentation audit.
+The declared code-quality criterion's performed result is recorded in
+`completion-evidence.results[]` as attested evidence: reviewer identity plus
+the per-universal disposition and finding for each selected universal or
+projection. The verify report remains the review narrative, and the
+`documentation` section remains the document-impact index — updated
+documents, documents verified accurate, and follow-up work-units — not the
+evidence home for a declared code-quality criterion.
 
 ## Cross-references
 

--- a/protocols/verify/references/documentation-review.md
+++ b/protocols/verify/references/documentation-review.md
@@ -52,7 +52,12 @@ The steps below keep the surrounding documentation honest against drift.
    change is incomplete until it is met or the gap is tracked as a follow-up
    work-unit.
 
-The outcome feeds the `documentation` section of `completion-evidence`.
+The declared documentation criterion's performed result is recorded in
+`completion-evidence.results[]` as attested evidence: reviewer identity plus
+the finding for each selected pillar or outcome. The `documentation` section
+remains the document-impact index — updated documents, documents verified
+accurate, and follow-up work-units — not the evidence home for a declared
+documentation criterion.
 
 ## Corruption Modes
 

--- a/skills/contract/SKILL.md
+++ b/skills/contract/SKILL.md
@@ -11,8 +11,8 @@ description: >-
   or completion claims must stay traceable to a defined contract instead of
   drifting toward implementation convenience.
 metadata:
-  version: "2.4.0"
-  updated: "2026-06-24"
+  version: "2.5.0"
+  updated: "2026-07-01"
 ---
 
 # Contract
@@ -21,8 +21,9 @@ A contract is the executable definition of done. It is **Contract-First**
 given concrete form — declare the seam, build to it, verify against it,
 keep the declaration the single home of the seam's truth — applied not to
 one aspect of a change but to every aspect that must hold when the work
-lands. A contract has dimensions; each declares what done means for one
-aspect, in the form that gives that aspect teeth.
+lands. A contract has dimensions, but every dimension enters the same
+surface: typed criteria in one structure, performed evidence in one
+structure, and only the criterion-level checking apparatus varying.
 
 This skill is the home of the contract across its dimensions. It declares
 the lifecycle as the single home for the contract surface: work-unit
@@ -43,13 +44,17 @@ decides nothing. Of every criterion, in every dimension, ask: *could a
 stub — a canned return, an absent doc, a rename that changes nothing — pass
 this?* If yes, it is hollow; sharpen it until a hollow delivery fails.
 
-The teeth principle is universal; the **form** of the check fits the
-dimension. Behavior earns teeth through executable scenarios a stub fails.
-Documentation earns them through a checklist of audience outcomes a
-doc-less delivery fails. Code quality earns them through corpus principles
-projected onto the change, each a locus a careless change fails. Forcing
-one form — a test — onto every dimension is the mistake; the constant is
-the failing-hollow-delivery test, not the apparatus that runs it.
+The teeth principle is universal because the contract has the **same
+contract structure** and the **same evidence obligation** for every
+dimension: every criterion in every dimension names the hollow delivery
+that would fail it, declares a statement of done, selects a criterion-level
+`check_kind`, and receives one performed result in
+`completion-evidence.results[]`. The checking apparatus may vary per
+criterion: `check_kind: "executable"` uses run or artifact evidence, and
+attested criteria with `check_kind: "attested"` use reviewer attestation
+with reviewer identity and a substantive finding. Apparatus variance is not
+structural variance; free-form reviewer prose outside the artifact is not
+evidence.
 
 ## The disposition default
 
@@ -86,11 +91,14 @@ after the defect is known to be a contract defect.
 
 ## The dimensions
 
-A contract declares the dimensions the work demands — behavior is always
-present; documentation and code quality are declared as the change
-warrants, and a subset is legitimate the way a contract need not
-exercise every code path. The lifecycle is inputs to validation ->
-validation defined -> validation performed, with validation carried through
+There is one contract machine. Every dimension a change demands is a
+first-class symmetric citizen in that machine: Behavior is one dimension
+among N, documentation and code quality carry the identical teeth
+obligation, and every dimension carries the same performed-evidence
+obligation. A subset of dimensions is legitimate the way a contract need
+not exercise every code path; what is illegitimate is a dimension present
+in lighter structure. The lifecycle is inputs to validation -> validation
+defined -> validation performed, with validation carried through
 `implement` and recorded at `land`.
 
 | Dimension | Lifecycle |
@@ -127,28 +135,29 @@ documentation contract; a user-facing capability may need dense user
 documentation inputs and ordinary code-quality projection. Silence is valid
 only after the dimension was considered and the general contract is enough.
 
-- **[Behavioral dimension](#the-behavioral-dimension)** — what the system
-  does. The most developed dimension and the worked exemplar below; its
-  form is BDD.
+- **[Behavior dimension](#the-behavior-dimension)** — what the system
+  does. Its common checking apparatus is BDD scenarios or
+  documentation-deliverable gates, emitted as typed criteria into the
+  uniform surface.
 - **[Documentation dimension](references/documentation-contract.md)** —
-  what each recipient can do once the work lands. Three sub-modules — user,
-  developer, discovery — each a checklist of audience outcomes.
+  what each recipient can do once the work lands. It consults `orient`'s
+  audience taxonomy and emits typed criteria into the uniform surface.
 - **[Code-quality dimension](references/code-quality-contract.md)** — what
-  must hold of the change's internal form: the relevant principles-corpus
-  universals projected onto the diff.
+  must hold of the change's internal form. It consults the principles corpus
+  and emits typed criteria into the uniform surface.
 
 New dimensions join here as they earn their place; satisfying the teeth
 principle and the inputs-defined-performed lifecycle is what makes a
 dimension one.
 
-## The behavioral dimension
+## The behavior dimension
 
-What the system does, specified once and traced everywhere. This is the
-contract's most developed dimension and the worked example of a dimension
-with teeth — the stub test below is the behavioral instance of the teeth
-principle above. Behavior is specified once, then everything traces to it:
-plans link decisions to scenarios, tests prove named scenarios,
-verification reports scenario-level coverage, landing records what coverage
+What the system does, specified once as criteria in the same contract
+surface every other dimension uses. BDD scenarios and
+documentation-deliverable gates are the behavior dimension's usual checking
+apparatus; they are not a privileged contract structure. Plans link
+decisions to the behavior criteria, tests or gates prove the named criteria,
+verification records performed results, and landing records what evidence
 shipped.
 
 Reference: [Dan North, Introducing BDD](https://dannorth.net/introducing-bdd/).
@@ -271,15 +280,16 @@ sections fails internal coherence.
 
 ### Carrying the Contract
 
-- **Implementation maps to behavior.** Every implementation increment names
-  the scenario it advances. Each RED test corresponds to a named scenario.
-  Work that cannot be traced to a scenario is unanchored — scope creep or a
-  missing specification; resolve which before proceeding.
-- **Behavior is the unit of progress.** Execution order follows behavior
-  gaps, not code adjacency. Work advances by proving another scenario.
-- **Completion is behavior coverage.** "All tests pass" is incomplete unless
-  it names which scenarios those tests prove and which criteria those
-  scenarios cover. Report coverage, not command output.
+- **Implementation maps to criteria.** Every implementation increment names
+  the contract criterion it advances. Each RED test or gate corresponds to
+  a named criterion. Work that cannot be traced to a criterion is unanchored
+  — scope creep or a missing specification; resolve which before proceeding.
+- **Contract criteria are the unit of progress.** Execution order follows
+  criteria gaps, not code adjacency. Work advances by proving another
+  criterion.
+- **Completion is criterion evidence.** "All tests pass" is incomplete
+  unless it names which contract criteria those tests prove. Report
+  performed results, not command output.
 
 #### When an existing test fails after a change
 
@@ -302,12 +312,14 @@ maker finishes. So the documentation contract declares, per recipient, the
 outcome that recipient must reach — and is satisfied only when they can
 reach it.
 
-Its teeth are a checklist, not a test, and the teeth principle decides the
-checklist's shape: an item has teeth only if a doc-less or hollow-doc
-delivery fails it. The tell is phrasing each item as an **audience
-outcome** — what the reader can now do — not artifact existence. "A new
-user completes the primary task from the README alone" fails a doc-less
-delivery; "a README exists" passes anything.
+Its common checking apparatus is an audience-outcome review, usually
+recorded as `check_kind: "attested"` criteria in `contract.criteria[]` and
+performed as reviewer findings in `completion-evidence.results[]`. The
+teeth principle still decides each criterion's substance: an item has teeth
+only if a doc-less or hollow-doc delivery fails it. The tell is phrasing
+each item as an **audience outcome** — what the reader can now do — not
+artifact existence. "A new user completes the primary task from the README
+alone" fails a doc-less delivery; "a README exists" passes anything.
 
 Three sub-modules, one per recipient: **user**, **developer**, and
 **discovery & marketing** — the last being the reader who does not yet know
@@ -324,14 +336,15 @@ verify checks — no layer restates another.
 
 ## The code-quality dimension
 
-Behavior says what the system does; documentation says what the recipient
-can do; the code-quality dimension declares what must hold of the change's
-internal form. Its teeth come not from an invented style rulebook but from
-the **principles corpus**: the universals that bear on this change,
-projected onto the diff as reviewer-checkable items. The corpus is the one
-home of quality invariants; the dimension consults it rather than
-re-deriving a second, divergent rulebook that would drift from it (consult,
-don't model).
+The code-quality dimension declares what must hold of the change's internal
+form. Its teeth come not from an invented style rulebook but from the
+**principles corpus**: the universals that bear on this change, projected
+onto the diff as reviewer-checkable criteria. Those criteria enter
+`contract.criteria[]`, commonly with `check_kind: "attested"`, and their
+performed evidence is a reviewer finding in `completion-evidence.results[]`.
+The corpus is the one home of quality invariants; the dimension consults it
+rather than re-deriving a second, divergent rulebook that would drift from
+it (consult, don't model).
 
 The projection is what makes the contract synergistic and recursive.
 Because the same universals that govern the whole system decide each change,
@@ -376,8 +389,8 @@ implementation are indistinguishable under it.
 behaviors. *Recognition:* runners configured, assertion libraries compared,
 no behavior specified yet.
 
-The modes above name the behavioral dimension's failures; two corruptions
-threaten any dimension:
+The modes above name behavior-apparatus failures; these corruptions threaten
+any dimension:
 
 **Hollow dimension.** A dimension whose criteria a hollow delivery passes —
 a checklist of artifact-existence items, a code-quality line that says
@@ -388,6 +401,13 @@ hollow delivery that would fail it.
 instead of consulting it — a code-quality rulebook paraphrasing the corpus,
 a documentation checklist re-listing the audience taxonomy `orient` already
 owns. *Recognition:* two homes for one truth, kept in agreement by hand.
+
+**Thin contract.** Contract criteria are present but too thin to shape a
+rich delivery: thin labels instead of statements, generic checklist
+assertions, or empty pass/fail attestations. *Recognition:* the criterion
+names a topic but not the product state it creates, and no one can explain
+what a richer delivery would do differently: contract richness determines
+product richness; a thin contract produces a thin product.
 
 **Refine-default.** A defective branch keeps its branch by default, or a
 strictly-bounded-but-large correction is routed to an in-place fix even
@@ -402,9 +422,10 @@ declared dimension proves qualification-to-remain.
   the method.
 - **Specification, not verification.** The contract's primary value is
   stating what the system does; catching regressions is the byproduct.
-- **Teeth before form.** The constant across dimensions is that a hollow
-  delivery fails a criterion; the form of the check is chosen to fit the
-  aspect, never the aspect bent to fit one form.
+- **Teeth before apparatus.** The constant across dimensions is that a
+  hollow delivery fails a criterion in the same contract structure; the
+  checking apparatus is chosen per criterion through `check_kind`, never by
+  giving a dimension a different structure.
 - **Each dimension consults its single home.** Behavior traces to
   scenarios, documentation to `orient`'s audience taxonomy, code quality to
   the principles corpus. A dimension that keeps its own editable copy of its

--- a/skills/contract/references/code-quality-contract.md
+++ b/skills/contract/references/code-quality-contract.md
@@ -1,23 +1,24 @@
 # Code-Quality Contract
 
-The code-quality dimension of the contract. The behavioral dimension
-declares what the system does; the documentation dimension declares what the
-recipient can do; this declares what must hold of the change's **internal
-form**.
+The code-quality dimension of the uniform contract machine declares what
+must hold of the change's **internal form**.
 
 Its teeth come from the resolved **principles corpus**, not from an invented
 style rulebook: the universals that bear on a change, consulted from the
-corpus and projected onto the diff as reviewer-checkable items.
+corpus and projected onto the diff as reviewer-checkable criteria in
+`contract.criteria[]`. The usual checking apparatus is
+`check_kind: "attested"` with performed evidence recorded as reviewer
+findings in `completion-evidence.results[]`.
 
 ## Why the corpus, not a rulebook
 
 A separate code-quality rulebook would be a second home for invariants the
 corpus already owns — and a second home drifts from the first. So this
-dimension consults the corpus rather than restating it (consult, don't
+dimension consults the corpus rather than restating it (consult, do not
 model). The corpus owns each universal's content; this module owns only how
-a universal lands on a diff and how the projection is generated. When the
-two would disagree, the corpus is authoritative and the projection is what
-changes.
+a universal lands on a diff and how the projection is generated as typed
+criteria for the uniform surface. When the two would disagree, the corpus
+is authoritative and the projection is what changes.
 
 ## The recursive property
 
@@ -45,7 +46,8 @@ Signal**).
 The projection is generated, not hardcoded. When `work-unit-craft`/`decompose`
 supplies inputs or `take` defines validation, consult the resolved corpus
 (`~/.groundwork/principles/`), select the universals this change most
-stresses, and write each as a checklist item in one shape:
+stresses, and write each as a typed `contract.criteria[]` entry whose
+statement carries one shape:
 
 - the universal as a **question** asked of the diff,
 - the **failing tell** a careless change leaves, and
@@ -77,22 +79,27 @@ demand.
 
 ## Lifecycle
 
-`work-unit-craft`/`decompose` supplies corpus pointers and stressed universals as inputs to
-validation. `take` turns those inputs into validation defined: the subset of
-universals the change puts under real pressure, named from the resolved
-corpus, not a ritual recital. `verify` performs validation by auditing the
-diff against each projected item. A subset is legitimate; under-declaration
-is not. A change that touches a shared asset without naming the universal
-that governs single homes, adds an abstraction without the one that governs
-earning a place, or moves a public surface without the one that governs
-honest surfaces, has left its risk outside validation.
+`work-unit-craft`/`decompose` supplies corpus pointers and stressed
+universals as inputs to validation. `take` turns those inputs into
+validation defined: the subset of universals the change puts under real
+pressure, named from the resolved corpus, not a ritual recital, and emitted
+as typed criteria into the uniform contract surface. `verify` performs
+validation by auditing the diff against each projected criterion and
+recording a reviewer finding in the uniform evidence surface. A subset is
+legitimate; under-declaration is not. A change that touches a shared asset
+without naming the universal that governs single homes, adds an abstraction
+without the one that governs earning a place, or moves a public surface
+without the one that governs honest surfaces, has left its risk outside
+validation.
 
 ## Verifying the contract
 
 At `verify`, the reviewer audits the diff against each defined item and
 records, per item, the locus where it holds or the finding where it fails.
 The method is `protocols/verify/references/code-quality-review.md`. The
-review is the gate; a self-report of cleanliness is not the evidence.
+review is the gate; a self-report of cleanliness is not the evidence. The
+result is an attested `completion-evidence.results[]` entry for each
+declared code-quality criterion, not prose outside the artifact.
 
 ## How the projection grows
 

--- a/skills/contract/references/documentation-contract.md
+++ b/skills/contract/references/documentation-contract.md
@@ -1,14 +1,16 @@
 # Documentation Contract
 
-The documentation dimension of the contract. Where the behavioral dimension
-declares what the system does, this declares what each **recipient** can do
-once the work lands. It serves **Transmission**: work completes when the
-recipient can act on it, not when the maker finishes — so the contract is
-written as outcomes the recipient reaches, and is satisfied only when they
-can reach them.
+The documentation dimension of the uniform contract machine declares what
+each **recipient** can do once the work lands. It serves **Transmission**:
+work completes when the recipient can act on it, not when the maker
+finishes — so the contract is written as outcomes the recipient reaches,
+and is satisfied only when they can reach them.
 
-The form is a checklist, not a test. The teeth principle decides the
-checklist's shape.
+This reference owns the documentation dimension's authoring discipline, not
+a separate contract structure. It consults `orient`'s audience taxonomy and
+emits typed documentation criteria into `contract.criteria[]`; the usual
+checking apparatus is `check_kind: "attested"` with performed evidence
+recorded as a reviewer finding in `completion-evidence.results[]`.
 
 ## The teeth of a documentation contract
 
@@ -25,19 +27,23 @@ outcome** — what the reader can now do — never as artifact existence.
 
 The check, run when documentation inputs are shaped, when validation is
 defined, and again when it is performed: *could a delivery that wrote
-nothing useful for this recipient still pass this item?* If yes, rewrite it
-as the recipient's outcome.
+nothing useful for this recipient still pass this criterion?* If yes,
+rewrite it as the recipient's outcome and keep the hollow delivery visible
+on the criterion.
 
 ## Lifecycle
 
-`work-unit-craft`/`decompose` supplies recipient outcomes as inputs to validation. `take`
-turns those inputs into validation defined: the pillars the change touches
-and the outcome each recipient must reach. `verify` performs validation by
-auditing whether those recipients can reach the outcomes. A subset is
-legitimate — a refactor with no user-visible effect carries no user pillar;
-a first public release carries all three. What is illegitimate is silence
-where the change clearly serves a recipient: a new user-facing capability
-with no user pillar is an under-declared contract, not a small one.
+`work-unit-craft`/`decompose` supplies recipient outcomes as inputs to
+validation. `take` turns those inputs into validation defined: typed
+criteria in the uniform contract surface naming the pillar, recipient
+outcome, hollow delivery, `check_kind`, and check descriptor. `verify`
+performs validation by auditing whether those recipients can reach the
+outcomes and recording the finding in the uniform evidence surface. A
+subset is legitimate — a refactor with no user-visible effect carries no
+user pillar; a first public release carries all three. What is illegitimate
+is silence where the change clearly serves a recipient: a new user-facing
+capability with no user pillar is an under-declared contract, not a small
+one.
 
 The audience taxonomy, artifact types, and writing stance are **not**
 restated here — they live in the `orient` skill's documentation discipline
@@ -115,10 +121,13 @@ Checklist:
 At `verify`, the documentation review audits the change against the defined
 contract: for each selected pillar, it confirms the recipient can now reach
 the defined outcome, and it keeps existing docs honest against drift. The
-method is `protocols/verify/references/documentation-review.md`; the outcome
-is recorded in the `documentation` section of `completion-evidence`.
-Verification is evidence, not assertion: the audit finds, per item, the
-place the outcome holds or the place it fails.
+method is `protocols/verify/references/documentation-review.md`; the
+criterion result is recorded in `completion-evidence.results[]` with an
+attestation carrying reviewer identity and finding. The legacy
+`documentation` summary in completion evidence remains the document-impact
+index, not the evidence home for a declared documentation criterion.
+Verification is evidence, not assertion: the audit finds, per criterion,
+the place the outcome holds or the place it fails.
 
 ## Single home
 

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -108,11 +108,13 @@ outside content
         body = read(CONTRACT_SKILL)
         changelog = read(CHANGELOG)
 
-        self.assertIn('version: "2.4.0"', body)
-        self.assertIn('updated: "2026-06-24"', body)
+        self.assertIn('version: "2.5.0"', body)
+        self.assertIn('updated: "2026-07-01"', body)
         self.assertEqual(1, changelog.splitlines().count("## [Unreleased]"))
         self.assertIn("**Contract disposition default** (#472)", changelog)
         self.assertIn("contract 2.3.0->2.4.0", changelog)
+        self.assertIn("**Uniform contract form** (#493)", changelog)
+        self.assertIn("contract 2.4.0->2.5.0", changelog)
 
     def test_disposition_default_is_sibling_of_teeth_principle(self) -> None:
         body = read(CONTRACT_SKILL)
@@ -125,6 +127,98 @@ outside content
         self.assertLess(teeth_index, disposition_index)
         self.assertLess(disposition_index, dimensions_index)
         self.assertNotIn("## The dimensions", body[teeth_index:disposition_index])
+
+    def test_teeth_principle_distinguishes_uniform_structure_from_checking_apparatus(self) -> None:
+        teeth = normalized(top_section(read(CONTRACT_SKILL), "The teeth principle"))
+
+        for expected in [
+            "same contract structure",
+            "same evidence obligation",
+            "checking apparatus may vary per criterion",
+            "`check_kind`",
+            "executable",
+            "attested",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, teeth)
+
+        forbidden = re.compile(
+            r"form of the check fits the dimension|"
+            r"forcing one form .* onto every dimension is the mistake|"
+            r"documentation earns them through a checklist|"
+            r"code quality earns them through corpus principles",
+            flags=re.IGNORECASE,
+        )
+        self.assertIsNone(forbidden.search(teeth))
+
+    def test_dimensions_are_first_class_citizens_of_one_machine(self) -> None:
+        dimensions = normalized(top_section(read(CONTRACT_SKILL), "The dimensions"))
+
+        for expected in [
+            "first-class symmetric citizen",
+            "one contract machine",
+            "Behavior is one dimension among N",
+            "documentation and code quality carry the identical teeth obligation",
+            "same performed-evidence obligation",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, dimensions)
+
+        forbidden = re.compile(
+            r"behavior is always present|declared as the change warrants|"
+            r"the most developed dimension|behavior is the unit of progress|"
+            r"completion is behavior coverage",
+            flags=re.IGNORECASE,
+        )
+        self.assertIsNone(forbidden.search(read(CONTRACT_SKILL)))
+
+    def test_attested_judgment_is_recorded_inside_the_uniform_evidence_surface(self) -> None:
+        body = normalized(read(CONTRACT_SKILL))
+
+        for expected in [
+            "every criterion in every dimension names the hollow delivery",
+            "attested criteria",
+            "`completion-evidence.results[]`",
+            "reviewer identity",
+            "finding",
+            "free-form reviewer prose outside the artifact is not evidence",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+        self.assertNotIn("reviewed, looks fine", body.lower())
+
+    def test_contract_richness_is_load_bearing(self) -> None:
+        body = normalized(read(CONTRACT_SKILL))
+        corruption_modes = normalized(top_section(read(CONTRACT_SKILL), "Corruption Modes"))
+
+        for expected in [
+            "contract richness determines product richness",
+            "thin labels",
+            "generic checklist assertions",
+            "empty pass/fail attestations",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+        self.assertIn("**Thin contract.**", corruption_modes)
+        self.assertIn("contract richness", corruption_modes)
+
+    def test_dimension_references_emit_typed_criteria_into_the_uniform_surface(self) -> None:
+        body = normalized(read(CONTRACT_SKILL))
+        documentation = normalized(read(ROOT / "skills" / "contract" / "references" / "documentation-contract.md"))
+        code_quality = normalized(read(ROOT / "skills" / "contract" / "references" / "code-quality-contract.md"))
+
+        for text, expected in [
+            (body, "typed criteria into the uniform surface"),
+            (documentation, "`contract.criteria[]`"),
+            (documentation, "`check_kind: \"attested\"`"),
+            (code_quality, "`contract.criteria[]`"),
+            (code_quality, "`check_kind: \"attested\"`"),
+            (code_quality, "consult, do not model"),
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, text)
 
     def test_disposition_default_defines_regenerate_as_the_review_default(self) -> None:
         disposition = normalized(top_section(read(CONTRACT_SKILL), "The disposition default"))


### PR DESCRIPTION
## Summary
- Teach the contract skill that every dimension uses one uniform contract/evidence structure.
- Update documentation and code-quality references to emit typed criteria into `contract.criteria[]` and record attested findings in `completion-evidence.results[]`.
- Add lifecycle tests covering uniform structure, first-class dimensions, attested evidence, richness, and single-home reference behavior.

## Verification
- `python -m unittest tests.test_contract_skill_lifecycle`
- `python -m unittest tests.test_artifact_schemas tests.test_verify_protocol_gate_coverage tests.test_take_protocol_contract_dimensions`
- `python -m tooling.conformance`
- `git diff --check`

Completion evidence: `completion-evidence-493-uniform-contract-skill`.

Closes #493.
