### PR TITLE
fix(take): take closes at its capstone — the session surface advances the pipeline (#505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Take closes at its capstone — the session surface advances the
+  pipeline** (#505). ADR-0008's second consequence applied to `take`: Step
+  6's carry-through instructed the agent to drive `plan` → `implement` →
+  `verify` → `submit` itself and encoded runtime wiring state ("`runa go
+  --work-unit` … not yet wired") that runa HEAD falsifies — session-mode
+  `go` is wired with a one-tick contract, and the installed interactive
+  handoff atop the same file already says the opposite. The step also
+  restated `plan`'s contract-centered design beside its home. The step and
+  its three modes (`abandon-at-contract`, `delegate-to-unwired-runtime`,
+  `mechanics-as-plan`) are gone: the final step delivers the `contract` and
+  states the seam — the session surface computes the next ready station
+  from artifact state and advances the work to it, per runa's
+  session-surface contract and the manifest's trigger declarations — with
+  the no-runtime fallback retained as the methodology's own. Plan-shape
+  discipline stays at `plan` (`contract-detachment`, `file-inventory-plan`,
+  and the schema-enforced `criterion_mapping`). The corrected boundary is
+  pinned: the take gates assert the five-step capstone close, the seam
+  terms, and the corruption-mode set by equality, and a new protocol-wide
+  gate in `tests/test_protocol_artifact_delivery_docs.py` holds every
+  protocol's prose free of runtime-wiring-state claims (take 3.7.0).
+
 - **Dependency-graph notation conflict resolved.** `templates.md` mandated
   ASCII art while the decompose protocol and `work-unit-model.md` mandated
   Mermaid `graph TD` plus a layered text summary. The Mermaid + layered

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -2,13 +2,12 @@
 name: take
 description: >-
   Contract-first entry of the scoped pipeline: receive an already-selected
-  work-unit, prepare the workspace, establish the contract that
-  defines done, and carry that contract through the pipeline to a submitted
-  change. The contract produced here is the spine every downstream protocol
-  carries to land; until the runtime sequences the stations autonomously,
-  take carries it. Trigger on: 'take', 'take work', 'start work-unit'.
+  work-unit, prepare the workspace, and establish the contract that
+  defines done. The contract produced here is the spine every downstream
+  protocol carries to land; the session surface advances the pipeline from
+  it. Trigger on: 'take', 'take work', 'start work-unit'.
 metadata:
-  version: "3.6.0"
+  version: "3.7.0"
   updated: "2026-07-02"
 ---
 
@@ -121,50 +120,16 @@ proves it, or records it.
 
    Runa validates the remaining artifact body fields against the contract
    schema, persists the artifact, and records it in the artifact store.
-   Where no runtime is present to accept the MCP tool — a checkout that is
-   not an initialized runa project — author the same contract as a committed
-   workspace artifact (the contract JSON, or the work-unit issue if there is
-   no workspace store) so the spine exists and binds the test-first cycle
-   either way.
 
-6. **Carry the contract through to a submitted change.** Take does not end
-   at contract delivery. When the runtime sequences the pipeline
-   autonomously, it advances the work station to station; until then, take
-   carries it — that bridging is take's job at the door.
-
-   The carry begins at `plan`, and the plan is where the work converges.
-   The plan that serves this work is the `plan` protocol's contract-centered
-   design: the goal stated from the contract's criteria, each criterion
-   mapped by `criterion_id` to the steps that make it true, and the test
-   strategy that turns each executable criterion into failing evidence
-   before the change satisfies it. Where the harness plans before it
-   executes, *that design is the plan you surface for approval* — not a
-   narration of pipeline mechanics, which station comes next or which
-   command advances it. Lead with the contract: criterion coverage across
-   every declared dimension, the absence of any gap through which a
-   delivery the contract accepts as done could still fail, and how each
-   executable criterion is driven red-then-green through the check its
-   contract entry names — a scenario test or a structural, coherence, and
-   conformance gate. Do not encode gates as scenarios. Surface that, and
-   accepting the plan is accepting the contracted work — full convergence at
-   the planning surface.
-
-   On acceptance, carry it forward yourself. You are already the agent:
-   deliver the `implementation-plan` artifact through its output tool to
-   advance `plan`, then drive the remaining stations directly — `implement`
-   (build it test-first; every executable criterion has failing evidence
-   before its code or documentation change, `contract-after-code`
-   forbidden), `verify` (every criterion evidenced, the change sound),
-   `submit`
-   (deliver the change for review) — opening
-   `runa-mcp` in session mode for the work-unit and, at each station,
-   reading its context, doing the work, producing its artifact, advancing.
-   Do not hand the carry-through to `runa go --work-unit`: that spawns a
-   separate agent that is not yet wired, and the work stalls; until it is
-   wired, you drive the session directly. Do not stop at a boundary waiting
-   to be carried. Review and land — the independent-judgment gate and the
-   governance close — follow once every scenario or gate is green and verify
-   passes.
+   Delivering the contract is take completing: the session surface computes
+   the next ready station from artifact state and advances the work to it —
+   the seam runa's session-surface contract
+   (`docs/session-surface-contract.md` in the runa repository) and the
+   manifest's trigger declarations own. Where no runtime is present
+   to accept the MCP tool — a checkout that is not an initialized runa
+   project — author the same contract as a committed workspace artifact (the
+   contract JSON, or the work-unit issue if there is no workspace store) so
+   the spine exists and binds the test-first cycle either way.
 
 ## Scale
 
@@ -202,20 +167,6 @@ begins — the dose is proportional.
   loses workspace isolation and makes `submit` harder.
 - `state-lag`: the tracker not reflecting that this work-unit is in
   progress. Inaccurate state is planning debt for every other session.
-- `abandon-at-contract`: delivering the contract and stopping —
-  handing the work to a runtime that is not sequencing it. The contract
-  becomes a definition of done that nothing executes, and the stations are
-  silently skipped. Until the runtime carries the work, take does.
-- `mechanics-as-plan`: surfacing a narration of pipeline mechanics — which
-  station is next, which command advances it — as the plan, instead of
-  running `plan` to produce the contract-centered design. Nothing
-  contract-shaped is put up to accept, only a procedure to run; the
-  convergence is lost.
-- `delegate-to-unwired-runtime`: handing the carry-through to `runa go
-  --work-unit` (the autonomous agent-spawn) while it is not yet wired,
-  instead of driving the session yourself. The work stalls at a spawned
-  agent that never advances — a quieter `abandon-at-contract`. Until that
-  path is wired, you are the driver.
 - `dimension-declaration-only`: naming documentation or code-quality
   dimensions without defining the validation each must satisfy. The
   contract has labels but no teeth.

--- a/tests/test_protocol_artifact_delivery_docs.py
+++ b/tests/test_protocol_artifact_delivery_docs.py
@@ -45,6 +45,25 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
                 with self.subTest(path=path.relative_to(ROOT), phrase=phrase):
                     self.assertNotIn(phrase, body)
 
+    def test_protocol_prose_carries_no_runtime_wiring_state(self) -> None:
+        """ADR-0008 consequence 2: a protocol states the methodology's own
+        seam and stops; which runtime commands are wired, configured, or
+        pending belongs to the runtime's own repository and tracker."""
+        forbidden = [
+            "not yet wired",
+            "until it is wired",
+            "until the runtime",
+            "`runa go",
+            "spawns a separate agent",
+            "you drive the session",
+        ]
+
+        for protocol in manifest_protocols():
+            body = normalized_protocol(protocol["name"])
+            for phrase in forbidden:
+                with self.subTest(protocol=protocol["name"], phrase=phrase):
+                    self.assertNotIn(phrase, body)
+
     def test_all_artifact_producing_protocols_explain_mcp_tool_input_boundary(self) -> None:
         producers = [protocol for protocol in manifest_protocols() if protocol["produces"]]
 

--- a/tests/test_take_protocol_contract_dimensions.py
+++ b/tests/test_take_protocol_contract_dimensions.py
@@ -154,25 +154,34 @@ class TakeProtocolContractDimensionTests(unittest.TestCase):
         self.assertNotIn("deferred", delivery)
         self.assertNotIn("behavior_form", delivery)
 
-    def test_carry_through_leads_with_criterion_coverage_across_every_dimension(self) -> None:
-        carry = normalized(step(read(TAKE_PROTOCOL), 6))
-        carry_lower = carry.lower()
+    def test_take_ends_at_the_capstone_and_states_the_session_surface_seam(self) -> None:
+        body = read(TAKE_PROTOCOL)
+        steps = section(body, "Steps")
 
+        self.assertIsNone(
+            re.search(r"^6\. \*\*", steps, flags=re.MULTILINE),
+            "take carries a step past the capstone",
+        )
+
+        delivery = normalized(step(body, 5))
         for expected in [
-            "criterion coverage",
-            "every declared dimension",
-            "`criterion_id`",
-            "red-then-green",
-            "every executable criterion",
-            "structural, coherence, and conformance",
-            "do not encode gates as scenarios",
+            "Delivering the contract is take completing",
+            "session surface computes the next ready station from artifact state",
+            "advances the work to it",
+            "Where no runtime is present",
         ]:
             with self.subTest(expected=expected):
-                self.assertIn(expected.lower(), carry_lower)
+                self.assertIn(expected, delivery)
 
-        self.assertNotIn("behavior_form", carry)
-        self.assertNotIn("scenario coverage for runtime behavior", carry_lower)
-        self.assertNotIn("gate coverage for a documentation-deliverable", carry_lower)
+        body_lower = normalized(body).lower()
+        for phrase in [
+            "carry the contract through",
+            "carry it forward yourself",
+            "drive the remaining stations",
+            "do not stop at a boundary",
+        ]:
+            with self.subTest(phrase=phrase):
+                self.assertNotIn(phrase, body_lower)
 
     def test_existing_take_discipline_sections_and_corruption_modes_survive(self) -> None:
         body = read(TAKE_PROTOCOL)
@@ -188,19 +197,21 @@ class TakeProtocolContractDimensionTests(unittest.TestCase):
             with self.subTest(heading=heading):
                 self.assertIn(f"## {heading}", body)
 
-        corruption_modes = normalized(section(body, "Corruption Modes"))
-        for mode in [
-            "contract-after-code",
-            "scope-creep",
-            "criteria-parroting",
-            "skip-preparation",
-            "state-lag",
-            "abandon-at-contract",
-            "mechanics-as-plan",
-            "delegate-to-unwired-runtime",
-        ]:
-            with self.subTest(mode=mode):
-                self.assertIn(mode, corruption_modes)
+        corruption_modes = section(body, "Corruption Modes")
+        named_modes = re.findall(r"^- `([a-z-]+)`", corruption_modes, flags=re.MULTILINE)
+        self.assertEqual(
+            [
+                "contract-after-code",
+                "scope-creep",
+                "criteria-parroting",
+                "skip-preparation",
+                "state-lag",
+                "dimension-declaration-only",
+                "gate-as-scenario",
+                "lifecycle-modeling",
+            ],
+            named_modes,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #505. Part of epic #503; traces to ADR-0008 (consequence 2).

## What this does

`take` now ends where its capstone lands. Step 6 ("Carry the contract through to a submitted change") and its three corruption modes (`abandon-at-contract`, `delegate-to-unwired-runtime`, `mechanics-as-plan`) are removed. The final step (5, Deliver the contract spine) states the seam in positive present form: *the session surface computes the next ready station from artifact state and advances the work to it* — consulting runa's session-surface contract by path and the manifest's trigger declarations — and retains the one degraded-mode sentence (no-runtime fallback) as the methodology's own. The frontmatter description drops the carry-through and its "until the runtime sequences the stations" temporal trace. take 3.6.0 → 3.7.0; CHANGELOG entry under Unreleased → Fixed.

Plan-shape discipline is not restated at take: `plan` owns it (`contract-detachment`, `file-inventory-plan`, and the schema-enforced `criterion_mapping` the validator holds for every criterion).

## Criterion mapping

- **AC1 (capstone + seam)** → `test_take_ends_at_the_capstone_and_states_the_session_surface_seam`: Steps section carries no step 6; step 5 states the seam terms and retains the fallback; the whole body carries no onward-driving instruction (the AC's hollow guard: "carry the contract through", "carry it forward yourself", "drive the remaining stations", "do not stop at a boundary").
- **AC2 (no runtime-wiring state)** → new protocol-wide gate `test_protocol_prose_carries_no_runtime_wiring_state` in `tests/test_protocol_artifact_delivery_docs.py` — the file ADR-0008 consequence 2 names as this boundary's enforcing home. Six wiring-state phrase forms forbidden across every manifest protocol; the AC's hollow ("may not be wired") has no foothold because the seam sentence carries no wiring modality at all.
- **AC3 (mode set polices real failures)** → mode-survival test upgraded to set-equality on the eight-mode repaired set; a resurrected stale mode fails it. The mechanics-as-plan guard is not re-homed at `plan`: its premise (surfacing a plan yourself at take) left with the carry, and a mechanics-narration "plan" cannot pass the machine — the implementation-plan schema + validator require a `criterion_mapping` covering every contract criterion, and `contract-detachment` names the prose-level failure.
- **AC4 (installed surface coherent; gates green)** → projected take document now gives one instruction path (handoff: record output, `advance`, stop — body: delivering the contract is take completing); take-dimension gates green; interactive-session-surface register unaffected (runa-binary-gated, reads no prose).
- **AC5 (version + changelog)** → 3.7.0, Keep-a-Changelog entry.

## Evidence

- **RED at `c0878b4`** (tests first, protocol unmodified): 8 failures, each on exactly this unit's defect — step 6 present; all six wiring phrases found in take and only take; mode set 11 ≠ 8.
- **GREEN at `0694a46`**: suite **415 OK (skipped=7)** (+1 net over the 414 baseline; one test replaced 1-for-1, one gate added); `tooling.protocol_prose` 9 protocols / 9 delivery blocks conform; `tooling.conformance` **21/0**.
- Mid-implementation, the substrate's own C-5 forge-leakage gate rejected a first seam draft that consulted the session-surface contract by `github.com` URL — repaired at source to a forge-neutral repo-path consult (ADR-0008 sanctions consult "by link **or path**"). The gate run that caught it: `protocols/2: protocol take leaks forge-specific token github.com`.

## Scope check

Four files: the protocol, the two test files that bind to the removed apparatus (per the unit's scope clause), CHANGELOG. Steps 1–4 and Step 5's delivery apparatus untouched (#484 leveling content intact — `test_named_apparatus_agrees_with_contract_skill` and the step-4/5 pins all green). The handoff document untouched (already correct).
