### PR TITLE
contract(documentation): documentation is a first-class inhabitant of the machine (#495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Documentation is a first-class inhabitant of the contract machine**
+  (#495). The pipeline's canonical exemplar now models the documentation
+  dimension as an audience outcome — an API consumer acting from the
+  reference alone — instead of artifact-content phrasing. A pillar exemplar
+  pair expresses the three recipient pillars (user, developer, discovery)
+  as attested audience-outcome criteria with per-pillar reviewer
+  attestations, and a hollow exemplar shows a generic
+  "documentation is reviewed" criterion failing the same shared
+  warranted-acceptance-criteria check every dimension answers to.
+  `tests/test_documentation_dimension.py` pins the pillar coverage, the
+  hollow-fails tooth (same detector, same message shape as sibling
+  dimensions), and evidence-shape parity; the documentation-contract
+  reference names the pillar-outcomes → warranted-set wiring.
+
 - **Ascent in reckon** (#327). `reckon` now names Ascent, the Purpose
   Ladder, as the upward counterpart to Recursive Why: structural choices
   made during Reconstruct climb back through purpose to the exigence before

--- a/skills/contract/references/documentation-contract.md
+++ b/skills/contract/references/documentation-contract.md
@@ -43,7 +43,12 @@ subset is legitimate — a refactor with no user-visible effect carries no
 user pillar; a first public release carries all three. What is illegitimate
 is silence where the change clearly serves a recipient: a new user-facing
 capability with no user pillar is an under-declared contract, not a small
-one.
+one. Mechanically, the pillar outcomes selected for a change enter the
+warranted acceptance-criteria set the shared contract/evidence detector
+checks — the same under-declaration flag every dimension answers to. The
+exemplar fixtures under `tests/fixtures/artifacts/` model both sides: the
+rich pillar pair that passes that gate, and the hollow generic form it
+catches (`tests/test_documentation_dimension.py` pins the pair).
 
 The audience taxonomy, artifact types, and writing stance are **not**
 restated here — they live in the `orient` skill's documentation discipline

--- a/tests/fixtures/artifacts/hollow-completion-evidence-documentation.json
+++ b/tests/fixtures/artifacts/hollow-completion-evidence-documentation.json
@@ -1,0 +1,21 @@
+{
+  "work_unit": "work-unit-495-hollow-user-facing",
+  "results": [
+    {
+      "criterion_id": "documentation-generic-review",
+      "result": "pass",
+      "evidence": {
+        "summary": "Reviewer marked documentation as reviewed.",
+        "attestation": {
+          "reviewer": "core",
+          "finding": "Documentation reviewed."
+        }
+      }
+    }
+  ],
+  "documentation": {
+    "updated": ["README.md"],
+    "verified_accurate": [],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/hollow-contract-documentation.json
+++ b/tests/fixtures/artifacts/hollow-contract-documentation.json
@@ -1,0 +1,15 @@
+{
+  "work_unit": "work-unit-495-hollow-user-facing",
+  "title": "User-facing change with a generic documentation criterion",
+  "criteria": [
+    {
+      "id": "documentation-generic-review",
+      "dimension": "documentation",
+      "acceptance_criterion": "Documentation is reviewed",
+      "statement": "A README exists and documentation was reviewed.",
+      "hollow_delivery": "The reviewer marks documentation as reviewed while no reader outcome was checked.",
+      "check_kind": "attested",
+      "check": "Reviewer notes documentation as reviewed."
+    }
+  ]
+}

--- a/tests/fixtures/artifacts/mismatched-work-unit-completion-evidence.json
+++ b/tests/fixtures/artifacts/mismatched-work-unit-completion-evidence.json
@@ -17,10 +17,10 @@
       "criterion_id": "documentation-api-reference",
       "result": "pass",
       "evidence": {
-        "summary": "Reviewer confirmed the API reference matches the delivered behavior.",
+        "summary": "Reviewer performed the submission and a failure recovery from the API reference alone.",
         "attestation": {
           "reviewer": "core",
-          "finding": "The API reference describes accepted records and validation failures."
+          "finding": "Following only the API reference, the reviewer constructed a valid record submission and recovered from the invalid-field validation failure."
         }
       }
     },
@@ -37,8 +37,12 @@
     }
   ],
   "documentation": {
-    "updated": ["README.md"],
-    "verified_accurate": ["docs/api-reference.md"],
+    "updated": [
+      "README.md"
+    ],
+    "verified_accurate": [
+      "docs/api-reference.md"
+    ],
     "follow_up_work_units": []
   }
 }

--- a/tests/fixtures/artifacts/valid-completion-evidence-attested.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-attested.json
@@ -5,17 +5,23 @@
       "criterion_id": "documentation-api-reference",
       "result": "pass",
       "evidence": {
-        "summary": "Reviewer confirmed documentation accuracy.",
+        "summary": "Reviewer performed the submission and a failure recovery from the API reference alone.",
         "attestation": {
           "reviewer": "core",
-          "finding": "Documentation describes the delivered behavior and omits stale scenario framing."
+          "finding": "Following only the API reference, the reviewer constructed a valid record submission and recovered from the invalid-field validation failure."
         }
       }
     }
   ],
   "documentation": {
-    "updated": ["schemas/README.md", "CHANGELOG.md"],
-    "verified_accurate": ["protocols/take/PROTOCOL.md", "protocols/verify/PROTOCOL.md"],
+    "updated": [
+      "schemas/README.md",
+      "CHANGELOG.md"
+    ],
+    "verified_accurate": [
+      "protocols/take/PROTOCOL.md",
+      "protocols/verify/PROTOCOL.md"
+    ],
     "follow_up_work_units": []
   }
 }

