### PR TITLE
fix(contract): retire silent dimension doctrine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Silent dimension doctrine** (#498). The contract doctrine now states
+  that every present dimension carries authored teeth-bearing criteria:
+  density may be light, but coverage is never zero for a dimension the
+  change has. The pointer-as-default and silence-as-valid framing is
+  retired across `contract`, `take`, and `work-unit-craft`; hollow delivery
+  is the discriminator for filler criteria and silent dimensions alike.
+  contract 2.5.0->2.6.0, take 3.4.0->3.5.0,
+  work-unit-craft 1.1.0->1.2.0.
+
 - **Uniform contract form** (#493). The `contract` skill now states the
   invariant behind the #492 surfaces: every dimension uses the same
   contract structure and the same performed-evidence obligation, while

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -8,8 +8,8 @@ description: >-
   carries to land; until the runtime sequences the stations autonomously,
   take carries it. Trigger on: 'take', 'take work', 'start work-unit'.
 metadata:
-  version: "3.4.0"
-  updated: "2026-06-20"
+  version: "3.5.0"
+  updated: "2026-07-01"
 ---
 
 # Take — Contract-First Entry
@@ -84,12 +84,13 @@ proves it, or records it.
    asks the universal as a question of the change, names the failing tell,
    and names the locus where it holds.
 
-   Apply pointer-as-default after you consider every dimension; this is the
-   defined-validation pass for all three dimensions. A
-   dimension with no special input uses its general contract as the
-   validation pointer; it does not force a dense block. Density is unequal,
-   consideration is equal. Silence is valid only after you can say the
-   general contract is enough for that dimension.
+   After considering all three dimensions, decide which dimensions the
+   change actually has. Every present dimension gets at least one authored
+   criterion in `contract.criteria[]`; it may be simple, but it names the
+   statement, `hollow_delivery`, `check_kind`, and check descriptor. Density
+   may be light; coverage is never zero for a present dimension. A dimension
+   absent from the change has no criterion; a dimension present in the
+   change has authored teeth-bearing validation.
 
 5. **Deliver the contract spine.** Invoke the `contract` MCP tool with
    dimension-agnostic criteria. Each criterion declares the dimension it

--- a/skills/contract/SKILL.md
+++ b/skills/contract/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   or completion claims must stay traceable to a defined contract instead of
   drifting toward implementation convenience.
 metadata:
-  version: "2.5.0"
+  version: "2.6.0"
   updated: "2026-07-01"
 ---
 
@@ -95,11 +95,20 @@ There is one contract machine. Every dimension a change demands is a
 first-class symmetric citizen in that machine: Behavior is one dimension
 among N, documentation and code quality carry the identical teeth
 obligation, and every dimension carries the same performed-evidence
-obligation. A subset of dimensions is legitimate the way a contract need
-not exercise every code path; what is illegitimate is a dimension present
-in lighter structure. The lifecycle is inputs to validation -> validation
-defined -> validation performed, with validation carried through
-`implement` and recorded at `land`.
+obligation. Every dimension the change has carries at least one authored
+criterion in the uniform contract surface. Density may be light; coverage
+is never zero for a present dimension. Each present dimension's criterion
+names a statement of done, `hollow_delivery`, `check_kind`, check
+descriptor, and a performed evidence path through
+`completion-evidence.results[]`.
+
+A criterion is legitimate only when a hollow delivery fails it. The same
+hollow-delivery test rejects filler criteria and silent dimensions: a
+dimension with no authored criterion has no hollow delivery to fail. A
+dimension absent from the change has no criterion; a dimension present in
+the change has at least one criterion with teeth. The lifecycle is inputs
+to validation -> validation defined -> validation performed, with
+validation carried through `implement` and recorded at `land`.
 
 | Dimension | Lifecycle |
 |---|---|
@@ -124,16 +133,14 @@ The stage boundary is part of the contract lifecycle:
 - `land` consumes validation performed and records what shipped, including
   explicit gaps if any remain.
 
-### Pointer-as-default
+### Density and coverage
 
-`work-unit-craft`/`decompose` must consider every dimension, but consideration is not a
-mandatory per-dimension declaration. A dimension carrying no special input
-is still validated: its general contract remains the validation pointer.
-The rule is: density across dimensions is unequal; consideration is equal. A
-refactor may need detailed code-quality inputs and only the general
-documentation contract; a user-facing capability may need dense user
-documentation inputs and ordinary code-quality projection. Silence is valid
-only after the dimension was considered and the general contract is enough.
+The density rule is about size, not existence. A small bug fix may need one
+behavior criterion and one terse code-quality projection; a documentation
+unit may need several audience outcomes and one simple internal-form
+projection. Unequal density is valid when every present dimension still has
+authored criteria with teeth and every absent dimension is truly outside the
+change.
 
 - **[Behavior dimension](#the-behavior-dimension)** — what the system
   does. Its common checking apparatus is BDD scenarios or
@@ -396,6 +403,10 @@ any dimension:
 a checklist of artifact-existence items, a code-quality line that says
 "clean," a scenario a stub satisfies. *Recognition:* you cannot name the
 hollow delivery that would fail it.
+
+**Silent dimension.** A dimension the change has, but no criterion in that
+dimension can fail. *Recognition:* a present dimension has no authored
+criterion, coverage is zero, or a pointer cannot fail a hollow delivery.
 
 **Modeled, not consulted.** A dimension that re-derives its authority
 instead of consulting it — a code-quality rulebook paraphrasing the corpus,

--- a/skills/work-unit-craft/SKILL.md
+++ b/skills/work-unit-craft/SKILL.md
@@ -9,8 +9,8 @@ description: >-
   and the corruption modes that make records mis-steer the agents who
   read them.
 metadata:
-  version: "1.1.0"
-  updated: "2026-06-19"
+  version: "1.2.0"
+  updated: "2026-07-01"
   origin: >-
     Adapted from pentaxis93/with-claude
     _shared/methodology/issue-craft.md (internal), renamed and
@@ -58,20 +58,18 @@ The authoring pass must **consider every dimension**:
   These are the behavior input the later contract sharpens into executable
   checks.
 - **Documentation:** consult `orient`'s audience taxonomy and record any
-  recipient outcomes the work must make true. If no recipient needs a special
-  outcome beyond the general documentation contract, say nothing more.
+  recipient outcomes the work must make true. If documentation is outside
+  the change, leave that dimension absent from the record.
 - **Code quality:** point to the principles corpus and name any stressed
-  universals the work puts under unusual pressure. If the general code-quality
-  contract is enough, the corpus pointer is sufficient.
+  universals the work puts under unusual pressure. If code quality is part
+  of the change, name the principle outcome the later contract must verify.
 
-This is a consideration prompt, **not a mandatory per-dimension body
-section**. The **general contract pointer** carries any dimension with no
-special input. Density is unequal; consideration is equal. A terse bug may
-carry only behavior criteria after the documentation and code quality
-dimensions were considered. A documentation-deliverable unit may carry dense
-recipient outcomes and only the general corpus pointer. In every case,
-silence is valid only after the dimension was considered and the general
-contract is enough.
+Every present dimension gets visible contract input the later `take`
+contract can sharpen into an authored criterion. Density may be light;
+coverage is never zero for a present dimension. A terse bug may carry brief
+inputs, and a documentation-deliverable unit may carry dense recipient
+outcomes with a terse internal-form projection, but each present dimension
+still exposes the hollow delivery its authored criterion must fail.
 
 ## The Sovereignty Test
 

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -5,11 +5,18 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+TAKE_PROTOCOL = ROOT / "protocols" / "take" / "PROTOCOL.md"
+WORK_UNIT_CRAFT = ROOT / "skills" / "work-unit-craft" / "SKILL.md"
 CHANGELOG = ROOT / "CHANGELOG.md"
 CONTRACT_SURFACE = [
     CONTRACT_SKILL,
     ROOT / "skills" / "contract" / "references" / "documentation-contract.md",
     ROOT / "skills" / "contract" / "references" / "code-quality-contract.md",
+]
+CONTRACT_AUTHORING_SURFACE = [
+    CONTRACT_SKILL,
+    TAKE_PROTOCOL,
+    WORK_UNIT_CRAFT,
 ]
 INSTRUCTION_FILES = [
     *sorted((ROOT / "protocols").glob("*/PROTOCOL.md")),
@@ -104,17 +111,21 @@ outside content
         self.assertIn("child content", result)
         self.assertNotIn("outside content", result)
 
-    def test_contract_version_and_changelog_record_disposition_default(self) -> None:
+    def test_contract_version_and_changelog_record_silent_dimension_doctrine(self) -> None:
         body = read(CONTRACT_SKILL)
         changelog = read(CHANGELOG)
 
-        self.assertIn('version: "2.5.0"', body)
+        self.assertIn('version: "2.6.0"', body)
         self.assertIn('updated: "2026-07-01"', body)
         self.assertEqual(1, changelog.splitlines().count("## [Unreleased]"))
         self.assertIn("**Contract disposition default** (#472)", changelog)
         self.assertIn("contract 2.3.0->2.4.0", changelog)
         self.assertIn("**Uniform contract form** (#493)", changelog)
         self.assertIn("contract 2.4.0->2.5.0", changelog)
+        self.assertIn("**Silent dimension doctrine** (#498)", changelog)
+        self.assertIn("contract 2.5.0->2.6.0", changelog)
+        self.assertIn("take 3.4.0->3.5.0", changelog)
+        self.assertIn("work-unit-craft 1.1.0->1.2.0", changelog)
 
     def test_disposition_default_is_sibling_of_teeth_principle(self) -> None:
         body = read(CONTRACT_SKILL)
@@ -167,10 +178,25 @@ outside content
         forbidden = re.compile(
             r"behavior is always present|declared as the change warrants|"
             r"the most developed dimension|behavior is the unit of progress|"
-            r"completion is behavior coverage",
+            r"completion is behavior coverage|need not exercise every code path",
             flags=re.IGNORECASE,
         )
         self.assertIsNone(forbidden.search(read(CONTRACT_SKILL)))
+
+    def test_present_dimensions_require_authored_teeth_bearing_criteria(self) -> None:
+        dimensions = normalized(top_section(read(CONTRACT_SKILL), "The dimensions"))
+
+        for expected in [
+            "Every dimension the change has carries at least one authored criterion",
+            "Density may be light",
+            "coverage is never zero for a present dimension",
+            "statement of done",
+            "`hollow_delivery`",
+            "`check_kind`",
+            "`completion-evidence.results[]`",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, dimensions)
 
     def test_attested_judgment_is_recorded_inside_the_uniform_evidence_surface(self) -> None:
         body = normalized(read(CONTRACT_SKILL))
@@ -392,14 +418,44 @@ outside content
             with self.subTest(path=path.relative_to(ROOT)):
                 self.assertIsNone(forbidden.search(read(path)))
 
-    def test_pointer_as_default_distinguishes_consideration_from_dense_inputs(self) -> None:
-        pointer = normalized(section(read(CONTRACT_SKILL), "Pointer-as-default"))
+    def test_pointer_as_default_doctrine_is_absent_from_authoring_surfaces(self) -> None:
+        forbidden = re.compile(
+            r"Pointer-as-default|"
+            r"not a mandatory per-dimension (?:declaration|body section)|"
+            r"general contract (?:remains the validation pointer|pointer)|"
+            r"silence is valid|"
+            r"dimension with no special input uses",
+            flags=re.IGNORECASE,
+        )
 
-        self.assertRegex(pointer, r"consider every dimension")
-        self.assertRegex(pointer, r"not a mandatory per-dimension declaration")
-        self.assertRegex(pointer, r"general contract remains the validation pointer")
-        self.assertRegex(pointer, r"density across dimensions is unequal; consideration is equal")
-        self.assertNotRegex(pointer, r"no special input[^.]+not validated")
+        for path in CONTRACT_AUTHORING_SURFACE:
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertIsNone(forbidden.search(read(path)))
+
+    def test_hollow_delivery_discriminator_rejects_filler_and_silence(self) -> None:
+        dimensions = normalized(top_section(read(CONTRACT_SKILL), "The dimensions"))
+        corruption_modes = normalized(top_section(read(CONTRACT_SKILL), "Corruption Modes"))
+        combined = f"{dimensions} {corruption_modes}"
+
+        for expected in [
+            "A criterion is legitimate only when a hollow delivery fails it",
+            "The same hollow-delivery test rejects filler criteria and silent dimensions",
+            "a dimension with no authored criterion has no hollow delivery to fail",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, combined)
+
+    def test_silent_dimension_corruption_mode_is_named(self) -> None:
+        corruption_modes = normalized(top_section(read(CONTRACT_SKILL), "Corruption Modes"))
+
+        for expected in [
+            "**Silent dimension.**",
+            "a present dimension has no authored criterion",
+            "pointer cannot fail a hollow delivery",
+            "coverage is zero",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, corruption_modes)
 
     def test_documentation_deliverable_gates_define_behavior_teeth(self) -> None:
         gates = normalized(section(read(CONTRACT_SKILL), "Documentation-deliverable behavior gates"))

--- a/tests/test_take_protocol_contract_dimensions.py
+++ b/tests/test_take_protocol_contract_dimensions.py
@@ -75,21 +75,25 @@ class TakeProtocolContractDimensionTests(unittest.TestCase):
         self.assertIn("reviewer-checkable", authoring)
         self.assertIn("projected", authoring)
 
-    def test_pointer_as_default_is_defined_as_general_contract_not_dense_required_blocks(self) -> None:
+    def test_take_requires_authored_criteria_for_present_dimensions(self) -> None:
         authoring = normalized(step(read(TAKE_PROTOCOL), 4))
-        authoring_lower = authoring.lower()
 
         for expected in [
-            "consider every dimension",
-            "general contract",
-            "pointer-as-default",
-            "density is unequal",
-            "consideration is equal",
+            "Every present dimension gets at least one authored criterion",
+            "Density may be light",
+            "coverage is never zero for a present dimension",
+            "hollow_delivery",
+            "check_kind",
         ]:
             with self.subTest(expected=expected):
-                self.assertIn(expected, authoring_lower)
+                self.assertIn(expected, authoring)
 
-        self.assertNotRegex(authoring, r"mandatory per-dimension (?:declaration|block)")
+        forbidden = re.compile(
+            r"Pointer-as-default|general contract (?:remains the validation pointer|pointer)|"
+            r"silence is valid|not a mandatory per-dimension (?:declaration|block)",
+            flags=re.IGNORECASE,
+        )
+        self.assertIsNone(forbidden.search(authoring))
 
     def test_take_consults_dimension_homes_without_reencoding_lifecycle_table(self) -> None:
         body = read(TAKE_PROTOCOL)

--- a/tests/test_work_unit_craft_skill.py
+++ b/tests/test_work_unit_craft_skill.py
@@ -122,7 +122,7 @@ class WorkUnitCraftSkillTests(unittest.TestCase):
             with self.subTest(expected=expected):
                 self.assertIn(expected, primary_workflow)
 
-    def test_pointer_as_default_is_a_considered_dimension_not_a_body_requirement(self) -> None:
+    def test_present_dimensions_require_visible_contract_inputs(self) -> None:
         body = read_work_unit_craft()
         primary_workflow = normalized(
             section_between(
@@ -132,10 +132,22 @@ class WorkUnitCraftSkillTests(unittest.TestCase):
             )
         )
 
-        self.assertIn("consider every dimension", primary_workflow)
-        self.assertIn("not a mandatory per-dimension body section", primary_workflow)
-        self.assertIn("general contract pointer", primary_workflow)
-        self.assertIn("silence is valid only after the dimension was considered", primary_workflow)
+        for expected in [
+            "Every present dimension gets visible contract input",
+            "Density may be light",
+            "coverage is never zero for a present dimension",
+            "hollow delivery",
+            "authored criterion",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, primary_workflow)
+
+        forbidden = re.compile(
+            r"general contract pointer|silence is valid|"
+            r"not a mandatory per-dimension body section",
+            flags=re.IGNORECASE,
+        )
+        self.assertIsNone(forbidden.search(primary_workflow))
 
     def test_declared_contract_work_consults_the_contract_instead_of_modeling_it(self) -> None:
         body = read_work_unit_craft()


### PR DESCRIPTION
## Summary

- Retires pointer-as-default / silence-valid doctrine across contract, take, and work-unit-craft.
- States the positive invariant: every present dimension carries authored teeth-bearing criteria; density may be light, coverage is never zero.
- Adds tests for the invariant, forbidden pointer/silence language, hollow-delivery discriminator, silent-dimension corruption mode, and metadata/changelog transmission.

## Verification

- `python -m unittest tests.test_contract_skill_lifecycle tests.test_take_protocol_contract_dimensions tests.test_work_unit_craft_skill tests.test_reference_links tests.test_conformance` — 83 tests OK.
- `python -m tooling.conformance` — 21 passed, 0 failed.
- `git diff --check` — pass.
- Forbidden doctrine scan across `skills/contract`, `protocols/take`, and `skills/work-unit-craft` — no matches.

## Notes

Full unittest discovery still has two pre-existing failures in `test_interactive_session_surface` where `runa-mcp` accepts invalid `completion-evidence` instead of rejecting contract mismatches. This change does not touch that surface.