### PR TITLE
fix(contract): retire silent dimension doctrine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Silent dimension doctrine** (#498). The contract authoring doctrine now
+  states that every present dimension carries authored teeth-bearing criteria:
+  density may be light, but pointer-covered or silent dimensions are not
+  valid. The hollow-delivery discriminator applies to both filler criteria and
+  dimensions with no criterion to fail, and the decompose authoring protocol is
+  covered by the same forbidden-pattern guard as contract, take, and
+  work-unit-craft. contract 2.5.0->2.6.0, take 3.4.0->3.5.0,
+  work-unit-craft 1.1.0->1.2.0.
 - **Uniform contract form** (#493). The `contract` skill now states the
   invariant behind the #492 surfaces: every dimension uses the same
   contract structure and the same performed-evidence obligation, while

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -70,10 +70,12 @@ inputs point to the principles corpus and name stressed universals when the
 work puts any under special pressure. The `contract` skill owns the lifecycle
 these inputs enter; decompose consults it and does not restate it.
 
-Considering a dimension does not require a dedicated body section. A dimension
-with no special input remains covered by the general contract pointer. The
-record is incomplete only when the author skipped the consideration pass or
-hid special inputs the implementer needs.
+The authoring pass must consider every dimension and leave authored
+teeth-bearing inputs for every dimension the change has. Density may be
+light: one recipient outcome or one projected universal can be enough when a
+dimension is lightly touched. Coverage is never zero. A record is incomplete
+when a present dimension has no input a hollow delivery could fail, or when
+it hides inputs the implementer needs.
 
 ### Dependencies
 

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -8,8 +8,8 @@ description: >-
   carries to land; until the runtime sequences the stations autonomously,
   take carries it. Trigger on: 'take', 'take work', 'start work-unit'.
 metadata:
-  version: "3.4.0"
-  updated: "2026-06-20"
+  version: "3.5.0"
+  updated: "2026-07-01"
 ---
 
 # Take — Contract-First Entry
@@ -84,12 +84,12 @@ proves it, or records it.
    asks the universal as a question of the change, names the failing tell,
    and names the locus where it holds.
 
-   Apply pointer-as-default after you consider every dimension; this is the
-   defined-validation pass for all three dimensions. A
-   dimension with no special input uses its general contract as the
-   validation pointer; it does not force a dense block. Density is unequal,
-   consideration is equal. Silence is valid only after you can say the
-   general contract is enough for that dimension.
+   For all three dimensions, every dimension the change has gets at least
+   one authored teeth-bearing criterion. Density may be light: one sharp
+   documentation outcome or one projected code-quality universal can be
+   enough when that dimension is lightly touched. Coverage is never zero.
+   Each dimension's criterion must name the hollow delivery that would fail
+   it, so ordinary discipline cannot stand in for validation defined.
 
 5. **Deliver the contract spine.** Invoke the `contract` MCP tool with
    dimension-agnostic criteria. Each criterion declares the dimension it

--- a/skills/contract/SKILL.md
+++ b/skills/contract/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   or completion claims must stay traceable to a defined contract instead of
   drifting toward implementation convenience.
 metadata:
-  version: "2.5.0"
+  version: "2.6.0"
   updated: "2026-07-01"
 ---
 
@@ -95,11 +95,17 @@ There is one contract machine. Every dimension a change demands is a
 first-class symmetric citizen in that machine: Behavior is one dimension
 among N, documentation and code quality carry the identical teeth
 obligation, and every dimension carries the same performed-evidence
-obligation. A subset of dimensions is legitimate the way a contract need
-not exercise every code path; what is illegitimate is a dimension present
-in lighter structure. The lifecycle is inputs to validation -> validation
-defined -> validation performed, with validation carried through
-`implement` and recorded at `land`.
+obligation: every dimension a change has carries at least one authored
+teeth-bearing criterion: statement of done, hollow delivery, `check_kind`,
+check descriptor, and later performed result. Density is situational; a
+lightly touched dimension may need one simple criterion, and simple criteria
+are legitimate, while a stressed dimension may need many. But coverage and
+teeth are not situational: coverage is never zero for a dimension the change
+has, and silent dimensions are not valid. The only honest form of less is fewer,
+simpler teeth-bearing criteria, never a dimension present with no criterion
+to fail. The lifecycle is inputs to validation -> validation defined ->
+validation performed, with validation carried through `implement` and
+recorded at `land`.
 
 | Dimension | Lifecycle |
 |---|---|
@@ -124,16 +130,17 @@ The stage boundary is part of the contract lifecycle:
 - `land` consumes validation performed and records what shipped, including
   explicit gaps if any remain.
 
-### Pointer-as-default
+### Density and Coverage
 
-`work-unit-craft`/`decompose` must consider every dimension, but consideration is not a
-mandatory per-dimension declaration. A dimension carrying no special input
-is still validated: its general contract remains the validation pointer.
-The rule is: density across dimensions is unequal; consideration is equal. A
-refactor may need detailed code-quality inputs and only the general
-documentation contract; a user-facing capability may need dense user
-documentation inputs and ordinary code-quality projection. Silence is valid
-only after the dimension was considered and the general contract is enough.
+`work-unit-craft`/`decompose` must consider every dimension and record
+inputs for every dimension the change has. The true density rule is that
+those inputs scale with the work: a refactor may need a single documentation
+criterion that existing workflows remain usable, while a user-facing
+capability may need dense user documentation outcomes and a light
+code-quality projection. The hollow-delivery discriminator governs both
+forms. A criterion is legitimate only when a hollow delivery fails it; a
+dimension with no criterion has nothing a hollow delivery can fail and is
+therefore uncovered.
 
 - **[Behavior dimension](#the-behavior-dimension)** — what the system
   does. Its common checking apparatus is BDD scenarios or
@@ -408,6 +415,13 @@ assertions, or empty pass/fail attestations. *Recognition:* the criterion
 names a topic but not the product state it creates, and no one can explain
 what a richer delivery would do differently: contract richness determines
 product richness; a thin contract produces a thin product.
+
+**Silent dimension.** A dimension the change has, left with no authored
+teeth-bearing criterion, is a design failure. *Recognition:* the surface
+points at a general rule or assumes ordinary discipline is enough, while a
+dimension the change has, left with no authored teeth-bearing criterion,
+names no statement of done, no hollow delivery, and no result path. A pointer
+has no teeth; an uncovered dimension hollows the contract.
 
 **Refine-default.** A defective branch keeps its branch by default, or a
 strictly-bounded-but-large correction is routed to an in-place fix even

--- a/skills/work-unit-craft/SKILL.md
+++ b/skills/work-unit-craft/SKILL.md
@@ -9,8 +9,8 @@ description: >-
   and the corruption modes that make records mis-steer the agents who
   read them.
 metadata:
-  version: "1.1.0"
-  updated: "2026-06-19"
+  version: "1.2.0"
+  updated: "2026-07-01"
   origin: >-
     Adapted from pentaxis93/with-claude
     _shared/methodology/issue-craft.md (internal), renamed and
@@ -58,20 +58,19 @@ The authoring pass must **consider every dimension**:
   These are the behavior input the later contract sharpens into executable
   checks.
 - **Documentation:** consult `orient`'s audience taxonomy and record any
-  recipient outcomes the work must make true. If no recipient needs a special
-  outcome beyond the general documentation contract, say nothing more.
+  recipient outcomes the work must make true. When documentation risk is
+  light, one simple recipient outcome is enough.
 - **Code quality:** point to the principles corpus and name any stressed
-  universals the work puts under unusual pressure. If the general code-quality
-  contract is enough, the corpus pointer is sufficient.
+  universals the work puts under unusual pressure. The code quality input can
+  be one projected universal when internal-form risk is light.
 
-This is a consideration prompt, **not a mandatory per-dimension body
-section**. The **general contract pointer** carries any dimension with no
-special input. Density is unequal; consideration is equal. A terse bug may
-carry only behavior criteria after the documentation and code quality
-dimensions were considered. A documentation-deliverable unit may carry dense
-recipient outcomes and only the general corpus pointer. In every case,
-silence is valid only after the dimension was considered and the general
-contract is enough.
+Every dimension the change has must leave an authored teeth-bearing input
+for the later contract; every dimension the change has is covered that way.
+The rule is that density may be light, but coverage is never zero: one sharp
+recipient outcome or one corpus projection can be enough, while silence
+cannot. Each input should make the hollow delivery visible enough that `take`
+can turn it into a criterion with a statement of done,
+`check_kind`, check descriptor, and result path.
 
 ## The Sovereignty Test
 

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -11,6 +11,12 @@ CONTRACT_SURFACE = [
     ROOT / "skills" / "contract" / "references" / "documentation-contract.md",
     ROOT / "skills" / "contract" / "references" / "code-quality-contract.md",
 ]
+AUTHORING_DOCTRINE_SURFACE = [
+    CONTRACT_SKILL,
+    ROOT / "protocols" / "take" / "PROTOCOL.md",
+    ROOT / "protocols" / "decompose" / "PROTOCOL.md",
+    ROOT / "skills" / "work-unit-craft" / "SKILL.md",
+]
 INSTRUCTION_FILES = [
     *sorted((ROOT / "protocols").glob("*/PROTOCOL.md")),
     *sorted((ROOT / "protocols").glob("*/references/*.md")),
@@ -108,13 +114,17 @@ outside content
         body = read(CONTRACT_SKILL)
         changelog = read(CHANGELOG)
 
-        self.assertIn('version: "2.5.0"', body)
+        self.assertIn('version: "2.6.0"', body)
         self.assertIn('updated: "2026-07-01"', body)
         self.assertEqual(1, changelog.splitlines().count("## [Unreleased]"))
         self.assertIn("**Contract disposition default** (#472)", changelog)
         self.assertIn("contract 2.3.0->2.4.0", changelog)
         self.assertIn("**Uniform contract form** (#493)", changelog)
         self.assertIn("contract 2.4.0->2.5.0", changelog)
+        self.assertIn("**Silent dimension doctrine** (#498)", changelog)
+        self.assertIn("contract 2.5.0->2.6.0", changelog)
+        self.assertIn("take 3.4.0->3.5.0", changelog)
+        self.assertIn("work-unit-craft 1.1.0->1.2.0", changelog)
 
     def test_disposition_default_is_sibling_of_teeth_principle(self) -> None:
         body = read(CONTRACT_SKILL)
@@ -160,6 +170,9 @@ outside content
             "Behavior is one dimension among N",
             "documentation and code quality carry the identical teeth obligation",
             "same performed-evidence obligation",
+            "every dimension a change has carries at least one authored teeth-bearing criterion",
+            "coverage is never zero",
+            "fewer, simpler teeth-bearing criteria",
         ]:
             with self.subTest(expected=expected):
                 self.assertIn(expected, dimensions)
@@ -167,7 +180,7 @@ outside content
         forbidden = re.compile(
             r"behavior is always present|declared as the change warrants|"
             r"the most developed dimension|behavior is the unit of progress|"
-            r"completion is behavior coverage",
+            r"completion is behavior coverage|need not exercise every code path",
             flags=re.IGNORECASE,
         )
         self.assertIsNone(forbidden.search(read(CONTRACT_SKILL)))
@@ -392,14 +405,49 @@ outside content
             with self.subTest(path=path.relative_to(ROOT)):
                 self.assertIsNone(forbidden.search(read(path)))
 
-    def test_pointer_as_default_distinguishes_consideration_from_dense_inputs(self) -> None:
-        pointer = normalized(section(read(CONTRACT_SKILL), "Pointer-as-default"))
+    def test_density_rule_distinguishes_simple_criteria_from_zero_coverage(self) -> None:
+        dimensions = normalized(top_section(read(CONTRACT_SKILL), "The dimensions"))
 
-        self.assertRegex(pointer, r"consider every dimension")
-        self.assertRegex(pointer, r"not a mandatory per-dimension declaration")
-        self.assertRegex(pointer, r"general contract remains the validation pointer")
-        self.assertRegex(pointer, r"density across dimensions is unequal; consideration is equal")
-        self.assertNotRegex(pointer, r"no special input[^.]+not validated")
+        for expected in [
+            "Density is situational",
+            "coverage and teeth are not situational",
+            "never zero for a dimension the change has",
+            "simple criteria are legitimate",
+            "silent dimensions are not",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, dimensions)
+
+        self.assertNotIn("Pointer-as-default", read(CONTRACT_SKILL))
+
+    def test_authoring_surfaces_reject_pointer_and_silence_doctrine(self) -> None:
+        forbidden = re.compile(
+            r"Pointer-as-default|"
+            r"general contract pointer|"
+            r"general contract remains the validation pointer|"
+            r"silence is valid|"
+            r"not a mandatory per-dimension (?:declaration|body section|block)|"
+            r"dimension with no special input (?:uses|remains covered by)|"
+            r"no special input uses its general contract|"
+            r"need not exercise every code path",
+            flags=re.IGNORECASE,
+        )
+
+        for path in AUTHORING_DOCTRINE_SURFACE:
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertIsNone(forbidden.search(read(path)))
+
+    def test_silent_dimension_corruption_mode_is_named(self) -> None:
+        corruption_modes = normalized(top_section(read(CONTRACT_SKILL), "Corruption Modes"))
+
+        for expected in [
+            "**Silent dimension.**",
+            "a dimension the change has, left with no authored teeth-bearing criterion",
+            "pointer has no teeth",
+            "uncovered dimension hollows the contract",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, corruption_modes)
 
     def test_documentation_deliverable_gates_define_behavior_teeth(self) -> None:
         gates = normalized(section(read(CONTRACT_SKILL), "Documentation-deliverable behavior gates"))

--- a/tests/test_take_protocol_contract_dimensions.py
+++ b/tests/test_take_protocol_contract_dimensions.py
@@ -75,21 +75,27 @@ class TakeProtocolContractDimensionTests(unittest.TestCase):
         self.assertIn("reviewer-checkable", authoring)
         self.assertIn("projected", authoring)
 
-    def test_pointer_as_default_is_defined_as_general_contract_not_dense_required_blocks(self) -> None:
+    def test_density_rule_requires_teeth_without_dense_required_blocks(self) -> None:
         authoring = normalized(step(read(TAKE_PROTOCOL), 4))
         authoring_lower = authoring.lower()
 
         for expected in [
-            "consider every dimension",
-            "general contract",
-            "pointer-as-default",
-            "density is unequal",
-            "consideration is equal",
+            "every dimension the change has",
+            "authored teeth-bearing criterion",
+            "density may be light",
+            "coverage is never zero",
+            "hollow delivery",
         ]:
             with self.subTest(expected=expected):
                 self.assertIn(expected, authoring_lower)
 
-        self.assertNotRegex(authoring, r"mandatory per-dimension (?:declaration|block)")
+        forbidden = re.compile(
+            r"Pointer-as-default|general contract pointer|silence is valid|"
+            r"not a mandatory per-dimension (?:declaration|block)|"
+            r"dimension with no special input uses its general contract",
+            flags=re.IGNORECASE,
+        )
+        self.assertIsNone(forbidden.search(authoring))
 
     def test_take_consults_dimension_homes_without_reencoding_lifecycle_table(self) -> None:
         body = read(TAKE_PROTOCOL)

--- a/tests/test_work_unit_craft_skill.py
+++ b/tests/test_work_unit_craft_skill.py
@@ -122,7 +122,7 @@ class WorkUnitCraftSkillTests(unittest.TestCase):
             with self.subTest(expected=expected):
                 self.assertIn(expected, primary_workflow)
 
-    def test_pointer_as_default_is_a_considered_dimension_not_a_body_requirement(self) -> None:
+    def test_contract_input_density_rule_requires_teeth_not_silence(self) -> None:
         body = read_work_unit_craft()
         primary_workflow = normalized(
             section_between(
@@ -132,10 +132,22 @@ class WorkUnitCraftSkillTests(unittest.TestCase):
             )
         )
 
-        self.assertIn("consider every dimension", primary_workflow)
-        self.assertIn("not a mandatory per-dimension body section", primary_workflow)
-        self.assertIn("general contract pointer", primary_workflow)
-        self.assertIn("silence is valid only after the dimension was considered", primary_workflow)
+        for expected in [
+            "consider every dimension",
+            "every dimension the change has",
+            "authored teeth-bearing input",
+            "density may be light",
+            "coverage is never zero",
+            "hollow delivery",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, primary_workflow)
+
+        forbidden = re.compile(
+            r"general contract pointer|silence is valid|not a mandatory per-dimension body section",
+            flags=re.IGNORECASE,
+        )
+        self.assertIsNone(forbidden.search(primary_workflow))
 
     def test_declared_contract_work_consults_the_contract_instead_of_modeling_it(self) -> None:
         body = read_work_unit_craft()


### PR DESCRIPTION
## Summary

Retires the pointer/silence doctrine for contract dimensions across the live authoring surfaces. Present dimensions now require authored teeth-bearing criteria; density may be light, but coverage is never zero.

## Coverage

- Behavior/gate coverage: focused lifecycle tests assert the density-vs-coverage invariant, the silent-dimension corruption mode, and retired pointer/silence forbidden patterns.
- Documentation coverage: contract, take, work-unit-craft, decompose, and CHANGELOG surfaces transmit the corrected doctrine.
- Code-quality coverage: contract remains the doctrine home; take, decompose, and work-unit-craft consume it without keeping a conflicting fallback rule.

## Verification

- `python -m pytest tests/test_contract_skill_lifecycle.py tests/test_take_protocol_contract_dimensions.py tests/test_work_unit_craft_skill.py`
- `rg -n "Pointer-as-default|general contract pointer|general contract remains the validation pointer|silence is valid|not a mandatory per-dimension|need not exercise every code path|dimension with no special input uses|with no special input remains covered" skills/contract protocols/take protocols/decompose skills/work-unit-craft -S` returned no matches
- `python -m tooling.conformance`