--- a/tests/fixtures/artifacts/valid-completion-evidence-documentation-pillars.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-documentation-pillars.json
@@ -1,0 +1,43 @@
+{
+  "work_unit": "work-unit-495-first-public-release",
+  "results": [
+    {
+      "criterion_id": "documentation-user-first-task",
+      "result": "pass",
+      "evidence": {
+        "summary": "Reviewer reached first success from the README alone.",
+        "attestation": {
+          "reviewer": "core",
+          "finding": "Following only the README, the reviewer installed the tool and completed the primary task end to end without reading source."
+        }
+      }
+    },
+    {
+      "criterion_id": "documentation-developer-integration",
+      "result": "pass",
+      "evidence": {
+        "summary": "Reviewer integrated against the documented contract without reading source.",
+        "attestation": {
+          "reviewer": "core",
+          "finding": "Starting from the architecture docs, the reviewer located the release surface and drafted a working integration call from its documented signatures and errors alone."
+        }
+      }
+    },
+    {
+      "criterion_id": "documentation-discovery-entry",
+      "result": "pass",
+      "evidence": {
+        "summary": "Reviewer stated the project's what, who, and why from the entry surface opening.",
+        "attestation": {
+          "reviewer": "core",
+          "finding": "Reading only the entry surface's first sentences, the reviewer stated what the project is, who it is for, and the reason to choose it over the status quo."
+        }
+      }
+    }
+  ],
+  "documentation": {
+    "updated": ["README.md", "docs/architecture.md", "CHANGELOG.md"],
+    "verified_accurate": ["docs/api-reference.md"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/valid-completion-evidence.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence.json
@@ -17,10 +17,10 @@
       "criterion_id": "documentation-api-reference",
       "result": "pass",
       "evidence": {
-        "summary": "Reviewer confirmed the API reference matches the delivered behavior.",
+        "summary": "Reviewer performed the submission and a failure recovery from the API reference alone.",
         "attestation": {
           "reviewer": "core",
-          "finding": "The API reference describes accepted records and validation failures."
+          "finding": "Following only the API reference, the reviewer constructed a valid record submission and recovered from the invalid-field validation failure."
         }
       }
     },
@@ -37,8 +37,12 @@
     }
   ],
   "documentation": {
-    "updated": ["README.md"],
-    "verified_accurate": ["docs/api-reference.md"],
+    "updated": [
+      "README.md"
+    ],
+    "verified_accurate": [
+      "docs/api-reference.md"
+    ],
     "follow_up_work_units": []
   }
 }

