### PR TITLE
contract(code-quality): code quality is a first-class inhabitant of the machine (#485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Code quality is a first-class inhabitant of the contract machine**
+  (#485). Structurally-checkable projections gain a real executable check:
+  `tooling/import_direction.py` ships as the reference fitness function
+  (stdlib-only layer-edge checker), a seeded cross-layer import fails it,
+  and groundwork's own tree answers to it with the `tooling → tests` edge
+  forbidden. A projection exemplar pair inhabits both check kinds — one
+  executable import-direction criterion evidenced by a recorded run, two
+  attested judgment projections whose universals resolve verbatim in the
+  embedded principles corpus (consult, don't model) with per-universal
+  reviewer findings — and a hollow exemplar shows the generic "code
+  quality is reviewed" criterion failing the same shared
+  warranted-acceptance-criteria check every dimension answers to. The
+  canonical exemplar's code-quality criterion is now honestly executable:
+  its check names an automated fitness test and its evidence is a run.
+  `tests/test_code_quality_dimension.py` pins the seeded red, the corpus
+  consultation, the hollow tooth (same detector, same message shape as
+  sibling dimensions), and evidence-shape parity; the code-quality-contract
+  and code-quality-review references teach the apparatus per projection
+  shape and name the stressed-universals → warranted-set wiring.
+
 - **Documentation is a first-class inhabitant of the contract machine**
   (#495). The pipeline's canonical exemplar now models the documentation
   dimension as an audience outcome — an API consumer acting from the

--- a/protocols/verify/references/code-quality-review.md
+++ b/protocols/verify/references/code-quality-review.md
@@ -11,8 +11,13 @@ review is the gate; a self-report of cleanliness is not the evidence
 
 ## Method
 
-Begin from the declared contract. List the universals the code-quality
-contract declared for this change; those are what this audit decides.
+Begin from the declared contract, splitting its code-quality criteria by
+`check_kind`. An **executable** criterion — a structural projection whose
+check is a fitness function — is verified by running its declared check
+and recording the run in `completion-evidence.results[]`; the reference
+implementation for layer edges is `tooling/import_direction.py`. The
+audit below is the **attested** criteria's method. List the universals
+those declared for this change; they are what the audit decides.
 
 1. **Read the diff as the substrate.** Audit the committed change, not the
    author's account of it. For each declared universal, the universal's full
@@ -34,9 +39,10 @@ contract declared for this change; those are what this audit decides.
    grow. The corpus is the bounded asset the spiral acts on.
 
 The declared code-quality criterion's performed result is recorded in
-`completion-evidence.results[]` as attested evidence: reviewer identity plus
-the per-universal disposition and finding for each selected universal or
-projection. The verify report remains the review narrative, and the
+`completion-evidence.results[]` shaped by its `check_kind`: run (or
+produced-artifact) evidence for an executable projection; for an attested
+one, reviewer identity plus the per-universal disposition and finding for
+each selected universal or projection. The verify report remains the review narrative, and the
 `documentation` section remains the document-impact index — updated
 documents, documents verified accurate, and follow-up work-units — not the
 evidence home for a declared code-quality criterion.

--- a/skills/contract/references/code-quality-contract.md
+++ b/skills/contract/references/code-quality-contract.md
@@ -5,10 +5,14 @@ must hold of the change's **internal form**.
 
 Its teeth come from the resolved **principles corpus**, not from an invented
 style rulebook: the universals that bear on a change, consulted from the
-corpus and projected onto the diff as reviewer-checkable criteria in
-`contract.criteria[]`. The usual checking apparatus is
-`check_kind: "attested"` with performed evidence recorded as reviewer
-findings in `completion-evidence.results[]`.
+corpus and projected onto the diff as typed criteria in
+`contract.criteria[]`. The checking apparatus follows the projection's
+shape: a **structurally-checkable** projection — dependency direction,
+layering, coupling, import direction — is `check_kind: "executable"`, its
+check an automated fitness function whose run is recorded in
+`completion-evidence.results[]`; a **judgment-shaped** projection is
+`check_kind: "attested"`, its performed evidence a reviewer finding in the
+same surface.
 
 ## Why the corpus, not a rulebook
 
@@ -40,6 +44,22 @@ not. The review of each item finds one of two things: the **locus** in the
 diff where the universal holds, or the **place** it fails. A finding is
 evidence; "looks fine" is not (**Verifiable Completion**, **Honest
 Signal**).
+
+## Structurally-checkable projections are executable
+
+Where a projection's failing tell is a structural fact of the tree — a
+forbidden layer edge, an import direction, a dependency cycle — the
+criterion is typed `executable` and its check is a **fitness function**: an
+automated check that a seeded violating change fails and whose run (or
+produced artifact) is the recorded evidence. `tooling/import_direction.py`
+is the shipped reference implementation: it fails a module in one layer
+that imports from a forbidden layer, groundwork's own tree answers to it
+(the `tooling → tests` edge is forbidden), and
+`tests/test_code_quality_dimension.py` proves the seeded violation goes
+red. A structural invariant left as an attested item asks a reviewer to
+eyeball what a run can decide; a manual inspection wearing
+`check_kind: "executable"` is a lying surface. Type each projection by
+what its check actually is.
 
 ## Projecting the corpus
 
@@ -90,7 +110,14 @@ legitimate; under-declaration is not. A change that touches a shared asset
 without naming the universal that governs single homes, adds an abstraction
 without the one that governs earning a place, or moves a public surface
 without the one that governs honest surfaces, has left its risk outside
-validation.
+validation. Mechanically, the stressed universals selected for a change
+enter the warranted acceptance-criteria set the shared contract/evidence
+detector checks — the same under-declaration flag every dimension answers
+to. The exemplar fixtures under `tests/fixtures/artifacts/` model both
+sides: the projection pair that inhabits both check kinds and passes that
+gate, and the generic "code quality is reviewed" form it catches
+(`tests/test_code_quality_dimension.py` pins the pair, and pins each
+attested exemplar universal to the resolved corpus by name).
 
 ## Verifying the contract
 

--- a/tests/fixtures/artifacts/hollow-completion-evidence-code-quality.json
+++ b/tests/fixtures/artifacts/hollow-completion-evidence-code-quality.json
@@ -1,0 +1,21 @@
+{
+  "work_unit": "work-unit-485-hollow-refactor",
+  "results": [
+    {
+      "criterion_id": "code-quality-generic-review",
+      "result": "pass",
+      "evidence": {
+        "summary": "Reviewer marked code quality as reviewed.",
+        "attestation": {
+          "reviewer": "core",
+          "finding": "Code quality reviewed."
+        }
+      }
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": [],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/hollow-contract-code-quality.json
+++ b/tests/fixtures/artifacts/hollow-contract-code-quality.json
@@ -1,0 +1,15 @@
+{
+  "work_unit": "work-unit-485-hollow-refactor",
+  "title": "Refactor with a generic code-quality criterion",
+  "criteria": [
+    {
+      "id": "code-quality-generic-review",
+      "dimension": "code-quality",
+      "acceptance_criterion": "Code quality is reviewed",
+      "statement": "The code was reviewed for quality.",
+      "hollow_delivery": "The reviewer marks code quality as reviewed while no universal was checked against the diff.",
+      "check_kind": "attested",
+      "check": "Reviewer notes code quality as reviewed."
+    }
+  ]
+}

--- a/tests/fixtures/artifacts/valid-completion-evidence-artifact.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-artifact.json
@@ -5,10 +5,10 @@
       "criterion_id": "code-quality-single-validation-path",
       "result": "pass",
       "evidence": {
-        "summary": "Artifact inspection confirms the shared validator remains the single path.",
+        "summary": "The validation-entry fitness test emitted its entry-point report.",
         "artifact": {
-          "path": "src/ingestion/validation.py",
-          "description": "The endpoint uses the shared validator rather than a one-off check."
+          "path": "reports/validation-entry.txt",
+          "description": "Entry-point report produced by the validation-entry fitness test, listing the one importer of the shared validator."
         }
       }
     }

--- a/tests/fixtures/artifacts/valid-completion-evidence-code-quality-projections.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-code-quality-projections.json
@@ -1,0 +1,44 @@
+{
+  "work_unit": "work-unit-485-code-quality-projections",
+  "results": [
+    {
+      "criterion_id": "code-quality-layer-import-direction",
+      "result": "pass",
+      "evidence": {
+        "summary": "The import-direction fitness function reports the src-to-tests edge absent.",
+        "run": {
+          "command": "python -m tooling.import_direction --root . --forbid src:tests",
+          "result": "pass",
+          "output_summary": "0 violations; the src layer imports only source layers"
+        }
+      }
+    },
+    {
+      "criterion_id": "code-quality-earns-its-place",
+      "result": "pass",
+      "evidence": {
+        "summary": "Reviewer audited each added element against the universal.",
+        "attestation": {
+          "reviewer": "core",
+          "finding": "Each of the three added elements names its constraint: the retry parameter serves the flaky-upstream requirement at src/ingestion/client.py:41; the two helpers are consumed at their call sites; the diff carries no speculative surface."
+        }
+      }
+    },
+    {
+      "criterion_id": "code-quality-fail-loudly",
+      "result": "pass",
+      "evidence": {
+        "summary": "Reviewer traced both failure paths the change adds.",
+        "attestation": {
+          "reviewer": "core",
+          "finding": "Both new failure paths raise a named error at their origin: the malformed-record path at src/ingestion/parser.py:23 and the upstream-timeout path at src/ingestion/client.py:57; neither is masked by a fallback."
+        }
+      }
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": ["docs/architecture/layers.md"],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/valid-completion-evidence.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence.json
@@ -28,10 +28,11 @@
       "criterion_id": "code-quality-single-validation-path",
       "result": "pass",
       "evidence": {
-        "summary": "The shared validation path remains the only endpoint validation path.",
-        "artifact": {
-          "path": "src/ingestion/validation.py",
-          "description": "The endpoint delegates to the shared validator."
+        "summary": "The validation-entry fitness test confirms the shared validator is the single entry.",
+        "run": {
+          "command": "python -m unittest tests.test_validation_entry",
+          "result": "pass",
+          "output_summary": "one importer of the shared validator; single entry confirmed"
         }
       }
     }

--- a/tests/fixtures/artifacts/valid-contract-code-quality-projections.json
+++ b/tests/fixtures/artifacts/valid-contract-code-quality-projections.json
@@ -1,0 +1,33 @@
+{
+  "work_unit": "work-unit-485-code-quality-projections",
+  "title": "Code-quality projections inhabit both check kinds",
+  "criteria": [
+    {
+      "id": "code-quality-layer-import-direction",
+      "dimension": "code-quality",
+      "acceptance_criterion": "Source layers keep their import direction",
+      "statement": "Every import under src/ resolves within the source layers; the src-to-tests edge stays absent under the import-direction fitness function.",
+      "hollow_delivery": "A module under src/ imports a helper from tests/ and the change lands green.",
+      "check_kind": "executable",
+      "check": "Run `python -m tooling.import_direction --root . --forbid src:tests`; the run reports zero violations."
+    },
+    {
+      "id": "code-quality-earns-its-place",
+      "dimension": "code-quality",
+      "acceptance_criterion": "Keep it as simple as the need allows",
+      "statement": "Asked of the diff: does every element added or kept trace to a need this change verifies? It holds when the constraint each new element serves is nameable at its locus.",
+      "hollow_delivery": "A defensive abstraction, speculative parameter, or compatibility shim lands with no constraint that demands it.",
+      "check_kind": "attested",
+      "check": "Reviewer audits the diff against the universal, recording the locus where it holds or the finding where it fails."
+    },
+    {
+      "id": "code-quality-fail-loudly",
+      "dimension": "code-quality",
+      "acceptance_criterion": "Fail loudly, early, and exactly once",
+      "statement": "Asked of the diff: does each failure path the change adds surface its error where it occurs, named, exactly once? It holds when every new failure path has a loud, pointable locus.",
+      "hollow_delivery": "A fallback introduced by the change silently masks an error and downstream code builds on the false success.",
+      "check_kind": "attested",
+      "check": "Reviewer traces each failure path the diff adds, recording its loud locus or the silent spot where it fails."
+    }
+  ]
+}

--- a/tests/fixtures/artifacts/valid-contract.json
+++ b/tests/fixtures/artifacts/valid-contract.json
@@ -27,7 +27,7 @@
       "statement": "Record validation continues through the shared validator path.",
       "hollow_delivery": "A second validator is added for this endpoint only.",
       "check_kind": "executable",
-      "check": "Inspect tests and code paths for one validation entry."
+      "check": "Automated check: the validation-entry fitness test asserts exactly one module imports the shared validator (tests/test_validation_entry.py)."
     }
   ]
 }

--- a/tests/test_code_quality_dimension.py
+++ b/tests/test_code_quality_dimension.py
@@ -1,0 +1,370 @@
+import json
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+from tooling.artifact_schemas import (
+    ArtifactSchemaError,
+    detect_contract_evidence_defects,
+    load_artifact,
+    validate_artifact,
+    validate_contract_evidence,
+)
+from tooling.import_direction import find_violations, main as import_direction_main
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "artifacts"
+EMBEDDED_CORPUS = ROOT / "principles" / "PRINCIPLES.md"
+
+# The two judgment-shaped universals the projection exemplar attests. The
+# embedded corpus is the resolved corpus of a bare checkout and the consulted
+# authority here: the pin below resolves each name against the corpus file,
+# so the exemplar consults the corpus rather than inventing a second rulebook.
+EARNS_ITS_PLACE = "Keep it as simple as the need allows"
+FAIL_LOUDLY = "Fail loudly, early, and exactly once"
+PROJECTED_UNIVERSALS = {EARNS_ITS_PLACE, FAIL_LOUDLY}
+
+# The canonical exemplar's code-quality acceptance criterion — a join key
+# also consumed by tests/test_artifact_schemas.py as a warranted input.
+CANONICAL_CQ_CRITERION = "Validation remains centralized"
+
+
+def fixture(name: str) -> Path:
+    return FIXTURES / name
+
+
+def canonical_contract() -> dict:
+    return load_artifact("contract", fixture("valid-contract.json"))
+
+
+def canonical_evidence() -> dict:
+    return load_artifact(
+        "completion-evidence", fixture("valid-completion-evidence.json")
+    )
+
+
+def projection_contract() -> dict:
+    return load_artifact(
+        "contract", fixture("valid-contract-code-quality-projections.json")
+    )
+
+
+def projection_evidence() -> dict:
+    return load_artifact(
+        "completion-evidence",
+        fixture("valid-completion-evidence-code-quality-projections.json"),
+    )
+
+
+def hollow_contract() -> dict:
+    return load_artifact("contract", fixture("hollow-contract-code-quality.json"))
+
+
+def hollow_evidence() -> dict:
+    return load_artifact(
+        "completion-evidence",
+        fixture("hollow-completion-evidence-code-quality.json"),
+    )
+
+
+def code_quality_criteria(contract: dict) -> list[dict]:
+    return [
+        criterion
+        for criterion in contract["criteria"]
+        if criterion["dimension"] == "code-quality"
+    ]
+
+
+def embedded_corpus_titles() -> set[str]:
+    corpus = EMBEDDED_CORPUS.read_text(encoding="utf-8")
+    return set(re.findall(r"^\d+\. \*\*(.+?)\.\*\*", corpus, re.MULTILINE))
+
+
+class ImportDirectionFitnessTests(unittest.TestCase):
+    """The shipped reference fitness function: a structural layer edge is
+    checked by a run, a seeded violation goes red, and groundwork's own
+    layering answers to it."""
+
+    def seeded_tree(self, root: Path) -> None:
+        (root / "src").mkdir()
+        (root / "src" / "__init__.py").write_text("", encoding="utf-8")
+        (root / "src" / "service.py").write_text(
+            "from tests.helpers import fake_clock\n", encoding="utf-8"
+        )
+        (root / "tests").mkdir()
+        (root / "tests" / "__init__.py").write_text("", encoding="utf-8")
+        (root / "tests" / "helpers.py").write_text(
+            "fake_clock = object()\n", encoding="utf-8"
+        )
+
+    def test_seeded_cross_layer_import_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.seeded_tree(root)
+
+            violations = find_violations(root, [("src", "tests")])
+
+            self.assertEqual(1, len(violations))
+            violation = violations[0]
+            self.assertEqual(Path("src") / "service.py", violation.path)
+            self.assertEqual("tests.helpers", violation.module)
+            self.assertEqual("src", violation.layer)
+
+    def test_clean_tree_reports_no_violations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.seeded_tree(root)
+            (root / "src" / "service.py").write_text(
+                "from src import validation\n", encoding="utf-8"
+            )
+            (root / "src" / "validation.py").write_text("", encoding="utf-8")
+
+            self.assertEqual([], find_violations(root, [("src", "tests")]))
+
+    def test_cli_fails_a_violating_change_and_passes_a_clean_one(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.seeded_tree(root)
+
+            self.assertEqual(
+                1,
+                import_direction_main(
+                    ["--root", str(root), "--forbid", "src:tests"]
+                ),
+            )
+
+            (root / "src" / "service.py").write_text("", encoding="utf-8")
+            self.assertEqual(
+                0,
+                import_direction_main(
+                    ["--root", str(root), "--forbid", "src:tests"]
+                ),
+            )
+
+    def test_groundworks_own_layering_holds_under_the_checker(self) -> None:
+        # Golden rule #16 with in-house teeth: the library layer imports
+        # nothing from its test layer, verified by the same fitness function
+        # the exemplar declares.
+        self.assertEqual([], find_violations(ROOT, [("tooling", "tests")]))
+
+
+class ProjectionExemplarTests(unittest.TestCase):
+    """The projection exemplar inhabits both check kinds in the uniform
+    surfaces: an executable structural projection evidenced by a run, and
+    attested judgment projections evidenced by per-universal findings."""
+
+    def test_exemplar_carries_one_executable_and_two_attested_projections(
+        self,
+    ) -> None:
+        criteria = code_quality_criteria(projection_contract())
+
+        self.assertEqual(
+            {"executable": 1, "attested": 2},
+            {
+                kind: len(
+                    [c for c in criteria if c["check_kind"] == kind]
+                )
+                for kind in ("executable", "attested")
+            },
+        )
+
+    def test_attested_projections_consult_the_embedded_corpus(self) -> None:
+        attested = [
+            criterion
+            for criterion in code_quality_criteria(projection_contract())
+            if criterion["check_kind"] == "attested"
+        ]
+
+        titles = embedded_corpus_titles()
+        self.assertEqual(
+            PROJECTED_UNIVERSALS,
+            {criterion["acceptance_criterion"] for criterion in attested},
+        )
+        for criterion in attested:
+            with self.subTest(criterion=criterion["id"]):
+                self.assertIn(criterion["acceptance_criterion"], titles)
+
+    def test_executable_projection_is_evidenced_by_a_recorded_run(self) -> None:
+        contract = projection_contract()
+        evidence = projection_evidence()
+        executable_ids = {
+            criterion["id"]
+            for criterion in code_quality_criteria(contract)
+            if criterion["check_kind"] == "executable"
+        }
+
+        for result in evidence["results"]:
+            if result["criterion_id"] not in executable_ids:
+                continue
+            with self.subTest(criterion=result["criterion_id"]):
+                run = result["evidence"]["run"]
+                self.assertIn("import_direction", run["command"])
+                self.assertEqual("pass", run["result"])
+
+    def test_projection_pair_passes_the_shared_gate_with_warranted_universals(
+        self,
+    ) -> None:
+        evidence = projection_evidence()
+
+        validate_contract_evidence(
+            projection_contract(),
+            evidence,
+            warranted_dimensions={"code-quality"},
+            warranted_acceptance_criteria={"code-quality": PROJECTED_UNIVERSALS},
+        )
+
+        attestations = [
+            result["evidence"]["attestation"]
+            for result in evidence["results"]
+            if "attestation" in result["evidence"]
+        ]
+        self.assertEqual(2, len(attestations))
+        for attestation in attestations:
+            self.assertTrue(attestation["reviewer"])
+            self.assertTrue(attestation["finding"])
+
+
+class HollowCodeQualityTests(unittest.TestCase):
+    """A hollow code-quality criterion fails the same shared mechanism that
+    judges every dimension — never a code-quality-only detector."""
+
+    def test_hollow_exemplar_is_schema_valid_but_hollow(self) -> None:
+        contract = hollow_contract()
+
+        validate_artifact("contract", contract)
+        self.assertEqual(
+            [],
+            detect_contract_evidence_defects(contract, hollow_evidence()),
+        )
+
+    def test_hollow_code_quality_criterion_fails_the_same_warranted_check(
+        self,
+    ) -> None:
+        defects = detect_contract_evidence_defects(
+            hollow_contract(),
+            hollow_evidence(),
+            warranted_acceptance_criteria={"code-quality": {EARNS_ITS_PLACE}},
+        )
+
+        messages = {message for _path, message in defects}
+        self.assertIn(
+            f"dimension 'code-quality' does not declare"
+            f" warranted criterion {EARNS_ITS_PLACE!r}",
+            messages,
+        )
+
+        # Same detector, same message shape as the sibling dimension: a
+        # warranted miss for documentation templates to the identical string
+        # once dimension and criterion are substituted.
+        sentinel = "A new user completes the primary task from the README alone"
+        sibling = detect_contract_evidence_defects(
+            hollow_contract(),
+            hollow_evidence(),
+            warranted_acceptance_criteria={"documentation": {sentinel}},
+        )
+        sibling_shape = {
+            message.replace("documentation", "<dimension>").replace(
+                sentinel, "<criterion>"
+            )
+            for _path, message in sibling
+        }
+        code_quality_shape = {
+            message.replace("code-quality", "<dimension>").replace(
+                EARNS_ITS_PLACE, "<criterion>"
+            )
+            for _path, message in defects
+        }
+        self.assertEqual(sibling_shape, code_quality_shape)
+
+
+class ProjectionParityTests(unittest.TestCase):
+    """Code-quality projections answer to the same coverage and
+    evidence-shape checks as every dimension."""
+
+    def test_declared_projection_left_unevidenced_is_flagged_identically(
+        self,
+    ) -> None:
+        contract = projection_contract()
+        dropped = code_quality_criteria(contract)[0]["id"]
+        evidence = projection_evidence()
+        evidence["results"] = [
+            result
+            for result in evidence["results"]
+            if result["criterion_id"] != dropped
+        ]
+
+        with self.assertRaises(ArtifactSchemaError) as context:
+            validate_contract_evidence(contract, evidence)
+        self.assertIn(
+            ("results", f"contract criterion {dropped!r} has no completion evidence"),
+            context.exception.errors,
+        )
+
+    def test_executable_projection_without_a_run_is_flagged(self) -> None:
+        contract = projection_contract()
+        evidence = projection_evidence()
+        executable_ids = {
+            criterion["id"]
+            for criterion in code_quality_criteria(contract)
+            if criterion["check_kind"] == "executable"
+        }
+        for result in evidence["results"]:
+            if result["criterion_id"] in executable_ids:
+                result["evidence"] = {
+                    "summary": "An attestation cannot satisfy an executable projection.",
+                    "attestation": {
+                        "reviewer": "core",
+                        "finding": "The layer edge looked absent.",
+                    },
+                }
+
+        with self.assertRaises(ArtifactSchemaError) as context:
+            validate_contract_evidence(contract, evidence)
+        self.assertTrue(
+            any(
+                "executable criterion requires run or artifact evidence" in message
+                for _path, message in context.exception.errors
+            )
+        )
+
+
+class CanonicalExemplarTests(unittest.TestCase):
+    """The canonical exemplar's code-quality criterion is honestly
+    executable and wired into the warranted mechanism."""
+
+    def test_canonical_code_quality_criterion_declares_an_automated_check(
+        self,
+    ) -> None:
+        criteria = code_quality_criteria(canonical_contract())
+
+        self.assertEqual(1, len(criteria))
+        criterion = criteria[0]
+        self.assertEqual("executable", criterion["check_kind"])
+        self.assertIn("Automated check", criterion["check"])
+
+    def test_canonical_code_quality_evidence_is_a_recorded_run(self) -> None:
+        results = {
+            result["criterion_id"]: result
+            for result in canonical_evidence()["results"]
+        }
+        evidence = results["code-quality-single-validation-path"]["evidence"]
+
+        self.assertIn("run", evidence)
+        self.assertEqual("pass", evidence["run"]["result"])
+
+    def test_canonical_pair_passes_the_shared_gate_with_its_criterion_warranted(
+        self,
+    ) -> None:
+        validate_contract_evidence(
+            canonical_contract(),
+            canonical_evidence(),
+            warranted_dimensions={"code-quality"},
+            warranted_acceptance_criteria={
+                "code-quality": {CANONICAL_CQ_CRITERION}
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/import_direction.py
+++ b/tooling/import_direction.py
@@ -1,0 +1,120 @@
+"""Reference fitness function: layer import direction.
+
+Checks that no Python module inside one top-level layer imports from a
+forbidden top-level layer — the structurally-checkable code-quality
+projection the contract skill's code-quality dimension types as an
+``executable`` criterion. A run of this checker is the recorded evidence
+for such a criterion; a seeded violating change fails it.
+
+Scope, stated honestly: layers are top-level directories under the given
+root, and the checker resolves absolute ``import``/``from`` statements by
+their first module segment. Relative imports stay inside their own
+package and cannot cross top-level layers, so they are out of scope by
+construction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One forbidden layer edge found in the tree."""
+
+    path: Path
+    lineno: int
+    layer: str
+    module: str
+
+    def render(self) -> str:
+        return f"{self.path}:{self.lineno}: layer {self.layer!r} imports {self.module!r}"
+
+
+def _imported_modules(tree: ast.AST) -> list[tuple[int, str]]:
+    modules: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            modules.append((node.lineno, node.module))
+    return modules
+
+
+def find_violations(
+    root: Path, forbidden: list[tuple[str, str]]
+) -> list[Violation]:
+    """Return every forbidden layer edge under ``root``.
+
+    ``forbidden`` pairs name edges as ``(importer_layer, imported_layer)``:
+    a module whose path sits under ``importer_layer`` may not import a
+    module whose top-level package is ``imported_layer``.
+    """
+    root = Path(root)
+    violations: list[Violation] = []
+    for importer_layer, imported_layer in forbidden:
+        layer_dir = root / importer_layer
+        if not layer_dir.is_dir():
+            continue
+        for source in sorted(layer_dir.rglob("*.py")):
+            try:
+                tree = ast.parse(source.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue
+            for lineno, module in _imported_modules(tree):
+                if module.split(".")[0] == imported_layer:
+                    violations.append(
+                        Violation(
+                            path=source.relative_to(root),
+                            lineno=lineno,
+                            layer=importer_layer,
+                            module=module,
+                        )
+                    )
+    return violations
+
+
+def _parse_edge(raw: str) -> tuple[str, str]:
+    importer, separator, imported = raw.partition(":")
+    if not separator or not importer or not imported:
+        raise argparse.ArgumentTypeError(
+            f"forbidden edge {raw!r} must be 'importer_layer:imported_layer'"
+        )
+    return importer, imported
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail when a module in one top-level layer imports from a "
+            "forbidden top-level layer."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Project root whose top-level directories are the layers.",
+    )
+    parser.add_argument(
+        "--forbid",
+        action="append",
+        required=True,
+        type=_parse_edge,
+        metavar="IMPORTER:IMPORTED",
+        help="Forbidden layer edge; repeatable.",
+    )
+    args = parser.parse_args(argv)
+
+    violations = find_violations(Path(args.root), args.forbid)
+    for violation in violations:
+        print(violation.render(), file=sys.stderr)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #485. Child of #484 — the last leveling child.

Implements the residual delta specced in the freshen record (grounded at `98d1f158`): inhabitation of both check kinds and the warranted wiring for the code-quality dimension. No schema, detector, protocol-body, or contract-SKILL change — versions intact by design.

**Executable (AC1, AC2)** — `tooling/import_direction.py` ships as the reference fitness function (stdlib `ast`, layer-edge checker with CLI). `tests/test_code_quality_dimension.py` proves a seeded cross-layer import goes red and the clean tree green, and dogfoods it on groundwork itself: the `tooling → tests` edge is forbidden and holds — golden rule #16 with in-house teeth. The canonical exemplar's code-quality criterion is honestly executable: check names an automated fitness test; evidence is a recorded run (join keys `code-quality-single-validation-path` / "Validation remains centralized" preserved; the artifact-evidence fixture reworded as the check's product).

**Attested (AC3)** — projection exemplar pair: one executable import-direction criterion + two attested judgment projections in the question / failing-tell / holds-when grammar, each `acceptance_criterion` resolved **verbatim** against the embedded corpus (`principles/PRINCIPLES.md`) by a conformance pin — consult, don't model — with per-universal reviewer finding + identity.

**Hollow + parity (AC4)** — hollow pair (`hollow-*-code-quality`, escaping the valid-/invalid- sweeps by the established naming): schema-valid, plain-detector-clean, fails **only** the shared warranted check with message-shape identity to the documentation sibling. Unevidenced projection and executable-without-run both flagged by the shared mechanism.

**Doctrine (AC5)** — `code-quality-contract.md`: apparatus per projection shape, a *Structurally-checkable projections are executable* section naming the reference checker, and the mechanical stressed-universals → warranted-set wiring sentence with exemplar/test pointer (sibling of the documentation reference's). `code-quality-review.md`: the executable branch (run the declared check; evidence shaped by `check_kind`).

**Evidence** — RED observed at `98d1f158` (dimension tests fail: `tooling.import_direction` absent). GREEN at head: 408 tests OK (+15 over the 393 baseline, skipped=7 unchanged, zero regressions); `python -m tooling.conformance` 21/0; stale-string sweep clean.