### PR TITLE
fix(survey): protocol artifact prose matches the enforced schema — ADR + conformance gate close the class (#504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Prose is projection: protocol artifact prose is conformance-gated to the
+  owning schema** (#504). ADR-0008 ratifies the invariant — the manifest,
+  the artifact schemas, and the workflow contracts are the single home of
+  every structural fact; prose consults the home, is a gate-bound rendering
+  of it, or carries judgment only — with each consequence traced to its
+  enforcing file. `tooling/protocol_prose.py` is the gate: for every
+  manifest protocol it verifies that each field the `PROTOCOL.md` attributes
+  to an artifact (delivery-call block keys at any depth, backticked `###`
+  field headings) exists in the owning schema, modulo the documented
+  `instance_id`/`work_unit` envelope, by consulting the live schema files —
+  a schema change flips the check unedited, the tooth
+  `tests/test_protocol_prose_conformance.py` pins alongside the live-tree
+  gate, a parse-coverage floor for every producer, and a standing-red
+  fixture. Run against the pre-fix tree, the gate failed on exactly the
+  survey protocol's nine phantom `requirements` fields; survey's
+  §Requirements Structure now derives from `schemas/requirements.schema.json`
+  — the six real fields carry the section's forces/resists discipline, and
+  the Procedures own the inquiry whose judgment they carry (survey 1.1.0).
+
 - **Code quality is a first-class inhabitant of the contract machine**
   (#485). Structurally-checkable projections gain a real executable check:
   `tooling/import_direction.py` ships as the reference fitness function

--- a/docs/architecture/decisions/0008-prose-is-projection.md
+++ b/docs/architecture/decisions/0008-prose-is-projection.md
@@ -1,0 +1,80 @@
+# ADR-0008: Prose Is Projection
+
+**Status:** Proposed — delivered for operator review with groundwork#504 \
+**Date:** 2026-07-02
+
+## Context
+
+Groundwork's identity is enforced, not exhorted: every belief traces to its
+enforcing file. Runa injects each `PROTOCOL.md` whole as the per-tick
+instruction, so protocol prose is executed surface, not commentary — a prose
+defect is delivered into every run.
+
+The manifest, the artifact schemas, and the workflow contracts are the
+enforced substrate, but prose surfaces had no stated relation to it, and
+structural claims stood in prose with nothing binding them. At the pipeline's
+front door, the survey protocol's §Requirements Structure documented nine
+fields that `schemas/requirements.schema.json` — `additionalProperties:
+false` — forbids on any valid instance: an impossible artifact described in
+the very prompt that instructs its production, and no check could see it.
+groundwork#503 catalogues the wider class this instance belongs to.
+
+## Decision
+
+**Prose is projection.** `manifest.toml`, `schemas/`, and
+`workflow-contracts/` are the single home of every structural fact — artifact
+shapes, protocol edges, triggers, mechanics, dispositions. Every prose
+surface does exactly one of three things with a structural fact:
+
+- **consults** the home, by link or path;
+- is a **gate-bound rendering** of it — prose whose agreement with the home a
+  committed check verifies by consulting the home itself; or
+- carries only what the substrate cannot carry — judgment, discipline,
+  corruption recognition, rationale.
+
+A structural claim standing in prose with no binding gate is a defect of the
+class this methodology exists to close: discipline held by memory instead of
+enforced substrate.
+
+Three consequences, each traced to its enforcing file:
+
+1. **Protocol artifact prose is conformance-gated to the owning schema.**
+   Every field a `PROTOCOL.md` attributes to an artifact — a key in a fenced
+   delivery-call block, a backticked `###` field heading — exists in that
+   artifact type's schema, modulo the documented tool-parameter/injection
+   envelope (`instance_id`, runtime-injected `work_unit`). Enforced by
+   `tooling/protocol_prose.py`, exercised over the live tree by
+   `tests/test_protocol_prose_conformance.py` in the CI conformance job
+   (`.github/workflows/conformance.yml`). The gate consults the live schemas:
+   a schema change flips it without the gate being edited.
+2. **Runtime and deployment wiring state lives outside methodology prose.** A
+   protocol states the methodology's own seam — what it delivers, to which
+   tool, under which envelope — and stops; which runtime commands are wired,
+   installed, or pending belongs to the runtime's own repository and tracker.
+   Enforced at the installed-surface boundary by
+   `tests/test_protocol_artifact_delivery_docs.py` (the
+   interactive-adapter-bypass and injection-contract pins).
+3. **Architecture prose carries rationale; structural renderings live in
+   their substrate homes.** `manifest.toml`, `schemas/`, and
+   `workflow-contracts/` hold the structure, validated by
+   `tooling/conformance.py`; an architecture document links to those homes
+   and carries the why. A hand-maintained manifest copy, edge list, or schema
+   rendering in prose is a second editable home.
+
+## Consequences
+
+- **A methodology author classifies a structural sentence before writing
+  it.** Is the fact held by the manifest, a schema, or a workflow contract?
+  State it in that home; prose consults it. Is it runtime wiring state? It
+  belongs to the runtime's repository, not here. Is it judgment, discipline,
+  or rationale? Prose owns it. Is it a rendering that must appear in prose —
+  a delivery example, a field walk-through? Write it in a form a committed
+  gate binds to the home (delivery-call blocks and backticked `###` field
+  headings are bound per consequence 1); a rendering no gate binds does not
+  enter prose.
+- A schema evolution needs no coordinated prose sweep to stay honest: any
+  protocol prose the change strands turns red in CI, at the file and line
+  that must move.
+- The `take`, `decompose`, and `connecting-structure` surfaces are brought
+  under this decision by groundwork#503's remaining units; this ADR is the
+  record they trace to.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -35,5 +35,6 @@ only that the operator may still revise the decision.
 | [0005](0005-principles-corpus-configuration.md) | Principles Corpus Configuration | Provisional | 2026-06-12 |
 | [0006](0006-runtime-driven-self-install-surface.md) | Runtime-Driven Self-Install Surface | Proposed — delivered for operator review | 2026-06-12 |
 | [0007](0007-dimension-agnostic-contract-machine.md) | Dimension-Agnostic Contract Machine | Proposed — delivered for operator review | 2026-07-01 |
+| [0008](0008-prose-is-projection.md) | Prose Is Projection | Proposed — delivered for operator review | 2026-07-02 |
 
 New decisions add a row here in the same change.

--- a/protocols/survey/PROTOCOL.md
+++ b/protocols/survey/PROTOCOL.md
@@ -8,8 +8,8 @@ description: >-
   of inheriting the backlog, the current architecture, or a familiar project
   pattern.
 metadata:
-  version: "1.0.0"
-  updated: "2026-03-17"
+  version: "1.1.0"
+  updated: "2026-07-02"
 ---
 
 # Survey
@@ -54,82 +54,71 @@ completion of every step at maximum depth.
 
 ## Requirements Structure
 
-The `requirements` artifact must make the cognitive work legible. Each field
-exists for two reasons: it forces specific thinking, and it blocks a specific
-failure mode.
+The `requirements` artifact is defined by its schema:
+`schemas/requirements.schema.json` is the single home of its fields, and this
+section derives from it — a reader of the section and the schema sees one
+artifact. Each field must make the cognitive work legible: it carries a
+specific judgment out of the inquiry, and it blocks a specific failure mode.
 
-### `surveyed-territory`
+### `scope`
 
-What area was examined, what boundaries define it, and what was intentionally
-left outside this survey.
+Purpose and boundaries of the work: the territory examined and the bounded
+exigence chosen within it, with what falls outside stated as a boundary.
 
-This forces the agent to name the actual territory instead of speaking about
-"the project" in the abstract. It resists scope sprawl, scope timidity, and
-the false authority that comes from making claims about areas that were never
-actually examined.
+This forces the survey to name the actual territory and commit to one body of
+work inside it. It resists scope sprawl, scope timidity, false authority over
+areas never examined, and the "fix everything" survey that never chooses.
 
-### `descriptive-state`
+### `functional_requirements`
 
-Observed facts about what exists now: code, docs, work-units, workflows,
-architecture, operator signals, and evidence gathered from the territory.
+What the system should do — discrete items, each a normative need derived from
+the territory's purpose rather than from its current implementation.
 
-This forces observation before prescription. It resists fantasy, premature
-design, and project-type pattern matching by making the agent state what is
-actually present before deciding what is needed.
+This forces translation from assessment into decomposable behaviors. It
+resists purely descriptive reporting that never crosses into an actionable
+body of work.
 
-### `normative-needs`
+### `non_functional_requirements`
 
-What must be true that is not yet true, derived from the territory's purpose,
-audience, or constraints rather than from its current implementation.
+The qualities the work must hold — performance, security, reliability, and
+their kin — stated as needs, not as descriptions of current behavior.
 
-This forces the descriptive-normative split. It resists treating the current
-architecture, backlog, or coding style as the definition of correctness.
+This forces qualities to be derived from purpose and audience. It resists
+treating whatever the system currently exhibits as the definition of adequate.
 
-### `chosen-exigence`
+### `constraints`
 
-The one body of work that should move forward now.
+Technical and business boundaries the work must respect: the real ones —
+physics, contract, mandate, platform.
 
-This forces commitment. It resists both "fix everything" sprawl and timid
-surface work by requiring a single real need, not a bag of observations.
+This forces the split between genuine boundaries and inherited convention. It
+resists precedent-as-constraint and the architecture legitimism that smuggles
+the current structure in as a requirement.
 
-### `priority-reasoning`
+### `assumptions`
 
-Why the chosen exigence outranks other plausible directions right now.
+What is taken as given: the load-bearing beliefs the survey did not verify,
+stated where `decompose` can see them.
 
-This forces comparative judgment rather than instinct. It resists anchoring on
-the existing backlog, first-seen problem, or most familiar solution shape.
+This forces epistemic honesty about the unverified. It resists bluffing past
+missing evidence and building silently on unknowns — a material uncertainty
+either becomes an explicit assumption here or sends the survey back to
+`research`.
 
-### `rejected-alternatives`
+### `dependencies`
 
-Plausible frames, fixes, or work bodies that were considered and rejected, with
-reasons for rejection.
+External dependencies affecting decomposition: what outside the territory the
+work waits on or touches.
 
-This forces dissent against the most tempting wrong answers. It resists
-backlog anchoring, familiar-template projection, and the silent assumption that
-the first plausible frame must be the right one.
+This forces the outward edges to be named before units are cut. It resists
+work-unit graphs that discover their blockers at execution time.
 
-### `recommended-work`
-
-The bounded work package that `decompose` should turn into executable work-units.
-
-This forces translation from assessment into action. It resists purely
-descriptive reporting that never crosses into an actionable body of work.
-
-### `out-of-scope-or-deferred`
-
-Work noticed during survey that should not be taken forward in this assessment,
-with reasons for exclusion or deferral.
-
-This forces boundary discipline. It resists "while we're here" expansion and
-keeps the assessment honest about what it is not trying to solve.
-
-### `unknowns-or-research-needs`
-
-Material uncertainties that still affect confidence, plus any evidence that
-must still be gathered.
-
-This forces epistemic honesty. It resists bluffing past missing evidence and
-tells `decompose` where additional grounding or research may still be needed.
+The inquiry that fills these fields — orienting to the territory, separating
+descriptive state from normative need, surfacing and rejecting distorting
+frames, choosing a bounded exigence — is owned by the Procedures below. The
+fields carry that inquiry's judgment; they do not replace it, and a
+schema-valid artifact produced without the inquiry is artifact theater (see
+Corruption Modes).
 
 ## Procedures
 

--- a/tests/fixtures/protocol_prose/red_tree/manifest.toml
+++ b/tests/fixtures/protocol_prose/red_tree/manifest.toml
@@ -1,0 +1,15 @@
+# Minimal manifest for the protocol-prose red fixture. The schemas are the
+# live repository schemas, supplied by the test via `schemas_dir` — the
+# fixture keeps no second editable copy of any schema.
+name = "protocol-prose-red-fixture"
+
+[[artifact_types]]
+name = "requirements"
+
+[[protocols]]
+name = "survey"
+produces = ["requirements"]
+
+[[protocols]]
+name = "silent"
+produces = []

--- a/tests/fixtures/protocol_prose/red_tree/protocols/silent/PROTOCOL.md
+++ b/tests/fixtures/protocol_prose/red_tree/protocols/silent/PROTOCOL.md
@@ -1,0 +1,7 @@
+# Red fixture: silent
+
+A protocol that produces nothing, so it has no field vocabulary.
+
+### `orphan-field`
+
+Unattributable by construction.

--- a/tests/fixtures/protocol_prose/red_tree/protocols/survey/PROTOCOL.md
+++ b/tests/fixtures/protocol_prose/red_tree/protocols/survey/PROTOCOL.md
@@ -1,0 +1,24 @@
+# Red fixture: survey
+
+A protocol document that attributes fields its schema rejects — the
+standing red the gate must always catch.
+
+## Requirements Structure
+
+### `surveyed-territory`
+
+A field heading the requirements schema grants no property for.
+
+### `scope`
+
+A field heading the requirements schema does grant.
+
+## Delivery
+
+```
+requirements({
+  instance_id: "<slug>",
+  scope: "<purpose and boundaries>",
+  chosen_exigence: "<a key the schema rejects>"
+})
+```

--- a/tests/test_protocol_prose_conformance.py
+++ b/tests/test_protocol_prose_conformance.py
@@ -1,0 +1,196 @@
+"""The protocol-prose conformance gate: prose agrees with the owning schema.
+
+Four teeth, each protecting a distinct clause of the gate's contract:
+
+- the live tree passes, for every manifest protocol — the standing CI gate;
+- every producing protocol yielded at least one parsed delivery block, so a
+  silent parse miss can never green;
+- a document attributing fields the schema rejects fails, on both prose
+  surfaces (delivery-block key, backticked ``###`` field heading), against
+  the live schemas — the standing red;
+- removing a property from the schema flips the check on the live survey
+  document without the checker being edited — the gate consults the
+  authority, it does not snapshot vocabulary.
+"""
+
+import json
+import shutil
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+from tooling.protocol_prose import check_tree, schema_property_names
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMAS = ROOT / "schemas"
+RED_TREE = ROOT / "tests" / "fixtures" / "protocol_prose" / "red_tree"
+
+
+def manifest_protocols() -> list[dict]:
+    manifest = tomllib.loads((ROOT / "manifest.toml").read_text(encoding="utf-8"))
+    return manifest["protocols"]
+
+
+class LiveTreeConformanceTests(unittest.TestCase):
+    def test_live_tree_conforms_for_every_manifest_protocol(self) -> None:
+        report = check_tree(ROOT)
+
+        self.assertEqual(
+            [entry["name"] for entry in manifest_protocols()],
+            report.protocols,
+            "the gate reads the protocol set from the manifest",
+        )
+        self.assertEqual(
+            [],
+            [violation.render() for violation in report.violations],
+        )
+        self.assertTrue(report.passed)
+
+    def test_every_producing_protocol_yields_a_parsed_delivery_block(self) -> None:
+        report = check_tree(ROOT)
+
+        for entry in manifest_protocols():
+            if not entry.get("produces"):
+                continue
+            with self.subTest(protocol=entry["name"]):
+                self.assertGreaterEqual(
+                    report.delivery_blocks.get(entry["name"], 0),
+                    1,
+                    "a producer whose delivery block the parser cannot "
+                    "find would pass vacuously — absence must not green",
+                )
+
+
+class StandingRedTests(unittest.TestCase):
+    def test_phantom_attributions_fail_against_the_live_schemas(self) -> None:
+        report = check_tree(RED_TREE, schemas_dir=SCHEMAS)
+
+        found = {
+            (violation.protocol, violation.surface, violation.token)
+            for violation in report.violations
+        }
+        self.assertEqual(
+            {
+                ("survey", "field-heading", "surveyed-territory"),
+                ("survey", "delivery-block", "chosen_exigence"),
+                ("silent", "field-heading", "orphan-field"),
+            },
+            found,
+        )
+        for violation in report.violations:
+            with self.subTest(token=violation.token):
+                self.assertIn(
+                    "grants no such property",
+                    violation.render(),
+                )
+        granted_heading_flagged = any(
+            violation.token == "scope" for violation in report.violations
+        )
+        self.assertFalse(
+            granted_heading_flagged,
+            "a heading the schema grants is not a violation",
+        )
+
+    def test_violation_names_the_consulted_schema_file(self) -> None:
+        report = check_tree(RED_TREE, schemas_dir=SCHEMAS)
+
+        survey_violations = [
+            violation
+            for violation in report.violations
+            if violation.protocol == "survey"
+        ]
+        self.assertTrue(survey_violations)
+        for violation in survey_violations:
+            with self.subTest(surface=violation.surface):
+                self.assertEqual(
+                    SCHEMAS / "requirements.schema.json",
+                    violation.schema_path,
+                )
+
+
+class ConsultsTheAuthorityTests(unittest.TestCase):
+    def test_schema_property_removal_flips_the_check_unedited(self) -> None:
+        schema = json.loads(
+            (SCHEMAS / "requirements.schema.json").read_text(encoding="utf-8")
+        )
+        live_doc = (ROOT / "protocols" / "survey" / "PROTOCOL.md").read_text(
+            encoding="utf-8"
+        )
+        removable = [
+            name
+            for name in schema_property_names(schema)
+            if f"`{name}`" in live_doc and name not in schema.get("required", [])
+        ]
+        self.assertTrue(
+            removable,
+            "the live survey document names schema-granted fields; if this "
+            "fails, the prose no longer derives from the schema",
+        )
+        removed = sorted(removable)[0]
+        del schema["properties"][removed]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            (tree / "protocols" / "survey").mkdir(parents=True)
+            (tree / "schemas").mkdir()
+            (tree / "manifest.toml").write_text(
+                'name = "rename-flip"\n\n'
+                "[[artifact_types]]\n"
+                'name = "requirements"\n\n'
+                "[[protocols]]\n"
+                'name = "survey"\n'
+                'produces = ["requirements"]\n',
+                encoding="utf-8",
+            )
+            (tree / "protocols" / "survey" / "PROTOCOL.md").write_text(
+                live_doc, encoding="utf-8"
+            )
+            (tree / "schemas" / "requirements.schema.json").write_text(
+                json.dumps(schema), encoding="utf-8"
+            )
+
+            report = check_tree(tree)
+
+        flagged = {violation.token for violation in report.violations}
+        self.assertIn(
+            removed,
+            flagged,
+            "the schema moved and the unedited checker flipped — the gate "
+            "consults the schema, it does not snapshot vocabulary",
+        )
+
+    def test_baseline_live_survey_passes_with_the_full_schema(self) -> None:
+        live_doc = (ROOT / "protocols" / "survey" / "PROTOCOL.md").read_text(
+            encoding="utf-8"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            (tree / "protocols" / "survey").mkdir(parents=True)
+            (tree / "manifest.toml").write_text(
+                'name = "rename-flip-baseline"\n\n'
+                "[[artifact_types]]\n"
+                'name = "requirements"\n\n'
+                "[[protocols]]\n"
+                'name = "survey"\n'
+                'produces = ["requirements"]\n',
+                encoding="utf-8",
+            )
+            (tree / "protocols" / "survey" / "PROTOCOL.md").write_text(
+                live_doc, encoding="utf-8"
+            )
+            shutil.copytree(SCHEMAS, tree / "schemas")
+
+            report = check_tree(tree)
+
+        self.assertEqual(
+            [],
+            [violation.render() for violation in report.violations],
+            "the flip test's contrast baseline: the same document against "
+            "the unmodified schema is clean",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/protocol_prose.py
+++ b/tooling/protocol_prose.py
@@ -1,0 +1,299 @@
+"""Conformance gate: protocol artifact prose agrees with the owning schema.
+
+Every field a ``PROTOCOL.md`` attributes to an artifact must exist in that
+artifact type's schema. The gate consults the live schema files — it holds
+no field list of its own, so a schema rename flips the result without this
+module being edited.
+
+Two prose surfaces carry field attributions, and the gate reads both:
+
+- **Fenced delivery-call blocks** — ``artifact-type({ ... })`` inside a
+  fenced code block. Every key the block names, at any nesting depth, must
+  be a property name somewhere in the named type's schema, modulo the
+  documented tool-parameter/injection envelope (``instance_id`` is a tool
+  parameter extracted before body validation; ``work_unit`` is
+  runtime-injected on scoped artifacts — both boundaries are stated in each
+  producer's delivery paragraph and pinned by
+  ``tests/test_protocol_artifact_delivery_docs.py``).
+- **Backticked ``###`` headings** — the protocol-document convention for
+  presenting an artifact field as a §-level subject (survey's
+  §Requirements Structure is the form's home). Each such token must be a
+  property of one of the protocol's produced artifact types. A protocol
+  that produces nothing has no field vocabulary, so any backticked ``###``
+  heading there is unattributable by construction.
+
+Structural nesting, types, and required-ness stay the runtime validator's
+job (runa validates delivered instances against the same schemas); this
+gate closes exactly the prose class: a protocol describing a field no
+schema grants.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+ENVELOPE = frozenset({"instance_id", "work_unit"})
+
+_CALL_OPEN = re.compile(r"^(?P<name>[a-z][a-z0-9-]*)\(\{\s*$")
+_BLOCK_KEY = re.compile(r"^\s*(?P<key>[A-Za-z_][A-Za-z0-9_-]*)\s*:")
+_FIELD_HEADING = re.compile(r"^###\s+`(?P<token>[^`]+)`\s*$")
+_FENCE = re.compile(r"^\s*```")
+
+_SUBSCHEMA_LIST_KEYS = ("oneOf", "anyOf", "allOf", "prefixItems")
+_SUBSCHEMA_DICT_KEYS = (
+    "items",
+    "additionalProperties",
+    "propertyNames",
+    "if",
+    "then",
+    "else",
+    "not",
+    "contains",
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One field attributed in prose that the owning schema rejects."""
+
+    protocol: str
+    path: Path
+    lineno: int
+    surface: str  # "delivery-block" | "field-heading"
+    artifact: str
+    token: str
+    schema_path: Path
+
+    def render(self) -> str:
+        return (
+            f"{self.path}:{self.lineno}: protocol `{self.protocol}` "
+            f"{self.surface} names `{self.token}` on artifact "
+            f"`{self.artifact}`, but {self.schema_path} grants no such "
+            f"property"
+        )
+
+
+@dataclass
+class Report:
+    """What the gate read and what it found."""
+
+    protocols: list[str]
+    violations: list[Violation]
+    delivery_blocks: dict[str, int] = field(default_factory=dict)
+    headings: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        return not self.violations
+
+
+def schema_property_names(schema: object) -> set[str]:
+    """Every property name granted anywhere in a schema document.
+
+    Collected by walking the schema itself — ``properties`` maps,
+    ``patternProperties`` values, ``$defs``, combinators, and array item
+    schemas — so the vocabulary is the schema's, never this module's.
+    """
+
+    names: set[str] = set()
+
+    def walk(node: object) -> None:
+        if isinstance(node, dict):
+            props = node.get("properties")
+            if isinstance(props, dict):
+                for key, sub in props.items():
+                    names.add(key)
+                    walk(sub)
+            for map_key in ("$defs", "definitions", "patternProperties"):
+                mapping = node.get(map_key)
+                if isinstance(mapping, dict):
+                    for sub in mapping.values():
+                        walk(sub)
+            for list_key in _SUBSCHEMA_LIST_KEYS:
+                subs = node.get(list_key)
+                if isinstance(subs, list):
+                    for sub in subs:
+                        walk(sub)
+            for dict_key in _SUBSCHEMA_DICT_KEYS:
+                sub = node.get(dict_key)
+                if isinstance(sub, dict):
+                    walk(sub)
+        elif isinstance(node, list):
+            for sub in node:
+                walk(sub)
+
+    walk(schema)
+    return names
+
+
+def _manifest_protocols(manifest_path: Path) -> list[dict]:
+    manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    return list(manifest.get("protocols", []))
+
+
+def _manifest_artifact_types(manifest_path: Path) -> set[str]:
+    manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    return {entry["name"] for entry in manifest.get("artifact_types", [])}
+
+
+def _delivery_block_keys(
+    lines: list[str], start: int
+) -> tuple[list[tuple[int, str]], int]:
+    """Keys named inside one call block, from its opening line.
+
+    Returns ``(keys, next_index)`` where ``keys`` pairs each key with its
+    line number and ``next_index`` is the first line after the block.
+    Depth is tracked over braces and brackets so nested keys are read at
+    every level; the block ends when depth returns to zero or the fence
+    closes.
+    """
+
+    keys: list[tuple[int, str]] = []
+    depth = lines[start].count("{") + lines[start].count("[")
+    depth -= lines[start].count("}") + lines[start].count("]")
+    index = start + 1
+    while index < len(lines) and depth > 0:
+        line = lines[index]
+        if _FENCE.match(line):
+            break
+        match = _BLOCK_KEY.match(line)
+        if match:
+            keys.append((index + 1, match.group("key")))
+        depth += line.count("{") + line.count("[")
+        depth -= line.count("}") + line.count("]")
+        index += 1
+    return keys, index
+
+
+def check_tree(root: Path | str, schemas_dir: Path | str | None = None) -> Report:
+    """Run the gate over a groundwork tree.
+
+    ``root`` must hold ``manifest.toml`` and ``protocols/<name>/PROTOCOL.md``
+    for each manifest protocol. ``schemas_dir`` defaults to
+    ``root / "schemas"``; passing it lets a fixture tree consult the live
+    schemas rather than keep a second editable copy.
+    """
+
+    root_path = Path(root).resolve()
+    schemas_path = (
+        Path(schemas_dir).resolve() if schemas_dir is not None else root_path / "schemas"
+    )
+    manifest_path = root_path / "manifest.toml"
+    protocols = _manifest_protocols(manifest_path)
+    artifact_types = _manifest_artifact_types(manifest_path)
+
+    vocab_cache: dict[str, tuple[Path, set[str]]] = {}
+
+    def vocabulary(artifact: str) -> tuple[Path, set[str]]:
+        if artifact not in vocab_cache:
+            schema_path = schemas_path / f"{artifact}.schema.json"
+            schema = json.loads(schema_path.read_text(encoding="utf-8"))
+            vocab_cache[artifact] = (schema_path, schema_property_names(schema))
+        return vocab_cache[artifact]
+
+    report = Report(
+        protocols=[entry["name"] for entry in protocols], violations=[]
+    )
+
+    for entry in protocols:
+        name = entry["name"]
+        produces = list(entry.get("produces", []))
+        doc_path = root_path / "protocols" / name / "PROTOCOL.md"
+        lines = doc_path.read_text(encoding="utf-8").splitlines()
+        report.delivery_blocks[name] = 0
+        report.headings[name] = 0
+
+        index = 0
+        while index < len(lines):
+            line = lines[index]
+
+            call = _CALL_OPEN.match(line.strip())
+            if call and call.group("name") in artifact_types:
+                artifact = call.group("name")
+                report.delivery_blocks[name] += 1
+                keys, index = _delivery_block_keys(lines, index)
+                schema_path, granted = vocabulary(artifact)
+                for lineno, key in keys:
+                    if key in granted or key in ENVELOPE:
+                        continue
+                    report.violations.append(
+                        Violation(
+                            protocol=name,
+                            path=doc_path,
+                            lineno=lineno,
+                            surface="delivery-block",
+                            artifact=artifact,
+                            token=key,
+                            schema_path=schema_path,
+                        )
+                    )
+                continue
+
+            heading = _FIELD_HEADING.match(line)
+            if heading:
+                token = heading.group("token")
+                report.headings[name] += 1
+                attributed = False
+                nearest_schema: Path | None = None
+                for artifact in produces:
+                    schema_path, granted = vocabulary(artifact)
+                    nearest_schema = schema_path
+                    if token in granted or token in ENVELOPE:
+                        attributed = True
+                        break
+                if not attributed:
+                    report.violations.append(
+                        Violation(
+                            protocol=name,
+                            path=doc_path,
+                            lineno=index + 1,
+                            surface="field-heading",
+                            artifact=" | ".join(produces) or "(produces nothing)",
+                            token=token,
+                            schema_path=nearest_schema
+                            or schemas_path / "(no produced type)",
+                        )
+                    )
+
+            index += 1
+
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check every protocol's artifact prose against the owning "
+            "artifact schemas."
+        )
+    )
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default=str(Path(__file__).resolve().parents[1]),
+        help="Groundwork tree root (defaults to this repository).",
+    )
+    args = parser.parse_args(argv)
+
+    report = check_tree(Path(args.root))
+    for violation in report.violations:
+        print(violation.render())
+    if report.passed:
+        checked = sum(report.delivery_blocks.values())
+        print(
+            f"protocol prose conforms to the owning schemas "
+            f"({len(report.protocols)} protocols, {checked} delivery blocks)."
+        )
+        return 0
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
Closes #504. Layer 0 of epic #503.

## What this delivers, per acceptance criterion

1. **ADR-0008 — Prose Is Projection** (`docs/architecture/decisions/0008-prose-is-projection.md`, register row added in the same change). States the invariant and its three consequences, each traced to its enforcing file: (a) protocol artifact prose gated to the owning schema → `tooling/protocol_prose.py` + `tests/test_protocol_prose_conformance.py` in the CI conformance job; (b) runtime wiring state outside methodology prose → `tests/test_protocol_artifact_delivery_docs.py`; (c) architecture prose carries rationale, structural renderings live in `manifest.toml`/`schemas/`/`workflow-contracts/` → validated by `tooling/conformance.py`. Consequences section carries the author's classification rule (the Documentation contract input).
2. **Survey derives from the schema.** §Requirements Structure presents exactly the six schema fields, each with the section's forces-X/resists-Y discipline framing re-grounded from the retired phantom narration, and closes by stating the Procedures own the inquiry whose judgment the fields carry. The §deliver-requirements pointer into the section stays coherent. Survey 1.1.0.
3. **The gate consults the authority.** `tooling/protocol_prose.py` (stdlib-only, CLI-runnable like `import_direction`): for every manifest protocol, every key in a fenced delivery-call block (any nesting depth) and every backticked `###` field heading must exist in the owning artifact schema, modulo the documented envelope (`instance_id`, runtime-injected `work_unit`). The vocabulary is collected from the live schema file per run — a rename flips the check unedited, which `test_schema_property_removal_flips_the_check_unedited` proves mechanically (live survey doc + mutated schema in a temp tree → red; unmodified schema baseline → clean).
4. **Red-then-green on this defect.** Run at `4218d03d` pre-repair, the gate failed on exactly the nine phantom survey fields — every other delivery block across all nine protocols parsed clean. Post-repair: `protocol prose conforms to the owning schemas (9 protocols, 9 delivery blocks)`, exit 0. The red is permanent via the standing fixture (`tests/fixtures/protocol_prose/red_tree/` — mini-manifest + violating prose only; schemas are consulted from the live `schemas/` dir, no second copy) plus the rename-flip tooth.
5. **Runs where the other conformance checks run.** The test module is picked up by `python -m unittest discover -s tests` in `.github/workflows/conformance.yml` — no CI change needed. A parse-coverage floor (`every producing protocol yields ≥1 parsed delivery block`) keeps a silent parser miss from greening.

## Evidence

- Baseline at `4218d03d`: 408 OK (skipped=7). Final: **414 OK (skipped=7), +6, zero regressions**; `tooling.conformance` **21 passed, 0 failed**.
- RED transcript (pre-repair): nine `field-heading` violations, lines 61–126 of `protocols/survey/PROTOCOL.md`, each naming `schemas/requirements.schema.json` as the consulted authority.
- Out of scope honored: requirements schema untouched; take/decompose/connecting-structure untouched (#505–#507); existing vocabulary/absence gates untouched (#476/#477).