### PR TITLE
fix(acquire,take): entry grounds on the whole ticket — body as spec, comment log as review state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Entry grounds on the whole ticket** (#516). Forge-capability re-vendored
+  at `1.2.0` (immutable pin `b229fb1`): the `read-ticket` snapshot carries an
+  optional ordered `comments` log. `acquire` (v1.1.0) reads the ticket whole
+  and surfaces the log as entry context, with the one-way discipline extended
+  — the artifact materializes from the body; the log is read, never persisted
+  (`log-blindness` names the entry failure). `take`'s Frame step (v3.8.0)
+  gains the review-state grounding discipline: the body is the spec, the log
+  is the running record, and on a resume the newest review directives at the
+  submitted head govern (`stale-directive-followership` names the framing
+  failure). Gated by the re-pinned drift test, a materializer identity test
+  (artifact provably unchanged by the log's presence, log never persisted),
+  a vendored-snapshot admission check, and entry-surface prose tokens.
+
 - **Prose is projection: protocol artifact prose is conformance-gated to the
   owning schema** (#504). ADR-0008 ratifies the invariant — the manifest,
   the artifact schemas, and the workflow contracts are the single home of

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -7,7 +7,7 @@ description: >-
   protocol carries to land; the session surface advances the pipeline from
   it. Trigger on: 'take', 'take work', 'start work-unit'.
 metadata:
-  version: "3.7.0"
+  version: "3.8.0"
   updated: "2026-07-02"
 ---
 
@@ -44,6 +44,16 @@ proves it, or records it.
    description-inferred boundaries when the arrays are absent). Do not start
    work whose `dependencies` are still open; a blocked work-unit is a
    substrate signal, not an invitation.
+
+   Ground the frame in the whole ticket. The ticket body is the work-unit's
+   spec; its comment log — surfaced at entry by `acquire`, carried in the
+   `read-ticket` snapshot per forge-capability `1.2.0` — is the running
+   record: review state, dispositions, and directives live there. On a
+   resume — a unit with a delivered change-proposal or an open review
+   round — the newest review directives at the submitted head govern the
+   work; the body remains the spec, and directives refine delivery against
+   it. Weigh each log entry by recency and standing: a directive superseded
+   by a newer round, or by a body amendment, is record, not direction.
 
 4. **Author validation defined across the contract.** First reckon it:
    authoring the contract is a generative act — open the resolved principles
@@ -163,6 +173,9 @@ begins — the dose is proportional.
   work-units.
 - `criteria-parroting`: copying acceptance criteria verbatim as scenarios
   without refinement into observable Given/When/Then behavior.
+- `stale-directive-followership`: framing a resume from older comment-trail
+  direction. The newest review directives at the submitted head govern;
+  the body is the spec — a superseded directive is record, not direction.
 - `skip-preparation`: authoring the contract on dirty or unbranched ground —
   loses workspace isolation and makes `submit` harder.
 - `state-lag`: the tracker not reflecting that this work-unit is in

--- a/schemas/forge-capability/v1/forge-capability.schema.json
+++ b/schemas/forge-capability/v1/forge-capability.schema.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "x-tesserine-canonical": {
-    "version": "1.1.0",
-    "schema_url": "https://raw.githubusercontent.com/tesserine/commons/6924159fc4ff58745f0e2c68ed16849ffd9b4086/schemas/forge-capability/v1/forge-capability.schema.json"
+    "version": "1.2.0",
+    "schema_url": "https://raw.githubusercontent.com/tesserine/commons/b229fb1a840c27ced31d582b40d766f4f441dcf6/schemas/forge-capability/v1/forge-capability.schema.json"
   },
   "title": "Forge Capability",
-  "description": "Canonical schema for the forge capability connector tool-set and operation payloads. Version 1.1.0. commons is the spec authority; FORGE-CAPABILITY.md carries the governing prose and ADR-0005 describes the system-conventions pattern under which this lives. When this schema and FORGE-CAPABILITY.md disagree, FORGE-CAPABILITY.md is authoritative.",
+  "description": "Canonical schema for the forge capability connector tool-set and operation payloads. Version 1.2.0. commons is the spec authority; FORGE-CAPABILITY.md carries the governing prose and ADR-0005 describes the system-conventions pattern under which this lives. When this schema and FORGE-CAPABILITY.md disagree, FORGE-CAPABILITY.md is authoritative.",
   "type": "object",
   "required": ["capability", "version", "handle_schema", "tools"],
   "additionalProperties": false,
@@ -14,7 +14,7 @@
       "const": "forge"
     },
     "version": {
-      "const": "1.1.0"
+      "const": "1.2.0"
     },
     "handle_schema": {
       "const": "#/$defs/handle"
@@ -402,6 +402,26 @@
         }
       }
     },