--- a/tests/fixtures/artifacts/valid-contract-documentation-pillars.json
+++ b/tests/fixtures/artifacts/valid-contract-documentation-pillars.json
@@ -1,0 +1,33 @@
+{
+  "work_unit": "work-unit-495-first-public-release",
+  "title": "First public release reaches every documentation recipient",
+  "criteria": [
+    {
+      "id": "documentation-user-first-task",
+      "dimension": "documentation",
+      "acceptance_criterion": "A new user completes the primary task from the README alone",
+      "statement": "A new user, reading only the README, installs the tool and completes the primary task end to end without reading source.",
+      "hollow_delivery": "The README is touched but a new user still cannot reach first success from it alone — or no README change lands at all.",
+      "check_kind": "attested",
+      "check": "Reviewer performs the install and primary task following only the README."
+    },
+    {
+      "id": "documentation-developer-integration",
+      "dimension": "documentation",
+      "acceptance_criterion": "A contributor locates where the change lives and integrates against its documented contract",
+      "statement": "A contributor, starting from the architecture docs, locates where the released surface lives and integrates against its documented signatures and errors without reverse-engineering the code.",
+      "hollow_delivery": "Architecture and API docs are untouched or restate file names, so a contributor still reverse-engineers the code to integrate.",
+      "check_kind": "attested",
+      "check": "Reviewer traces the release surface from the architecture docs and drafts an integration call from the documented contract alone."
+    },
+    {
+      "id": "documentation-discovery-entry",
+      "dimension": "documentation",
+      "acceptance_criterion": "A discovery reader tells what the project is, who it is for, and why to choose it from the entry surface",
+      "statement": "A reader who does not know the project exists tells, within the first few sentences of the entry surface, what it is, who it is for, and why to choose it over the status quo.",
+      "hollow_delivery": "The entry surface leads with internals or borrowed prestige, so a discovery reader leaves without learning who it is for or why to choose it.",
+      "check_kind": "attested",
+      "check": "Reviewer reads only the entry surface's opening and states the project's what, who, and why."
+    }
+  ]
+}

