### PR TITLE
Cold-start ticket entry reaches Groundwork's acquisition surface while ordinary untargeted planning remains requirements-gated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   covered by the same forbidden-pattern guard as contract, take, and
   work-unit-craft. contract 2.5.0->2.6.0, take 3.4.0->3.5.0,
   work-unit-craft 1.1.0->1.2.0.
+
+- **Cold-start acquisition surface reachability** (#499). `decompose`
+  remains the sole unscoped `work-unit` producer but no longer requires a
+  planning-phase `requirements` artifact as an entry precondition; the
+  `requirements` trigger still preserves ordinary survey → requirements →
+  decompose planning. Ticket-entry dry runs now reach the acquisition
+  surface and project `take`, while untargeted intent still waits for
+  requirements before decomposition.
+
 - **Uniform contract form** (#493). The `contract` skill now states the
   invariant behind the #492 surfaces: every dimension uses the same
   contract structure and the same performed-evidence obligation, while

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -135,6 +135,14 @@ methodology cannot skip this step." Accepts means "the methodology
 benefits from this context but the protocol can still do valid work
 without it."
 
+`decompose` is the planning-phase exception that keeps the distinction
+visible. Ordinary planning still reaches `decompose` through the
+`requirements` trigger, and `requirements` is accepted so the protocol
+receives the content it is decomposing. It is not a `requires` edge:
+cold-start ticket entry substitutes the trigger with the ticket reference,
+reaches the same `work-unit` output surface, and has no planning-phase
+requirements artifact yet.
+
 ## No Signals
 
 If artifacts are the sole state mechanism, then signals are a second
@@ -246,8 +254,7 @@ trigger = { type = "on_artifact", name = "intent" }
 
 [[protocols]]
 name = "decompose"
-requires = ["requirements"]
-accepts = ["research-record"]
+accepts = ["requirements", "research-record"]
 produces = ["work-unit"]
 may_produce = ["research-record"]
 trigger = { type = "on_artifact", name = "requirements" }
@@ -760,9 +767,11 @@ flow produces artifacts that runa tracks and threads by work-unit identity.
 
 ### decompose
 
-- **requires:** requirements. Cannot break work into work-units without
-  knowing what the work is.
-- **accepts:** research-record. Research may inform decomposition decisions.
+- **accepts:** requirements, research-record. Requirements is the ordinary
+  planning input decompose breaks into work-units, injected as context when
+  present; it is not a hard precondition, so cold-start ticket entry can reach
+  this surface with no requirements artifact yet. Research-record may inform
+  decomposition.
 - **trigger:** `on_artifact("requirements")`
 
 ### take

--- a/manifest.toml
+++ b/manifest.toml
@@ -83,6 +83,12 @@ name = "run-test"
 # Scoped pipeline (per work unit):
 #   take → plan → implement → verify → submit → review → land
 #
+# `decompose` is also the acquisition surface: it is the sole unscoped
+# producer of `work-unit`. Ordinary planning still reaches it through the
+# `requirements` trigger, while cold-start ticket entry substitutes that
+# trigger so acquisition can materialize the work-unit before requirements
+# exist.
+#
 # The contract is the spine: take produces it at entry, and every
 # judgment station (plan, implement, verify, submit, review) requires it.
 # land, the mechanical applier, accepts it for the completion record.
@@ -97,8 +103,7 @@ trigger = { type = "on_artifact", name = "intent" }
 
 [[protocols]]
 name = "decompose"
-requires = ["requirements"]
-accepts = ["research-record"]
+accepts = ["requirements", "research-record"]
 produces = ["work-unit"]
 may_produce = ["research-record"]
 trigger = { type = "on_artifact", name = "requirements" }

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -14,6 +14,15 @@ person who sees the problem to the agent who will solve it. The agent has no
 access to your context, your codebase familiarity, or your unstated assumptions.
 Everything it needs must be in the work-unit.
 
+`decompose` is also Groundwork's acquisition surface: it is the sole unscoped
+producer of the `work-unit` artifact. Ordinary planning reaches this protocol
+when a `requirements` artifact satisfies its trigger, so requirements still
+precede decomposition in the planning route. Cold-start ticket entry substitutes
+that trigger with the entry reference and serves the same work-unit output
+surface so the acquire discipline can read the ticket and materialize the
+work-unit before any planning-phase requirements artifact exists. The manifest
+therefore keeps `requirements` as the trigger, not as a `requires` precondition.
+
 For concrete templates, see [references/templates.md](references/templates.md).
 For the work-unit state model and dependency graph format, see
 [`work-unit-model.md`](../../docs/architecture/work-unit-model.md).

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -3,6 +3,7 @@
 import json
 import os
 import subprocess
+import shutil
 import sys
 import tempfile
 import unittest
@@ -33,6 +34,35 @@ def materialize(read_ticket_stdout: str) -> subprocess.CompletedProcess[str]:
 def write_fake_command(path: Path, body: str) -> None:
     path.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
     path.chmod(0o755)
+
+
+def append_github_forge_config(project_dir: Path, owner: str, name: str) -> None:
+    config_path = project_dir / ".runa" / "config.toml"
+    existing = config_path.read_text(encoding="utf-8")
+    config_path.write_text(
+        f'{existing}\n[forge]\ntype = "github"\nowner = "{owner}"\nname = "{name}"\n',
+        encoding="utf-8",
+    )
+
+
+def init_groundwork_project(root: Path, runa: Path) -> Path:
+    project = root / "project"
+    project.mkdir()
+    init = subprocess.run(
+        [str(runa), "init", "--methodology", str(ROOT / "manifest.toml")],
+        cwd=project,
+        capture_output=True,
+        text=True,
+    )
+    assert init.returncode == 0, f"{init.stdout}\n{init.stderr}"
+    append_github_forge_config(project, "tesserine", "groundwork")
+    return project
+
+
+def write_workspace_artifact(project: Path, artifact_type: str, instance_id: str, body: dict) -> None:
+    directory = project / ".runa" / "workspace" / artifact_type
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / f"{instance_id}.json").write_text(json.dumps(body, indent=2), encoding="utf-8")
 
 
 class MaterializeTicketTests(unittest.TestCase):
@@ -183,12 +213,26 @@ class MaterializeTicketTests(unittest.TestCase):
 
 
 def runa_bin() -> Path | None:
+    candidates: list[Path] = []
     configured = os.environ.get("GROUNDWORK_RUNA_BIN")
     if configured:
-        path = Path(configured)
-        return path if path.is_file() else None
-    sibling = ROOT.parent / "runa" / "target" / "debug" / "runa"
-    return sibling if sibling.is_file() else None
+        candidates.append(Path(configured))
+    discovered = shutil.which("runa")
+    if discovered:
+        candidates.append(Path(discovered))
+    candidates.append(ROOT.parent / "runa" / "target" / "debug" / "runa")
+
+    for path in candidates:
+        if not path.is_file():
+            continue
+        help_result = subprocess.run(
+            [str(path), "run", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        if "--ticket" in help_result.stdout:
+            return path
+    return None
 
 
 def runa_mcp_bin(runa: Path) -> Path | None:
@@ -202,6 +246,101 @@ def runa_mcp_bin(runa: Path) -> Path | None:
 
 @unittest.skipUnless(runa_bin() is not None, "runa binary not available")
 class AcquisitionEntryEndToEndTests(unittest.TestCase):
+    def test_ticket_entry_dry_run_reaches_acquisition_and_projects_take(self) -> None:
+        runa = runa_bin()
+        self.assertIsNotNone(runa)
+
+        with tempfile.TemporaryDirectory(prefix="groundwork-acquire-entry-") as tmp:
+            project = init_groundwork_project(Path(tmp), runa)
+
+            output = subprocess.run(
+                [
+                    str(runa),
+                    "run",
+                    "--ticket",
+                    "tesserine/groundwork#499",
+                    "--dry-run",
+                    "--json",
+                ],
+                cwd=project,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(output.returncode, 0, f"stdout:\n{output.stdout}\nstderr:\n{output.stderr}")
+            payload = json.loads(output.stdout)
+            self.assertEqual(payload["entry"]["acquisition_protocol"], "decompose")
+            self.assertGreater(len(payload["execution_plan"]), 0, payload)
+            self.assertEqual(payload["execution_plan"][0]["protocol"], "decompose")
+            self.assertEqual(payload["execution_plan"][0]["projection"], "current")
+            projected = [
+                entry for entry in payload["execution_plan"]
+                if entry["protocol"] == "take" and entry["projection"] == "projected"
+            ]
+            self.assertEqual(1, len(projected), payload["execution_plan"])
+            self.assertEqual("work-unit-499", projected[0]["work_unit"])
+
+    def test_untargeted_intent_waits_for_requirements_before_decompose(self) -> None:
+        runa = runa_bin()
+        self.assertIsNotNone(runa)
+
+        with tempfile.TemporaryDirectory(prefix="groundwork-acquire-planning-") as tmp:
+            project = init_groundwork_project(Path(tmp), runa)
+            write_workspace_artifact(
+                project,
+                "intent",
+                "intent-untargeted",
+                {
+                    "statement": "Plan ordinary work before decomposition.",
+                    "source": "operator",
+                },
+            )
+
+            intent_only = subprocess.run(
+                [str(runa), "state", "--json"],
+                cwd=project,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                intent_only.returncode,
+                0,
+                f"stdout:\n{intent_only.stdout}\nstderr:\n{intent_only.stderr}",
+            )
+            intent_state = {
+                protocol["name"]: protocol
+                for protocol in json.loads(intent_only.stdout)["protocols"]
+            }
+            self.assertEqual("ready", intent_state["survey"]["status"], intent_state)
+            self.assertEqual("waiting", intent_state["decompose"]["status"], intent_state)
+
+            write_workspace_artifact(
+                project,
+                "requirements",
+                "requirements-from-survey",
+                {
+                    "scope": "Ordinary planning route.",
+                    "functional_requirements": ["Requirements precede decomposition."],
+                },
+            )
+
+            with_requirements = subprocess.run(
+                [str(runa), "state", "--json"],
+                cwd=project,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                with_requirements.returncode,
+                0,
+                f"stdout:\n{with_requirements.stdout}\nstderr:\n{with_requirements.stderr}",
+            )
+            requirements_state = {
+                protocol["name"]: protocol
+                for protocol in json.loads(with_requirements.stdout)["protocols"]
+            }
+            self.assertEqual("ready", requirements_state["decompose"]["status"], requirements_state)
+
     def test_acquired_work_unit_makes_take_the_next_ready_station(self) -> None:
         runa = runa_bin()
         runa_mcp = runa_mcp_bin(runa)


### PR DESCRIPTION
## Summary
- Make `decompose` the acquisition surface reachable from cold-start ticket entry by removing its `requirements` prerequisite while keeping the normal `on_artifact(requirements)` trigger.
- Document how ticket acquisition substitutes for the requirements trigger and update the changelog.
- Add acquisition coverage for ticket dry-run projection and the ordinary untargeted requirements gate.

## Verification
- `python -m unittest tests.test_acquisition tests.test_conformance tests.test_protocol_artifact_delivery_docs`
- `python -m tooling.conformance`