+    "comment-entry": {
+      "type": "object",
+      "required": ["body"],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "type": "string",
+          "minLength": 1
+        },
+        "author": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_at": {
+          "type": "string",
+          "description": "Provider-normalized timestamp.",
+          "minLength": 1
+        }
+      }
+    },
     "ticket-snapshot": {
       "type": "object",
       "required": ["handle", "title", "state"],
@@ -420,6 +440,13 @@
         "state": {
           "type": "string",
           "minLength": 1
+        },
+        "comments": {
+          "type": "array",
+          "description": "Ordered comment log, oldest first. The ticket body is the work-unit's spec; the comment log is its running record — review state, dispositions, and directives.",
+          "items": {
+            "$ref": "#/$defs/comment-entry"
+          }
         }
       }
     },

--- a/skills/acquire/SKILL.md
+++ b/skills/acquire/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   of decompose's create path: decompose creates the ticket it delivers;
   acquire adopts the ticket it is given, and creates no ticket.
 metadata:
-  version: "1.0.1"
+  version: "1.1.0"
   updated: "2026-07-02"
 ---
 
@@ -44,8 +44,13 @@ cold start.
    ```
 
    The deployment-selected connector owns provider coordinates and
-   credentials. Groundwork receives `{handle, title, body, state}`, where
-   `handle` is the connector-issued `{ id, display }` identity.
+   credentials. Groundwork receives the whole ticket:
+   `{handle, title, body, state}` plus, per forge-capability `1.2.0`, an
+   optional ordered `comments` log — `handle` is the connector-issued
+   `{ id, display }` identity. The body is the work-unit's spec; the
+   comment log is its running record — review state, dispositions, and
+   directives. Surface the log to the session as entry context so the
+   session grounds on the whole ticket, not the spec alone.
 
 2. **Materialize the artifact body.** Pipe the read-ticket output through
    the materializer:
@@ -59,7 +64,10 @@ cold start.
    It derives the work-unit body — `title`, `description`, and
    `acceptance_criteria` from the ticket content, `handle` carried through
    verbatim — and the `instance_id` (`work-unit-<sha256(handle.id)>`). The
-   derivation never invents content (see step 3).
+   derivation never invents content (see step 3). The artifact
+   materializes from the ticket body alone: the comment log is read as
+   entry context, never persisted into the artifact — the ticket remains
+   the planning home, and the artifact carries the spec.
 
 3. **Surface gaps; never invent.** When the ticket does not map cleanly onto
    the required schema fields — no extractable acceptance criteria, an empty
@@ -98,6 +106,10 @@ cold start.
 
 ## Corruption Modes
 
+- `log-blindness`: handing off to `take` with the ticket's comment log
+  unread and unsurfaced. The snapshot carries the running record so the
+  session grounds on the whole ticket; an entry that reads the spec alone
+  executes blind to its own live corrections.
 - `ticket-creation`: calling `create-ticket` during acquisition. Acquisition
   adopts an existing ticket; creating one is `decompose`'s path, and doing
   both makes a second ticket for the same work.
@@ -117,4 +129,5 @@ cold start.
 - `take` (protocol): proceeds on the acquired artifact through its existing
   contract; owns tracker claiming.
 - `read-ticket` (connector capability operation): emits
-  `{handle, title, body, state}` for the selected connector.
+  `{handle, title, body, state}` and, per forge-capability `1.2.0`, the
+  optional ordered `comments` log for the selected connector.

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -89,6 +89,33 @@ class MaterializeTicketTests(unittest.TestCase):
         )
         self.assertRegex(payload["instance_id"], r"^work-unit-[0-9a-f]{64}$")
 
+    def test_comment_log_leaves_the_materialized_artifact_unchanged(self) -> None:
+        bare = {
+            "handle": {"id": "ticket:log-bearing", "display": "TRACK-LOG"},
+            "title": "task(entry): resume a unit carrying a live review record",
+            "body": TICKET_BODY,
+            "state": "open",
+        }
+        with_log = {
+            **bare,
+            "comments": [
+                {"body": "**Freshen pass — 2026-07-02** grounded at head; freshen-in-place."},
+                {
+                    "body": "Review round 2: required correction — rename the gate before resume.",
+                    "author": "operator",
+                    "created_at": "2026-07-02T10:53:26Z",
+                },
+            ],
+        }
+
+        bare_result = materialize(json.dumps(bare))
+        log_result = materialize(json.dumps(with_log))
+
+        self.assertEqual(0, bare_result.returncode, bare_result.stderr)
+        self.assertEqual(0, log_result.returncode, log_result.stderr)
+        self.assertEqual(bare_result.stdout, log_result.stdout)
+        self.assertNotIn("comments", json.loads(log_result.stdout)["artifact"])
+
     def test_materializer_identity_uses_handle_id_not_display(self) -> None:
         first = {
             "handle": {"id": "ticket:stable-identity", "display": "First display"},

--- a/tests/test_forge_capability.py
+++ b/tests/test_forge_capability.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from jsonschema import Draft202012Validator
 
 from tooling.artifact_schemas import ArtifactSchemaError, validate_artifact
+from tooling.forge_capability import CAPABILITY_PROVENANCE_URL, CAPABILITY_VERSION
 from tooling.conformance import run_conformance
 from tooling.workflow_contracts import workflow_registry_from_manifest
 
@@ -13,11 +14,6 @@ from tooling.workflow_contracts import workflow_registry_from_manifest
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMAS = ROOT / "schemas"
 VENDORED_SCHEMA = SCHEMAS / "forge-capability" / "v1" / "forge-capability.schema.json"
-PROVENANCE_URL = (
-    "https://raw.githubusercontent.com/tesserine/commons/"
-    "6924159fc4ff58745f0e2c68ed16849ffd9b4086/"
-    "schemas/forge-capability/v1/forge-capability.schema.json"
-)
 EXPECTED_OPERATIONS = {
     "read-ticket",
     "create-ticket",
@@ -47,12 +43,12 @@ class ForgeCapabilityTests(unittest.TestCase):
         schema = vendored_schema()
 
         self.assertEqual("forge", schema["properties"]["capability"]["const"])
-        self.assertEqual("1.1.0", schema["properties"]["version"]["const"])
+        self.assertEqual(CAPABILITY_VERSION, schema["properties"]["version"]["const"])
         self.assertEqual("#/$defs/handle", schema["properties"]["handle_schema"]["const"])
         self.assertEqual(
             {
-                "version": "1.1.0",
-                "schema_url": PROVENANCE_URL,
+                "version": CAPABILITY_VERSION,
+                "schema_url": CAPABILITY_PROVENANCE_URL,
             },
             schema["x-tesserine-canonical"],
         )
@@ -224,6 +220,36 @@ class ForgeCapabilityTests(unittest.TestCase):
             "state": "open",
         }
         Draft202012Validator(schema).evolve(schema=ticket_snapshot).validate(snapshot)
+        snapshot["comments"] = [
+            {"body": "Freshen record."},
+            {
+                "body": "Review round 2: required correction.",
+                "author": "operator",
+                "created_at": "2026-07-02T10:53:26Z",
+            },
+        ]
+        Draft202012Validator(schema).evolve(schema=ticket_snapshot).validate(snapshot)
+
+    def test_entry_surfaces_ground_on_the_whole_ticket(self) -> None:
+        acquire = (ROOT / "skills" / "acquire" / "SKILL.md").read_text(encoding="utf-8")
+        take = (ROOT / "protocols" / "take" / "PROTOCOL.md").read_text(encoding="utf-8")
+
+        for token in [
+            "`comments`",
+            "entry context",
+            "never persisted into the artifact",
+            "`log-blindness`",
+        ]:
+            with self.subTest(surface="acquire", token=token):
+                self.assertIn(token, acquire)
+
+        for token in [
+            "comment log",
+            "newest review directives at the submitted head",
+            "`stale-directive-followership`",
+        ]:
+            with self.subTest(surface="take", token=token):
+                self.assertIn(token, take)
 
 
 if __name__ == "__main__":

--- a/tests/test_take_protocol_contract_dimensions.py
+++ b/tests/test_take_protocol_contract_dimensions.py
@@ -204,6 +204,7 @@ class TakeProtocolContractDimensionTests(unittest.TestCase):
                 "contract-after-code",
                 "scope-creep",
                 "criteria-parroting",
+                "stale-directive-followership",
                 "skip-preparation",
                 "state-lag",
                 "dimension-declaration-only",

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -403,7 +403,7 @@ def _manifest_capability_contract_errors(root: Path) -> list[tuple[str, str]]:
 
     metadata = schema.get("x-tesserine-canonical")
     if metadata != {"version": CAPABILITY_VERSION, "schema_url": CAPABILITY_PROVENANCE_URL}:
-        errors.append(("schemas/forge-capability/v1/forge-capability.schema.json", "vendored forge capability provenance is not immutable v1.1.0"))
+        errors.append(("schemas/forge-capability/v1/forge-capability.schema.json", f"vendored forge capability provenance is not immutable v{CAPABILITY_VERSION}"))
     if schema.get("properties", {}).get("handle_schema", {}).get("const") != "#/$defs/handle":
         errors.append(("schemas/forge-capability/v1/forge-capability.schema.json", "forge capability handle_schema must point at #/$defs/handle"))
     if len(forge_operation_names(schema)) != 8:

--- a/tooling/forge_capability.py
+++ b/tooling/forge_capability.py
@@ -8,10 +8,10 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 CAPABILITY_SCHEMA = ROOT / "schemas" / "forge-capability" / "v1" / "forge-capability.schema.json"
-CAPABILITY_VERSION = "1.1.0"
+CAPABILITY_VERSION = "1.2.0"
 CAPABILITY_PROVENANCE_URL = (
     "https://raw.githubusercontent.com/tesserine/commons/"
-    "6924159fc4ff58745f0e2c68ed16849ffd9b4086/"
+    "b229fb1a840c27ced31d582b40d766f4f441dcf6/"
     "schemas/forge-capability/v1/forge-capability.schema.json"
 )
 


### PR DESCRIPTION
Implements tesserine/groundwork#516. Consumes forge-capability `1.2.0` (tesserine/commons#100, landed at `b229fb1`).

**Surfaces**
- **Vendor** — `schemas/forge-capability/v1/` re-vendored byte-current with commons @ `b229fb1` (proved: stripped of the provenance block, the file equals the canonical byte-for-byte); `x-tesserine-canonical` → `{1.2.0, immutable b229fb1 URL}`.
- **Pin discipline** — the provenance pin previously lived in two editable homes (`tooling/forge_capability.py` + a test-local literal), hand-synced; the pin's single home is now `tooling/forge_capability.py`, the drift test consults it, and conformance C-5's message renders the expected version instead of narrating a stale one.
- **`acquire` v1.1.0** — step 1 reads the ticket whole and surfaces the log as entry context; the one-way discipline is extended (the artifact materializes from the body; the log is read, never persisted); `log-blindness` names the entry failure.
- **`take` v3.8.0** — Frame gains the review-state grounding discipline: the body is the spec, the log is the running record, and on a resume the newest review directives at the submitted head govern; `stale-directive-followership` names the framing failure. The mode-enumeration gate updated in kind.
- **Tests** — materializer identity under a directive-bearing log: output byte-identical with and without `comments`, and `comments` never persisted into the artifact; the vendored snapshot admits the log; entry-surface prose tokens pinned; CHANGELOG entry.

**Evidence** — at `294e0e8`: `python -m unittest discover -s tests` → 421 OK (7 runa-gated skips, unchanged); `python -m tooling.conformance` → 21/21; `./scripts/release-check metadata` → pass.

Out of scope holds: no work-unit artifact schema change (the log is session context, not artifact content); the connector implementation is tesserine/runa#228.