### PR TITLE
fix(decompose): the work-unit craft has one home — the protocol consults it, and delivery prose states the present architecture (#506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **One craft home** (#506). The work-unit authoring craft lives only in
+  `skills/work-unit-craft/SKILL.md`; `protocols/decompose/PROTOCOL.md` is the
+  decompose protocol — titled as itself, owning its own moves (procedures,
+  epic decomposition, delivery, triggers) and a protocol-level corruption-mode
+  set (`kitchen-sink-epic`, `graph-omission`, and the new
+  `refinement-as-first-delivery`, distilled from the delivery rules), and
+  consulting the skill by link for the craft it no longer restates. The
+  skill's What Belongs absorbs the two atoms the deleted guidelines carried
+  (hard-only dependencies; parent linkage). §deliver-work-unit and acquire's
+  placement state the present architecture in positive form — the two coupled
+  delivery surfaces, and the two sessions that host acquisition — with the
+  runtime-pending fork retired. The templates reference is titled for the
+  work-unit vocabulary. `tests/test_work_unit_craft_skill.py` pins the
+  corrected boundary: the protocol's title, its consult link, and its
+  protocol-level mode set. decompose 1.0.0->1.1.0, work-unit-craft
+  1.2.0->1.3.0, acquire 1.0.0->1.0.1.
+
 - **Uniform pipeline carry** (#494). The scoped pipeline now carries the
   uniform contract structure end to end, and the contract-dimension
   conformance tests pin symmetry instead of the retired per-dimension

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -1,18 +1,26 @@
 ---
 name: decompose
 description: >-
-  Transfer problem understanding across context boundaries through well-formed
-  work-units. Produce `work-unit` artifacts: creating, decomposing, refining,
-  and triaging. Close-state review happens here; the close itself is performed
-  by `land`.
+  The work-unit protocol. Produce `work-unit` artifacts: create, refine, and
+  triage work-units, decompose epics into them, and deliver each through the
+  `work-unit` MCP tool with its connector ticket handle. Close-state review
+  happens here; the close itself is performed by `land`. The authoring craft
+  lives in the `work-unit-craft` skill; this protocol consults it.
+metadata:
+  version: "1.1.0"
+  updated: "2026-07-02"
 ---
 
-# Work-Unit Craft
+# Decompose
 
-A work-unit transfers problem understanding across a context boundary — from the
-person who sees the problem to the agent who will solve it. The agent has no
-access to your context, your codebase familiarity, or your unstated assumptions.
-Everything it needs must be in the work-unit.
+`decompose` is the pipeline's work-unit surface. It creates, refines, and
+triages `work-unit` artifacts, decomposes epics into them, and reviews
+close-state before `land` seals the close. The authoring craft those moves
+apply — outcomes over prescription, the sovereignty test, contract inputs,
+body-vs-comment authority, and the corruption modes that make records
+mis-steer implementing agents — lives in the
+[`work-unit-craft` skill](../../skills/work-unit-craft/SKILL.md); this
+protocol consults that home and owns only its own moves.
 
 `decompose` is also Groundwork's acquisition surface: it is the sole unscoped
 producer of the `work-unit` artifact. Ordinary planning reaches this protocol
@@ -29,20 +37,6 @@ For the work-unit state model and dependency graph format, see
 For first-principles constraint verification before framing work-units, use
 `reckon`.
 
-## The Central Discipline
-
-**Work-units describe what must be true, not how to get there.**
-
-A work-unit that says "Replace X with Y" has already made the design decision. If
-that decision is wrong, the implementing agent will faithfully execute the wrong
-solution — and the further the prescription travels through decomposition,
-planning, and implementation, the harder it is to catch. The work-unit author's job
-is to describe the problem and the desired end state. The implementer's job is
-to find the path.
-
-This is not a stylistic preference. It is the structural defense against the
-most common failure mode in work-unit-driven development.
-
 ## Guidelines
 
 ### Scope and sizing
@@ -55,43 +49,6 @@ completion ambiguous. When you notice scope creeping across boundaries, split.
 agent session — from reading context through passing verification. Oversized
 work-units cause context loss mid-execution; undersized work-units create coordination
 overhead that exceeds the work itself.
-
-### Acceptance criteria
-
-**Criteria describe outcomes, not activities.** "Refactor the parser" is an
-activity — it passes when someone did something, not when something is true.
-"Parser returns typed errors for malformed input" is an outcome — it passes when
-a specific observable behavior exists. Every criterion should be verifiable by
-running a command or inspecting an artifact.
-
-**Include testing and documentation expectations.** If the change needs tests,
-say what kind (unit, integration, behavior). If it affects user-facing behavior,
-include documentation updates as criteria. Making these explicit prevents the
-implementer from treating them as optional.
-
-### Contract inputs
-
-Every work-unit authoring pass records contract inputs across the dimensions
-the `work-unit-craft` skill names: behavior, documentation, and code quality.
-Behavior inputs are the positive acceptance criteria. Documentation inputs are
-recipient outcomes, using `orient` for the audience taxonomy. Code quality
-inputs point to the principles corpus and name stressed universals when the
-work puts any under special pressure. The `contract` skill owns the lifecycle
-these inputs enter; decompose consults it and does not restate it.
-
-The authoring pass must consider every dimension and leave authored
-teeth-bearing inputs for every dimension the change has. Density may be
-light: one recipient outcome or one projected universal can be enough when a
-dimension is lightly touched. Coverage is never zero. A record is incomplete
-when a present dimension has no input a hollow delivery could fail, or when
-it hides inputs the implementer needs.
-
-### Dependencies
-
-**Explicit and hard only.** Dependencies name other work-units that represent
-true blockers — work that literally cannot proceed without the dependency being
-complete. Preferred ordering is not a dependency. Soft dependencies create
-false bottlenecks that serialize work unnecessarily.
 
 ### Epics and decomposition
 
@@ -117,16 +74,6 @@ Capability-epic release identity belongs to the commons release authority:
 ADR-0011, ADR-0012, ADR-0014, and `ECOSYSTEM-RELEASE.md`. Decompose requires
 the terminal ecosystem-release step, but does not define the manifest schema,
 version choice, verification, or publication procedure.
-
-### The work-unit as contract
-
-**Must stand alone without external context.** A work-unit is a contract, not a
-conversation. The implementer may be a different agent, in a different session,
-with no access to the discussion that produced the work-unit. Summary states what
-and why. Scope names concrete files or modules. Criteria are binary pass/fail.
-Task work-units reference their parent epic or milestone so the work has context
-in the work-unit graph. If the work-unit requires reading a Slack thread or "seeing
-the earlier discussion" to understand, it is incomplete.
 
 ## Procedures
 
@@ -201,8 +148,8 @@ A well-bounded task has:
 4. Re-apply the contract input pass from `work-unit-craft`, preserving any
    behavior, documentation, and code quality inputs that remain true and adding
    any missing special inputs.
-5. Re-verify the central discipline — does any criterion or scope statement
-   prescribe an implementation approach?
+5. Re-verify `work-unit-craft`'s central discipline — does any criterion or
+   scope statement prescribe an implementation approach?
 
 ### triage-work-units
 
@@ -225,12 +172,11 @@ owns the pre-close review; `land` owns the seal.
 
 ### deliver-work-unit
 
-Tracker operations in the procedures above — searching existing work-units,
-labels, stale-age review, and parent-epic checklist updates — remain required
-for `decompose`'s current forge-tracker-coupled workflow. Delivering the
-`work-unit` artifact through runa's MCP tool does not replace those tracker
-surfaces. Full runa-native `decompose` — where work-units live as runa
-artifacts with tracker as an optional sync target — is separate future work.
+Delivery is two coupled surfaces. The tracker operations the procedures above
+perform — searching existing work-units, labels, stale-age review, and
+parent-epic checklist updates — act on the planning home; the `work-unit` MCP
+tool call below persists the execution-scoped artifact that carries the
+connector handle back to it.
 
 Deliver each `work-unit` artifact by invoking the `work-unit` MCP tool once
 per delivered artifact. Every work-unit is tracker-backed. For a newly created
@@ -317,34 +263,13 @@ values, not tracker shorthand such as `#123`, `123`, `work-unit-123`, or
 
 ## Corruption Modes
 
-- `implicit-how`: implementation prescription leaks into scope or criteria.
-  The work-unit says "use library X" or "replace A with B" instead of describing
-  the required end state.
-  *Recognition: read scope and criteria aloud — if they name tools, patterns,
-  or implementation steps rather than observable outcomes, prescription has
-  leaked in.*
-
-- `activity-criteria`: criteria describe activities ("refactor", "clean up",
-  "investigate") rather than outcomes. They pass when someone did something,
-  not when something is true.
-  *Recognition: ask "can I verify this by running a command or inspecting an
-  artifact?" If no, it is an activity.*
-
-- `dependency-blindness`: blockers exist but are not surfaced. The implementer
-  discovers mid-session that prerequisite work is incomplete.
-  *Recognition: before filing, ask "what must already be true for this work
-  to start?" If the answer references unfinished work, that is a dependency.*
+The authoring corruption modes live in `work-unit-craft`; the modes below are
+decompose's own — epic, graph, and delivery misuse.
 
 - `kitchen-sink-epic`: an epic that accumulates loosely related work until it
   is too large to reason about or track. No clear deliverable boundary.
   *Recognition: if you cannot state the epic's done condition in one sentence,
   it is too broad.*
-
-- `premature-work-units`: filing detailed task work-units for work that depends on
-  unresolved design decisions. The work-units will need rewriting when the
-  decisions land.
-  *Recognition: if the work-unit's scope would change based on an open question,
-  the question must be answered first (spike work-unit).*
 
 - `graph-omission`: an epic with 4+ tasks has no dependency graph or layered
   execution order, forcing implementers to discover sequencing by reading
@@ -352,8 +277,19 @@ values, not tracker shorthand such as `#123`, `123`, `work-unit-123`, or
   *Recognition: if someone asked "what can I work on right now?" and you
   cannot answer without reading all task bodies, the graph is missing.*
 
+- `refinement-as-first-delivery`: a refinement is delivered as if it were a
+  first delivery — `create-ticket` invoked, a fresh `instance_id` minted, or
+  `handle` re-derived for an already-delivered work-unit. The tracker gains a
+  second ticket for the same work, or the artifact store gains a duplicate
+  whose inbound `dependencies` still point at the stale instance.
+  *Recognition: before delivering, ask "does a delivered artifact for this
+  work-unit already exist?" If yes, the delivery is a refinement — reuse its
+  `instance_id` and carry its `handle` through unchanged.*
+
 ## Cross-References
 
+- `work-unit-craft` (skill): the authoring craft every procedure applies —
+  the single home of record discipline and its corruption modes.
 - `reckon`: first-principles constraint verification before work-unit framing,
   refinement, and epic decomposition.
 - `acquire` (skill): the mirror of this protocol's create path — decompose

--- a/protocols/decompose/references/templates.md
+++ b/protocols/decompose/references/templates.md
@@ -1,6 +1,6 @@
-# Issue Templates
+# Work-Unit Templates
 
-Concrete templates for each issue type. Copy and fill in the sections.
+Concrete templates for each work-unit type. Copy and fill in the sections.
 All templates use GitHub-flavored markdown.
 
 ## Table of Contents

--- a/skills/acquire/SKILL.md
+++ b/skills/acquire/SKILL.md
@@ -8,8 +8,8 @@ description: >-
   of decompose's create path: decompose creates the ticket it delivers;
   acquire adopts the ticket it is given, and creates no ticket.
 metadata:
-  version: "1.0.0"
-  updated: "2026-06-11"
+  version: "1.0.1"
+  updated: "2026-07-02"
 ---
 
 # Acquire
@@ -30,10 +30,9 @@ is indistinguishable downstream from a decomposed one: same `handle`, same
 
 This is a skill, not a protocol, because it runs when there is no artifact
 state for a trigger to fire on. It belongs to whatever surface hosts a
-work-unit delivery: today, a `decompose`-scoped session (the `work-unit`
-MCP tool is served there); under the cold-start runtime entrypoint
-([tesserine/runa#188](https://github.com/tesserine/runa/issues/188)), the
-session that entrypoint opens.
+work-unit delivery: a `decompose`-scoped session, where the `work-unit` MCP
+tool is served, and the promised-entry session a targeted intent opens at
+cold start.
 
 ## Steps
 

--- a/skills/work-unit-craft/SKILL.md
+++ b/skills/work-unit-craft/SKILL.md
@@ -9,8 +9,8 @@ description: >-
   and the corruption modes that make records mis-steer the agents who
   read them.
 metadata:
-  version: "1.2.0"
-  updated: "2026-07-01"
+  version: "1.3.0"
+  updated: "2026-07-02"
   origin: >-
     Adapted from pentaxis93/with-claude
     _shared/methodology/issue-craft.md (internal), renamed and
@@ -398,7 +398,12 @@ to start?" If the answer references unfinished work, that is a dependency.
 - **Declared contract conformance:** when work conforms to an existing
   contract, consult the declared contract, derive criteria from its
   declarations, and verify positively against the declaration.
-- **Dependencies:** Work-unit references that represent true blockers.
+- **Dependencies:** Work-unit references that represent true blockers — work
+  that cannot start until the dependency is complete. Preferred ordering is
+  not a dependency; soft dependencies serialize independent work into false
+  bottlenecks.
+- **Parent linkage:** Task work-units reference their parent epic or
+  milestone so the record sits in the work-unit graph.
 
 ## What Does Not Belong in a Record
 

--- a/tests/test_work_unit_craft_skill.py
+++ b/tests/test_work_unit_craft_skill.py
@@ -174,6 +174,25 @@ class WorkUnitCraftSkillTests(unittest.TestCase):
             with self.subTest(expected=expected):
                 self.assertIn(expected, corruption_modes)
 
+    def test_decompose_is_titled_as_itself_and_consults_the_craft_home(self) -> None:
+        body = read_decompose_protocol()
+
+        self.assertRegex(body, r"(?m)^# Decompose$")
+        self.assertIn("skills/work-unit-craft/SKILL.md", body)
+
+    def test_decompose_corruption_modes_are_protocol_level(self) -> None:
+        body = read_decompose_protocol()
+        corruption_modes = normalized(section(body, "Corruption Modes"))
+
+        self.assertIn("`work-unit-craft`", corruption_modes)
+        for expected in [
+            "`kitchen-sink-epic`",
+            "`graph-omission`",
+            "`refinement-as-first-delivery`",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, corruption_modes)
+
     def test_decompose_procedures_apply_the_contract_input_pass(self) -> None:
         body = read_decompose_protocol()
         create_work_unit = normalized(


### PR DESCRIPTION
Closes #506. Part of #503; traces to ADR-0008.

**AC1 — one craft home.** The protocol carries no restatement of the skill's central discipline or its corruption modes; the transfer-boundary opening, the Central Discipline section, the acceptance-criteria/contract-inputs/dependencies/standalone-contract guidelines, and the four skill-owned modes (`implicit-how`, `activity-criteria`, `dependency-blindness`, `premature-work-units`≈`premature-record`) are removed; the skill is consulted by link (opening, procedures, Cross-References). The protocol's own set names epic/graph/delivery misuse — `kitchen-sink-epic`, `graph-omission`, and the new `refinement-as-first-delivery` distilled from §deliver's standing rules — each absent from the skill. Reader-diff of the pair finds no duplicated normative paragraph; the two atoms the deleted guidelines carried (hard-only dependencies, parent linkage) move to the skill's What Belongs as the receiving home.

**AC2.** `# Decompose`, frontmatter description matches; metadata added per house convention (decompose 1.0.0→1.1.0 — it was the sole versionless protocol).

**AC3.** §deliver-work-unit opens on the present architecture in positive form: the two coupled delivery surfaces and the operations each comprises. No current/future framing anywhere in the file.

**AC4.** acquire states both hosting surfaces as they exist (`decompose`-scoped session; the promised-entry session a targeted intent opens at cold start); the runa#188 fork is gone (acquire 1.0.1).

**AC5.** `# Work-Unit Templates`; gate-pinned section structure and the `issue_lint`-schema-coupled fenced headings untouched; reference-link gate and the documented `issue_lint.py` pointer green.

**Evidence.** RED at `c0878b48`: the two new boundary tests fail against the unrepaired tree (title, consult link, `refinement-as-first-delivery` all absent). GREEN: suite **416 OK** (414 baseline +2, zero regressions, skipped=7); `tooling.conformance` 21/0; `tooling.protocol_prose` clean (9 protocols, 9 delivery blocks). Every pre-existing pin on these files (procedures span, delivery-identity rules, epic taxonomy, templates epic-example regexes, contract-lifecycle surface bans) passes untouched.

**Stressed universals:** Single Home, Positive Form. work-unit-craft 1.2.0→1.3.0; CHANGELOG entry under Unreleased/Changed.