--- a/tests/fixtures/artifacts/valid-contract.json
+++ b/tests/fixtures/artifacts/valid-contract.json
@@ -14,11 +14,11 @@
     {
       "id": "documentation-api-reference",
       "dimension": "documentation",
-      "acceptance_criterion": "Public API behavior is documented",
-      "statement": "The API reference describes accepted records and validation failures.",
-      "hollow_delivery": "The code changes but the API reference still describes the old behavior.",
+      "acceptance_criterion": "An API consumer submits a valid record and handles each validation failure from the reference alone",
+      "statement": "An API consumer, reading only the API reference, constructs a valid record submission and recovers from each documented validation failure without reading source.",
+      "hollow_delivery": "The reference is touched but an API consumer still cannot construct a submission or handle a failure from it alone \u2014 or no reference change lands at all.",
       "check_kind": "attested",
-      "check": "Reviewer reads the API reference against the implemented behavior."
+      "check": "Reviewer performs the primary submission and one failure recovery following only the API reference."
     },
     {
       "id": "code-quality-single-validation-path",

--- a/tests/fixtures/artifacts/valid-implementation-plan.json
+++ b/tests/fixtures/artifacts/valid-implementation-plan.json
@@ -8,7 +8,7 @@
     },
     {
       "decision": "Validate at the HTTP handler level before enqueuing",
-      "rationale": "Fail fast — rejected records never touch the queue, reducing wasted processing"
+      "rationale": "Fail fast \u2014 rejected records never touch the queue, reducing wasted processing"
     }
   ],
   "affected_files": [
@@ -29,7 +29,7 @@
     {
       "criterion_id": "documentation-api-reference",
       "steps": [
-        "Describe accepted records and validation failures in the API reference"
+        "Document, in the API reference, the record submission an API consumer performs and the recovery step for each validation failure"
       ]
     },
     {

--- a/tests/test_documentation_dimension.py
+++ b/tests/test_documentation_dimension.py
@@ -1,0 +1,250 @@
+import json
+import unittest
+from pathlib import Path
+
+from tooling.artifact_schemas import (
+    ArtifactSchemaError,
+    detect_contract_evidence_defects,
+    load_artifact,
+    validate_artifact,
+    validate_contract_evidence,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "artifacts"
+
+# The three recipient-pillar outcomes the pillar exemplar declares. The
+# fixture is the exemplar home; these constants are pinned equal to it below
+# and then reused as the warranted acceptance-criteria input, so the test
+# consults the fixture rather than keeping a second editable copy.
+USER_OUTCOME = "A new user completes the primary task from the README alone"
+DEVELOPER_OUTCOME = (
+    "A contributor locates where the change lives and integrates"
+    " against its documented contract"
+)
+DISCOVERY_OUTCOME = (
+    "A discovery reader tells what the project is, who it is for,"
+    " and why to choose it from the entry surface"
+)
+PILLAR_OUTCOMES = {USER_OUTCOME, DEVELOPER_OUTCOME, DISCOVERY_OUTCOME}
+
+# The canonical exemplar's documentation criterion is the user pillar for its
+# own change: an API consumer acting from the reference alone.
+CANONICAL_USER_OUTCOME = (
+    "An API consumer submits a valid record and handles each"
+    " validation failure from the reference alone"
+)
+
+
+def fixture(name: str) -> Path:
+    return FIXTURES / name
+
+
+def canonical_contract() -> dict:
+    return load_artifact("contract", fixture("valid-contract.json"))
+
+
+def canonical_evidence() -> dict:
+    return load_artifact(
+        "completion-evidence", fixture("valid-completion-evidence.json")
+    )
+
+
+def pillar_contract() -> dict:
+    return load_artifact(
+        "contract", fixture("valid-contract-documentation-pillars.json")
+    )
+
+
+def pillar_evidence() -> dict:
+    return load_artifact(
+        "completion-evidence",
+        fixture("valid-completion-evidence-documentation-pillars.json"),
+    )
+
+
+def hollow_contract() -> dict:
+    return load_artifact("contract", fixture("hollow-contract-documentation.json"))
+
+
+def hollow_evidence() -> dict:
+    return load_artifact(
+        "completion-evidence",
+        fixture("hollow-completion-evidence-documentation.json"),
+    )
+
+
+def documentation_criteria(contract: dict) -> list[dict]:
+    return [
+        criterion
+        for criterion in contract["criteria"]
+        if criterion["dimension"] == "documentation"
+    ]
+
+
+class PillarExemplarTests(unittest.TestCase):
+    """The three recipient pillars are expressed as machine-touched criteria."""
+
+    def test_pillar_exemplar_declares_the_three_recipient_outcomes(self) -> None:
+        criteria = documentation_criteria(pillar_contract())
+
+        self.assertEqual(
+            PILLAR_OUTCOMES,
+            {criterion["acceptance_criterion"] for criterion in criteria},
+        )
+        for criterion in criteria:
+            with self.subTest(criterion=criterion["id"]):
+                self.assertEqual("documentation", criterion["dimension"])
+                self.assertEqual("attested", criterion["check_kind"])
+
+    def test_rich_pillar_pair_passes_the_shared_gate_with_warranted_outcomes(
+        self,
+    ) -> None:
+        contract = pillar_contract()
+        evidence = pillar_evidence()
+
+        validate_contract_evidence(
+            contract,
+            evidence,
+            warranted_dimensions={"documentation"},
+            warranted_acceptance_criteria={"documentation": PILLAR_OUTCOMES},
+        )
+
+        for result in evidence["results"]:
+            with self.subTest(criterion=result["criterion_id"]):
+                attestation = result["evidence"]["attestation"]
+                self.assertTrue(attestation["reviewer"])
+                self.assertTrue(attestation["finding"])
+
+
+class HollowDocumentationTests(unittest.TestCase):
+    """A hollow documentation criterion fails the same shared mechanism that
+    judges every dimension — never a documentation-only detector."""
+
+    def test_hollow_exemplar_is_schema_valid_but_hollow(self) -> None:
+        contract = hollow_contract()
+
+        validate_artifact("contract", contract)
+        self.assertEqual(
+            [],
+            detect_contract_evidence_defects(contract, hollow_evidence()),
+        )
+
+    def test_hollow_documentation_criterion_fails_the_same_warranted_check(
+        self,
+    ) -> None:
+        warranted = {USER_OUTCOME, DEVELOPER_OUTCOME}
+        defects = detect_contract_evidence_defects(
+            hollow_contract(),
+            hollow_evidence(),
+            warranted_acceptance_criteria={"documentation": warranted},
+        )
+
+        messages = {message for _path, message in defects}
+        for outcome in sorted(warranted):
+            with self.subTest(outcome=outcome):
+                self.assertIn(
+                    f"dimension 'documentation' does not declare"
+                    f" warranted criterion {outcome!r}",
+                    messages,
+                )
+
+        # Same detector, same message shape as every other dimension: a
+        # warranted miss for code-quality on the canonical pair templates to
+        # the identical string once dimension and criterion are substituted.
+        sentinel = "Public APIs stay typed"
+        sibling = detect_contract_evidence_defects(
+            canonical_contract(),
+            canonical_evidence(),
+            warranted_acceptance_criteria={"code-quality": {sentinel}},
+        )
+        sibling_shape = {
+            message.replace("code-quality", "<dimension>").replace(
+                sentinel, "<criterion>"
+            )
+            for _path, message in sibling
+        }
+        documentation_shape = {
+            message.replace("documentation", "<dimension>").replace(
+                outcome, "<criterion>"
+            )
+            for _path, message in defects
+            for outcome in warranted
+            if outcome in message
+        }
+        self.assertEqual(sibling_shape, documentation_shape)
+
+
+class PillarParityTests(unittest.TestCase):
+    """Documentation pillars answer to the same coverage and evidence-shape
+    checks as every dimension."""
+
+    def test_declared_pillar_left_unevidenced_is_flagged_identically(self) -> None:
+        contract = pillar_contract()
+        dropped = documentation_criteria(contract)[0]["id"]
+        evidence = pillar_evidence()
+        evidence["results"] = [
+            result
+            for result in evidence["results"]
+            if result["criterion_id"] != dropped
+        ]
+
+        with self.assertRaises(ArtifactSchemaError) as context:
+            validate_contract_evidence(contract, evidence)
+        self.assertIn(
+            ("results", f"contract criterion {dropped!r} has no completion evidence"),
+            context.exception.errors,
+        )
+
+    def test_attested_pillar_without_attestation_is_flagged(self) -> None:
+        contract = pillar_contract()
+        evidence = pillar_evidence()
+        evidence["results"][0]["evidence"] = {
+            "summary": "A run cannot satisfy an attested pillar.",
+            "run": {
+                "command": "python -m unittest",
+                "result": "pass",
+                "output_summary": "tests passed",
+            },
+        }
+
+        with self.assertRaises(ArtifactSchemaError) as context:
+            validate_contract_evidence(contract, evidence)
+        self.assertIn(
+            (
+                "results/0/evidence",
+                "attested criterion requires reviewer attestation",
+            ),
+            context.exception.errors,
+        )
+
+
+class CanonicalExemplarTests(unittest.TestCase):
+    """The canonical exemplar's documentation criterion is an audience
+    outcome wired into the warranted mechanism."""
+
+    def test_canonical_documentation_criterion_is_the_user_pillar_outcome(
+        self,
+    ) -> None:
+        criteria = documentation_criteria(canonical_contract())
+
+        self.assertEqual(1, len(criteria))
+        self.assertEqual(
+            CANONICAL_USER_OUTCOME, criteria[0]["acceptance_criterion"]
+        )
+
+    def test_canonical_pair_passes_the_shared_gate_with_its_outcome_warranted(
+        self,
+    ) -> None:
+        validate_contract_evidence(
+            canonical_contract(),
+            canonical_evidence(),
+            warranted_dimensions={"documentation"},
+            warranted_acceptance_criteria={
+                "documentation": {CANONICAL_USER_OUTCOME}
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #495. Part of epic #484 (leveling).

## What

The structural machine landed under #492/#494; this unit makes documentation **inhabit** it with the richness the epic demands:

- **Canonical exemplar enriched.** `valid-contract.json`'s documentation criterion is now an audience outcome — *an API consumer submits a valid record and handles each validation failure from the reference alone* — replacing the artifact-content phrasing ("the reference describes X"). The join key `documentation-api-reference` is kept; evidence findings, the attested exemplar, the mismatched-work-unit exemplar, and the plan step move with it.
- **Pillar exemplar pair.** A first-public-release-shaped contract declares all three recipient pillars (user, developer, discovery) as `attested` audience-outcome criteria instancing `orient`'s profiles, with per-pillar reviewer attestations in its evidence.
- **Hollow exemplar.** A user-facing change whose sole documentation criterion is the generic "Documentation is reviewed" form is schema-valid and fully evidenced — and fails the **same** shared `warranted_acceptance_criteria` check every dimension answers to. Named `hollow-*` to escape the valid-/invalid- sweeps, since plain validation correctly cannot judge it.
- **Conformance.** `tests/test_documentation_dimension.py` (8 tests, written RED against `c21e0bf`) pins pillar coverage (fixture ↔ warranted-set equality), the hollow-fails tooth with message-shape identity against a sibling-dimension miss, unevidenced-pillar and attested-without-attestation parity, and the canonical pair passing the shared gate with its outcome warranted.
- **Doctrine.** `documentation-contract.md` names the wiring in one sentence: pillar outcomes enter the warranted set the shared detector checks; the exemplars model both sides.

No schema or detector changes — the shared machinery is consulted, not modified (Single Home; Dosed Compliance: judgment-shaped richness stays attested, no hollowness lexer).

## Evidence

- RED: 7 errors + 1 failure against head before any change (fixtures absent; canonical AC was the old string).
- GREEN: full suite `Ran 393 — OK (skipped=7)` (+8 over the #494 baseline, zero regressions); `python -m tooling.conformance` 21 passed / 0 failed.

Station-direct per operator wish on #495.