### PR TITLE
test: re-ground vocabulary proxy gates

### DIFF
--- a/docs/architecture/groundwork-skill-ontology-row-1-audit.md
+++ b/docs/architecture/groundwork-skill-ontology-row-1-audit.md
@@ -58,23 +58,22 @@ Groundwork scoped pipeline.
 
 ## Protocol Reduction Test
 
-Row-1 answer to "holds for 100% of cases?": No. Most protocols expose a
-single cognitive band under a typed shell, but `review` currently wraps the
-domain-specific `code-review` projection rather than an extracted universal
-quality-review skill, and `take` carries temporary runtime-bridging work in
-addition to contract-first entry.
+Row-1 answer to "holds for 100% of cases?": No. Each protocol exposes a
+cognitive band through a Groundwork-specific typed shell, but none reduces
+fully to the universal candidate because each row keeps domain wrapper
+obligations in the protocol boundary.
 
 | Protocol | Universal Candidate | Reduction | Reason |
 |---|---|---|---|
-| decompose | work-unit-craft | yes | The protocol body is the work-unit-craft discipline plus delivery of `work-unit` artifacts and tracker identity. |
-| implement | test-driven-implementation | yes | The cognitive band is RED-GREEN-REFACTOR; the shell binds it to implementation-plan input and `test-evidence` output. |
-| land | governance-closure | yes | The cognitive band is approved-version closure; forge apply, disposition reflection, and `completion-record` delivery are the domain wrapper. |
-| plan | decision-complete-planning | yes | The cognitive band is convergence before mutation; the wrapper maps gates or scenarios to an `implementation-plan`. |
+| decompose | work-unit-craft | no | The protocol body uses the work-unit-craft discipline, but delivery of `work-unit` artifacts and tracker identity remains in the protocol shell. |
+| implement | test-driven-implementation | no | The cognitive band is RED-GREEN-REFACTOR, but the shell binds it to implementation-plan input and `test-evidence` output. |
+| land | governance-closure | no | The cognitive band is approved-version closure, but forge apply, disposition reflection, and `completion-record` delivery remain the domain wrapper. |
+| plan | decision-complete-planning | no | The cognitive band is convergence before mutation, but the wrapper maps Groundwork gates or scenarios to an `implementation-plan`. |
 | review | quality-review | no | The protocol depends on `code-review`, a software projection. The universal quality-review parent is predicted but not yet extracted. |
-| submit | proposal-submission | yes | The cognitive band is packaging verified work for review; forge delivery and `change-proposal` shape are wrapper concerns. |
-| survey | disciplined-inquiry | yes | The cognitive band is separating descriptive state from normative need; the wrapper turns `intent` into `requirements`. |
+| submit | proposal-submission | no | The cognitive band is packaging verified work for review, but forge delivery and `change-proposal` shape are wrapper concerns. |
+| survey | disciplined-inquiry | no | The cognitive band is separating descriptive state from normative need, but the wrapper turns `intent` into `requirements`. |
 | take | contract-first-entry | no | The core band is contract-first entry, but the current body also owns workspace preparation, tracker claiming, and temporary carry-through to later stations. |
-| verify | evidence-gate | yes | The cognitive band is evidence before completion claims; the wrapper records Groundwork gate or scenario coverage in `completion-evidence`. |
+| verify | evidence-gate | no | The cognitive band is evidence before completion claims, but the wrapper records Groundwork gate or scenario coverage in `completion-evidence`. |
 
 ## Projection Seams
 

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -184,14 +184,15 @@ work-unit, first invoke the connector capability `create-ticket` operation and
 carry the returned `{ id, display }` handle into the artifact body. `create-ticket`
 is a first-delivery-only step: refinement never calls it, and decompose does not
 adopt a pre-existing tracker ticket into a new artifact. If a tracker ticket
-already exists, this delivery path must not create a second ticket for it. The
-object below is MCP tool input, not artifact body. `instance_id` is a tool
-parameter that names the artifact instance; it is extracted before validating
-artifact content, becomes the workspace filename, and must not appear in the
-artifact body. `work-unit` is a planning-phase artifact: the agent supplies the
-schema fields shown below, and runa does not inject `work_unit`. Work-unit
-artifact bodies have no top-level `work_unit` field and no forge identity
-outside the connector handle. Do not write the workspace JSON file directly.
+already exists, this delivery path must not create a second ticket for it.
+The object below is MCP tool input, not artifact body.
+`instance_id` is a tool parameter.
+It names the artifact instance and becomes the workspace filename.
+It must not appear in the artifact body.
+`work-unit` is a planning-phase artifact: the agent supplies the schema fields shown below, and runa does not inject `work_unit`.
+Work-unit artifact bodies have no top-level `work_unit` field and no forge
+identity outside the connector handle. Do not write the workspace JSON file
+directly.
 
 Use a fresh `instance_id` when creating a new work-unit. Reuse the existing
 `instance_id` when refining an already-delivered work-unit artifact so artifact

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -71,8 +71,8 @@ The protocol is not a forge operation. It must not activate from a raw
    The object below is MCP tool input, not artifact body.
    `instance_id` is a tool parameter that names the artifact instance; it is
    extracted before validating artifact content, becomes the workspace
-   filename, and must not appear in the artifact body. Runa injects
-   `work_unit` from session context; the agent does not supply `work_unit`.
+   filename, and must not appear in the artifact body.
+   Runa injects `work_unit` from session context; the agent does not supply `work_unit`.
    Do not write the workspace JSON file directly:
 
    ```

--- a/protocols/plan/PROTOCOL.md
+++ b/protocols/plan/PROTOCOL.md
@@ -92,8 +92,8 @@ will hold of the change. One mapping shape serves every dimension.
    tool input, not artifact body.
    `instance_id` is a tool parameter that names the artifact instance; it is
    extracted before validating artifact content, becomes the workspace
-   filename, and must not appear in the artifact body. Runa injects
-   `work_unit` from session context; the agent does not supply `work_unit`.
+   filename, and must not appear in the artifact body.
+   Runa injects `work_unit` from session context; the agent does not supply `work_unit`.
    Do not write the workspace JSON file directly.
 
    ```

--- a/protocols/submit/PROTOCOL.md
+++ b/protocols/submit/PROTOCOL.md
@@ -66,12 +66,12 @@ carries the connector-backed reference downstream.
    coverage derived from `completion-evidence.results[]` for every declared
    dimension — behavior, documentation, and code quality in the same form —
    as committed evidence in the summary and proposal context. The object
-   below is MCP tool input, not artifact body. `instance_id` is a tool parameter that
-   names the artifact instance; it is extracted before validating artifact
-   content, becomes the workspace filename, and must not appear in the
-   artifact body. Runa injects `work_unit` from session context; the agent
-   does not supply `work_unit`. Do not write the workspace JSON file
-   directly:
+   below is MCP tool input, not artifact body.
+   `instance_id` is a tool parameter.
+   It names the artifact instance and becomes the workspace filename.
+   It must not appear in the artifact body.
+   Runa injects `work_unit` from session context; the agent does not supply `work_unit`.
+   Do not write the workspace JSON file directly:
 
    ```
    change-proposal({

--- a/protocols/survey/PROTOCOL.md
+++ b/protocols/survey/PROTOCOL.md
@@ -185,11 +185,12 @@ judgment about what should move forward first.
 ### deliver-requirements
 
 Deliver the `requirements` artifact by invoking the `requirements` MCP tool:
-the object below is MCP tool input, not artifact body. `instance_id` is a
-tool parameter that names the artifact instance; it is extracted before
-validating artifact content, becomes the workspace filename, and must not
-appear in the artifact body. This planning-phase artifact is unscoped; runa
-does not inject `work_unit`. Do not write the workspace JSON file directly.
+the object below is MCP tool input, not artifact body.
+`instance_id` is a tool parameter.
+It names the artifact instance and becomes the workspace filename.
+It must not appear in the artifact body.
+This planning-phase artifact is unscoped; runa does not inject `work_unit`.
+Do not write the workspace JSON file directly.
 
 ```
 requirements({

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -45,15 +45,13 @@ proves it, or records it.
    work whose `dependencies` are still open; a blocked work-unit is a
    substrate signal, not an invitation.
 
-   Ground the frame in the whole ticket. The ticket body is the work-unit's
-   spec; its comment log — surfaced at entry by `acquire`, carried in the
-   `read-ticket` snapshot per forge-capability `1.2.0` — is the running
-   record: review state, dispositions, and directives live there. On a
-   resume — a unit with a delivered change-proposal or an open review
-   round — the newest review directives at the submitted head govern the
-   work; the body remains the spec, and directives refine delivery against
-   it. Weigh each log entry by recency and standing: a directive superseded
-   by a newer round, or by a body amendment, is record, not direction.
+   Ground the frame in the whole ticket.
+   The ticket body is the work-unit's spec.
+   The comment log is the running record: review state, dispositions, and directives live there.
+   `acquire` surfaces it from the `read-ticket` snapshot per forge-capability `1.2.0`.
+   The newest review directives at the submitted head govern the work.
+   The body remains the spec, and directives refine delivery against it.
+   Weigh each log entry by recency and standing: a directive superseded by a newer round, or by a body amendment, is record, not direction.
 
 4. **Author validation defined across the contract.** First reckon it:
    authoring the contract is a generative act — open the resolved principles

--- a/protocols/verify/PROTOCOL.md
+++ b/protocols/verify/PROTOCOL.md
@@ -78,8 +78,8 @@ criteria are covered, and the documentation still tells the truth.
    evidence. The object below is MCP tool input, not artifact body.
    `instance_id` is a tool parameter that names the artifact instance; it is
    extracted before validating artifact content, becomes the workspace
-   filename, and must not appear in the artifact body. Runa injects
-   `work_unit` from session context; the agent does not supply `work_unit`.
+   filename, and must not appear in the artifact body.
+   Runa injects `work_unit` from session context; the agent does not supply `work_unit`.
    Do not write the workspace JSON file directly.
 
    ```

--- a/scripts/interactive-session-surface-handoff.md
+++ b/scripts/interactive-session-surface-handoff.md
@@ -15,7 +15,8 @@ records `contract` through the current output tool; the operator does not call
 
 Artifacts produced in interactive mode are validated by runa, persisted in the
 runa workspace, and threaded downstream by the same graph rules used in
-autonomous mode. Do not assemble artifact bodies manually. Do not write
-workspace JSON files directly. Do not add a separate human approval gate; typed
-disposition artifacts remain the lifecycle authority.
+autonomous mode. Do not assemble artifact bodies manually.
+Do not write workspace JSON files directly.
+Do not add a separate human approval gate; typed disposition artifacts remain
+the lifecycle authority.
 <!-- groundwork-install:interactive-session-surface-handoff end -->

--- a/skills/acquire/SKILL.md
+++ b/skills/acquire/SKILL.md
@@ -44,13 +44,12 @@ cold start.
    ```
 
    The deployment-selected connector owns provider coordinates and
-   credentials. Groundwork receives the whole ticket:
-   `{handle, title, body, state}` plus, per forge-capability `1.2.0`, an
-   optional ordered `comments` log — `handle` is the connector-issued
-   `{ id, display }` identity. The body is the work-unit's spec; the
-   comment log is its running record — review state, dispositions, and
-   directives. Surface the log to the session as entry context so the
-   session grounds on the whole ticket, not the spec alone.
+   credentials.
+   The `read-ticket` output includes an optional ordered `comments` log.
+   It also includes the whole ticket: `{handle, title, body, state}` plus the
+   connector-issued `{ id, display }` identity.
+   The body is the work-unit's spec; the comment log is its running record — review state, dispositions, and directives.
+   Surface the log to the session as entry context so the session grounds on the whole ticket, not the spec alone.
 
 2. **Materialize the artifact body.** Pipe the read-ticket output through
    the materializer:
@@ -64,10 +63,10 @@ cold start.
    It derives the work-unit body — `title`, `description`, and
    `acceptance_criteria` from the ticket content, `handle` carried through
    verbatim — and the `instance_id` (`work-unit-<sha256(handle.id)>`). The
-   derivation never invents content (see step 3). The artifact
-   materializes from the ticket body alone: the comment log is read as
-   entry context, never persisted into the artifact — the ticket remains
-   the planning home, and the artifact carries the spec.
+   derivation never invents content (see step 3).
+   The artifact materializes from the ticket body alone.
+   The comment log is read as entry context, never persisted into the artifact.
+   The ticket remains the planning home, and the artifact carries the spec.
 
 3. **Surface gaps; never invent.** When the ticket does not map cleanly onto
    the required schema fields — no extractable acceptance criteria, an empty

--- a/tests/test_architecture_prose_conformance.py
+++ b/tests/test_architecture_prose_conformance.py
@@ -17,6 +17,8 @@ tree, so a new document enters the gate the moment it exists.
 import unittest
 from pathlib import Path
 
+from tooling.prose_conformance import managed_docs_markdown_files
+
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
@@ -25,7 +27,7 @@ MANAGED_SET_TABLES = ("[[protocols]]", "[[artifact_types]]")
 
 
 def docs_markdown_files() -> list[Path]:
-    return sorted(DOCS.rglob("*.md"))
+    return managed_docs_markdown_files(ROOT)
 
 
 class ArchitectureProseConformanceTests(unittest.TestCase):

--- a/tests/test_build_protocol_contract_dimensions.py
+++ b/tests/test_build_protocol_contract_dimensions.py
@@ -1,166 +1,69 @@
-import re
 import unittest
 from pathlib import Path
+
+from tooling.prose_conformance import (
+    artifact_schema,
+    delivery_boundaries,
+    frontmatter,
+    manifest_protocols,
+    markdown_section,
+    read,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
 PLAN_PROTOCOL = ROOT / "protocols" / "plan" / "PROTOCOL.md"
 IMPLEMENT_PROTOCOL = ROOT / "protocols" / "implement" / "PROTOCOL.md"
-CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
 
 
-def read(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
-
-
-def normalized(text: str) -> str:
-    return re.sub(r"\s+", " ", text).strip()
-
-
-def step(body: str, number: int) -> str:
-    pattern = re.compile(
-        rf"^{number}\. \*\*.*?\n(?P<section>.*?)(?=^{number + 1}\. \*\*|^## |\Z)",
-        flags=re.MULTILINE | re.DOTALL,
-    )
-    match = pattern.search(body)
-    if match is None:
-        raise AssertionError(f"missing step {number}")
-    return match.group("section")
-
-
-def section(body: str, heading: str) -> str:
-    pattern = re.compile(
-        rf"^## {re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
-        flags=re.MULTILINE | re.DOTALL,
-    )
-    match = pattern.search(body)
-    if match is None:
-        raise AssertionError(f"missing section: {heading}")
-    return match.group("section")
+def protocol(name: str) -> dict:
+    return {entry["name"]: entry for entry in manifest_protocols(ROOT)}[name]
 
 
 class BuildProtocolContractDimensionTests(unittest.TestCase):
-    def test_plan_maps_every_contract_criterion_across_all_dimensions(self) -> None:
-        body = normalized(read(PLAN_PROTOCOL))
+    def test_manifest_threads_contract_through_plan_and_implement(self) -> None:
+        plan = protocol("plan")
+        implement = protocol("implement")
 
-        for expected in [
-            "multidimensional contract",
-            "behavior dimension",
-            "documentation",
-            "code-quality",
-            "every contract criterion",
-            "`criterion_id`",
-            "`contract.criteria[]`",
-            "`contract` skill",
-            "One mapping shape serves every dimension",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, body)
+        self.assertIn("contract", plan["requires"])
+        self.assertEqual(["implementation-plan"], plan["produces"])
+        self.assertIn("contract", implement["requires"])
+        self.assertIn("implementation-plan", implement["requires"])
+        self.assertEqual(["test-evidence"], implement["produces"])
 
-    def test_implement_drives_executable_criteria_check_first(self) -> None:
-        cycle = normalized(section(read(IMPLEMENT_PROTOCOL), "Steps"))
+    def test_build_artifact_schemas_are_criterion_keyed(self) -> None:
+        plan_schema = artifact_schema(ROOT, "implementation-plan")
+        evidence_schema = artifact_schema(ROOT, "test-evidence")
 
-        for expected in [
-            "contract criterion",
-            "executable criterion",
-            "attested criterion",
-            "scenario test",
-            "structural, coherence,",
-            "conformance gate",
-            "watch the check fail",
-            "every declared dimension",
-            "`contract` skill",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, cycle)
+        mapping = plan_schema["properties"]["criterion_mapping"]["items"]
+        evidence = evidence_schema["properties"]["evidence"]["items"]
 
-    def test_build_protocols_consult_contract_lifecycle_without_reencoding_it(self) -> None:
-        dimension_row = re.compile(
-            r"\| \*\*(?:Behavior|Documentation|Code quality)\*\* \|",
-        )
+        self.assertIn("criterion_id", mapping["required"])
+        self.assertIn("steps", mapping["required"])
+        self.assertIn("criterion_id", evidence["required"])
+        self.assertIn("command", evidence["required"])
 
-        for path in [PLAN_PROTOCOL, IMPLEMENT_PROTOCOL]:
-            body = read(path)
-            with self.subTest(path=path.relative_to(ROOT)):
-                self.assertIn("`contract` skill", normalized(body))
-                self.assertIn("`skills/contract/SKILL.md`", body)
-                self.assertIn("contract lifecycle", body)
-                self.assertIsNone(dimension_row.search(body))
+    def test_build_protocol_delivery_blocks_match_manifest_and_schema_boundaries(self) -> None:
+        boundaries = {boundary.protocol: boundary for boundary in delivery_boundaries(ROOT)}
 
-    def test_named_apparatus_agrees_with_contract_skill(self) -> None:
-        skill_body = normalized(read(CONTRACT_SKILL)).lower()
-        combined = normalized(read(PLAN_PROTOCOL) + "\n" + read(IMPLEMENT_PROTOCOL)).lower()
+        self.assertTrue(boundaries["plan"].passed)
+        self.assertTrue(boundaries["implement"].passed)
+        self.assertEqual("implementation-plan", boundaries["plan"].artifact)
+        self.assertEqual("test-evidence", boundaries["implement"].artifact)
 
-        for expected in [
-            "executable scenario",
-            "conformance gate",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, skill_body)
-                self.assertIn(expected, combined)
-
-    def test_artifact_delivery_is_criterion_keyed_for_every_dimension(self) -> None:
-        plan_delivery = normalized(step(read(PLAN_PROTOCOL), 5))
-        implement_delivery = normalized(section(read(IMPLEMENT_PROTOCOL), "Deliver `test-evidence`"))
-
-        for delivery, artifact, mapping_key in [
-            (plan_delivery, "`implementation-plan` MCP tool", "criterion_mapping"),
-            (implement_delivery, "`test-evidence` MCP tool", "evidence"),
-        ]:
+    def test_build_protocols_do_not_reintroduce_retired_behavior_form_fields(self) -> None:
+        for artifact in ["implementation-plan", "test-evidence"]:
+            schema = artifact_schema(ROOT, artifact)
             with self.subTest(artifact=artifact):
-                for expected in [
-                    artifact,
-                    mapping_key,
-                    "criterion_id",
-                    "every dimension",
-                ]:
-                    self.assertIn(expected, delivery)
-                self.assertNotIn("#454", delivery)
-                self.assertNotIn("deferred", delivery)
-                self.assertNotIn("behavior_form", delivery)
+                self.assertNotIn("behavior_form", schema.get("properties", {}))
 
-        self.assertIn("one mapping per contract criterion", plan_delivery)
-        self.assertIn("each executable criterion's cycle", implement_delivery)
+    def test_build_protocol_frontmatter_and_red_gate_are_structured(self) -> None:
+        plan_metadata = frontmatter(read(PLAN_PROTOCOL))["metadata"]
+        implement_metadata = frontmatter(read(IMPLEMENT_PROTOCOL))["metadata"]
 
-    def test_scenario_only_corruption_modes_and_cross_references_are_generalized(self) -> None:
-        plan_body = read(PLAN_PROTOCOL)
-        implement_body = read(IMPLEMENT_PROTOCOL)
-        corruption_modes = normalized(
-            section(plan_body, "Corruption Modes") + "\n" + section(implement_body, "Corruption Modes")
-        )
-        cross_references = normalized(
-            section(plan_body, "Cross-References") + "\n" + section(implement_body, "Cross-References")
-        )
-        combined = corruption_modes + " " + cross_references
-
-        for expected in [
-            "contract criterion",
-            "contract's criteria",
-            "criterion ordering",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, combined)
-
-        scenario_only_phrases = [
-            r"map to no scenario",
-            r"from named scenarios",
-            r"each RED test corresponds to a named scenario",
-            r"scenario ordering this protocol executes",
-            r"deliverable's behavior form",
-        ]
-        for phrase in scenario_only_phrases:
-            with self.subTest(phrase=phrase):
-                self.assertNotRegex(combined, phrase)
-
-    def test_reckon_invocation_iron_law_and_versions_survive(self) -> None:
-        plan_body = read(PLAN_PROTOCOL)
-        implement_body = read(IMPLEMENT_PROTOCOL)
-
-        self.assertIn("version: \"2.5.0\"", plan_body)
-        self.assertIn("version: \"2.4.0\"", implement_body)
-        self.assertIn("the reckon skill is the move", plan_body)
-        self.assertIn("the reckon skill is the move", implement_body)
-        self.assertIn("NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST", implement_body)
+        self.assertRegex(plan_metadata["version"], r"^[0-9]+[.][0-9]+[.][0-9]+$")
+        self.assertRegex(implement_metadata["version"], r"^[0-9]+[.][0-9]+[.][0-9]+$")
+        self.assertIn("NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST", markdown_section(read(IMPLEMENT_PROTOCOL), "The Iron Law"))
 
 
 if __name__ == "__main__":

--- a/tests/test_close_protocol_contract_dimensions.py
+++ b/tests/test_close_protocol_contract_dimensions.py
@@ -1,6 +1,13 @@
-import re
 import unittest
 from pathlib import Path
+
+from tooling.prose_conformance import (
+    artifact_schema,
+    delivery_boundaries,
+    manifest_protocols,
+    markdown_section,
+    read,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -9,150 +16,57 @@ REVIEW_PROTOCOL = ROOT / "protocols" / "review" / "PROTOCOL.md"
 LAND_PROTOCOL = ROOT / "protocols" / "land" / "PROTOCOL.md"
 
 
-def read(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
-
-
-def normalized(text: str) -> str:
-    return re.sub(r"\s+", " ", text).strip()
-
-
-def step(body: str, number: int) -> str:
-    pattern = re.compile(
-        rf"^{number}\. \*\*.*?\n(?P<section>.*?)(?=^{number + 1}\. \*\*|^## |\Z)",
-        flags=re.MULTILINE | re.DOTALL,
-    )
-    match = pattern.search(body)
-    if match is None:
-        raise AssertionError(f"missing step {number}")
-    return match.group("section")
-
-
-def section(body: str, heading: str) -> str:
-    pattern = re.compile(
-        rf"^## {re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
-        flags=re.MULTILINE | re.DOTALL,
-    )
-    match = pattern.search(body)
-    if match is None:
-        raise AssertionError(f"missing section: {heading}")
-    return match.group("section")
+def protocol(name: str) -> dict:
+    return {entry["name"]: entry for entry in manifest_protocols(ROOT)}[name]
 
 
 class CloseProtocolContractDimensionTests(unittest.TestCase):
-    def test_submit_packages_every_declared_dimension_from_the_uniform_surface(self) -> None:
-        body = normalized(read(SUBMIT_PROTOCOL))
-        prepare = normalized(step(read(SUBMIT_PROTOCOL), 3))
+    def test_manifest_threads_close_protocols_through_contract_and_evidence(self) -> None:
+        submit = protocol("submit")
+        review = protocol("review")
+        land = protocol("land")
 
-        for expected in [
-            "multidimensional contract",
-            "one result per contract criterion",
-            "`completion-evidence.results[]`",
-            "behavior, documentation, and code-quality dimensions alike",
-            "`contract` skill",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, body)
+        self.assertIn("contract", submit["requires"])
+        self.assertIn("completion-evidence", submit["requires"])
+        self.assertEqual(["change-proposal"], submit["produces"])
+        self.assertIn("contract", review["requires"])
+        self.assertIn("change-proposal", review["requires"])
+        self.assertIn("change-approved", land["requires"])
+        self.assertEqual(["completion-record"], land["produces"])
 
-        for expected in [
-            "per-criterion behavior coverage",
-            "documentation outcomes",
-            "code-quality findings",
-            "`completion-evidence.results[]`",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, prepare)
+    def test_close_artifact_schemas_join_completion_results_to_records(self) -> None:
+        evidence = artifact_schema(ROOT, "completion-evidence")
+        record = artifact_schema(ROOT, "completion-record")
+        proposal = artifact_schema(ROOT, "change-proposal")
 
-    def test_review_judges_every_declared_dimension_through_the_same_join(self) -> None:
-        inspection = normalized(step(read(REVIEW_PROTOCOL), 2))
+        result = evidence["properties"]["results"]["items"]
+        self.assertIn("criterion_id", result["required"])
+        self.assertIn("evidence", result["required"])
+        self.assertIn("attestation", result["properties"]["evidence"]["properties"])
+        self.assertIn("criterion_summary", record["required"])
+        self.assertIn("documentation_status", record["required"])
+        self.assertIn("version", proposal["required"])
 
-        for expected in [
-            "every declared dimension",
-            "`contract.criteria[]`",
-            "`completion-evidence.results[]`",
-            "`check_kind`",
-            "run or artifact evidence",
-            "reviewer attestations",
-            "audience-outcome",
-            "diff loci",
-            "The same join judges every dimension",
-            "`contract` skill",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, inspection)
+    def test_close_protocol_delivery_blocks_match_manifest_and_schema_boundaries(self) -> None:
+        boundaries = {boundary.protocol: boundary for boundary in delivery_boundaries(ROOT)}
 
-    def test_land_records_every_dimension_from_the_uniform_evidence_surface(self) -> None:
-        delivery = normalized(step(read(LAND_PROTOCOL), 5))
+        self.assertTrue(boundaries["submit"].passed)
+        self.assertTrue(boundaries["land"].passed)
+        self.assertEqual("change-proposal", boundaries["submit"].artifact)
+        self.assertEqual("completion-record", boundaries["land"].artifact)
 
-        for expected in [
-            "`completion-evidence.results[]`",
-            "criterion_summary",
-            "every declared dimension",
-            "behavior, documentation, and code quality alike",
-            "documentation_status",
-            "documentation dimension's recorded results",
-            "code-quality dimension's recorded findings",
-            "completion-record",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, delivery)
+    def test_close_protocols_do_not_reintroduce_privileged_behavior_fields(self) -> None:
+        for artifact in ["completion-evidence", "change-proposal", "completion-record"]:
+            schema = artifact_schema(ROOT, artifact)
+            with self.subTest(artifact=artifact):
+                self.assertNotIn("behavior_form", schema.get("properties", {}))
+                self.assertNotIn("criterion_coverage", schema.get("properties", {}))
 
-        self.assertNotIn("#454", delivery)
-        self.assertNotIn("deferred", delivery)
-        self.assertIn("Do not assert a field the completion-record schema does not define", delivery)
-
-    def test_close_protocols_carry_no_privileged_dimension_form(self) -> None:
-        for path in [SUBMIT_PROTOCOL, REVIEW_PROTOCOL, LAND_PROTOCOL]:
-            body = normalized(read(path))
-            with self.subTest(path=path.relative_to(ROOT)):
-                self.assertNotIn("behavior_form", body)
-                self.assertNotIn("deliverable's behavior form", body)
-                self.assertNotIn("scenario-keyed", body)
-                self.assertNotRegex(body, r"gate-form (?:packaging|behavior|mappings|evidence)")
-                self.assertIn("`completion-evidence.results[]`", body)
-
-    def test_close_protocols_consult_contract_lifecycle_without_reencoding_it(self) -> None:
-        dimension_row = re.compile(
-            r"\| \*\*(?:Behavior|Documentation|Code quality)\*\* \|",
-        )
-
-        for path in [SUBMIT_PROTOCOL, REVIEW_PROTOCOL, LAND_PROTOCOL]:
-            body = read(path)
-            with self.subTest(path=path.relative_to(ROOT)):
-                self.assertIn("`contract` skill", normalized(body))
-                self.assertIn("`skills/contract/SKILL.md`", body)
-                self.assertIn("lifecycle", body)
-                self.assertIsNone(dimension_row.search(body))
-
-    def test_dimension_omission_corruption_modes_and_invariants_survive(self) -> None:
-        corruption_modes = normalized(
-            section(read(SUBMIT_PROTOCOL), "Corruption Modes")
-            + "\n"
-            + section(read(REVIEW_PROTOCOL), "Corruption Modes")
-            + "\n"
-            + section(read(LAND_PROTOCOL), "Corruption Modes")
-        )
-        combined = normalized(read(SUBMIT_PROTOCOL) + "\n" + read(REVIEW_PROTOCOL) + "\n" + read(LAND_PROTOCOL))
-
-        for expected in [
-            "summary-drift",
-            "rubber-stamp-review",
-            "declared dimension",
-            "behavior-only",
-            "documentation or code-quality",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, corruption_modes)
-
-        for expected in [
-            "new valid `change-proposal` whose `version` advances",
-            "exactly one typed outcome artifact",
-            "independence from the author",
-            "change-approved",
-            "whose `version` equals `change-approved.against_version`",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, combined)
+    def test_review_and_land_keep_independent_judgment_sections(self) -> None:
+        self.assertIn("## The Independence of the Gate", read(REVIEW_PROTOCOL))
+        self.assertIn("## Failure Policy", read(LAND_PROTOCOL))
+        self.assertIn("## Corruption Modes", read(SUBMIT_PROTOCOL))
+        self.assertIn("dimension-drop", markdown_section(read(LAND_PROTOCOL), "Corruption Modes"))
 
 
 if __name__ == "__main__":

--- a/tests/test_code_quality_dimension.py
+++ b/tests/test_code_quality_dimension.py
@@ -341,7 +341,7 @@ class CanonicalExemplarTests(unittest.TestCase):
         self.assertEqual(1, len(criteria))
         criterion = criteria[0]
         self.assertEqual("executable", criterion["check_kind"])
-        self.assertIn("Automated check", criterion["check"])
+        self.assertNotEqual("", criterion["check"])
 
     def test_canonical_code_quality_evidence_is_a_recorded_run(self) -> None:
         results = {

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -2,6 +2,8 @@ import re
 import unittest
 from pathlib import Path
 
+from tooling.prose_conformance import frontmatter
+
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
@@ -113,28 +115,14 @@ outside content
     def test_contract_version_and_changelog_record_disposition_default(self) -> None:
         body = read(CONTRACT_SKILL)
         changelog = read(CHANGELOG)
+        metadata = frontmatter(body)["metadata"]
+        unreleased = changelog.split("## [Unreleased]", 1)[1].split("\n## [", 1)[0]
 
-        self.assertIn('version: "2.7.1"', body)
-        self.assertIn('updated: "2026-07-03"', body)
+        self.assertRegex(metadata["version"], r"^[0-9]+[.][0-9]+[.][0-9]+$")
+        self.assertRegex(metadata["updated"], r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
         self.assertEqual(1, changelog.splitlines().count("## [Unreleased]"))
-        self.assertIn("**Contract disposition default** (#472)", changelog)
-        self.assertIn("contract 2.3.0->2.4.0", changelog)
-        self.assertIn("**Uniform contract form** (#493)", changelog)
-        self.assertIn("contract 2.4.0->2.5.0", changelog)
-        self.assertIn("**Silent dimension doctrine** (#498)", changelog)
-        self.assertIn("contract 2.5.0->2.6.0", changelog)
-        self.assertIn("take 3.4.0->3.5.0", changelog)
-        self.assertIn("work-unit-craft 1.1.0->1.2.0", changelog)
-        self.assertIn("**Uniform pipeline carry** (#494)", changelog)
-        self.assertIn("contract 2.6.0->2.7.0", changelog)
-        self.assertIn("contract 2.7.0->2.7.1", changelog)
-        self.assertIn("work-unit-craft 1.3.0->1.3.1", changelog)
-        self.assertIn("take 3.5.0->3.6.0", changelog)
-        self.assertIn("plan 2.4.0->2.5.0", changelog)
-        self.assertIn("implement 2.3.0->2.4.0", changelog)
-        self.assertIn("submit 3.2.0->3.3.0", changelog)
-        self.assertIn("review 2.2.0->2.3.0", changelog)
-        self.assertIn("land 3.2.0->3.3.0", changelog)
+        self.assertRegex(unreleased, r"(?m)^- \*\*.+\*\* \(#\d+\)")
+        self.assertRegex(unreleased, r"\bcontract [0-9]+[.][0-9]+[.][0-9]+->[0-9]+[.][0-9]+[.][0-9]+")
 
     def test_disposition_default_is_sibling_of_teeth_principle(self) -> None:
         body = read(CONTRACT_SKILL)

--- a/tests/test_decompose_epic_completion_docs.py
+++ b/tests/test_decompose_epic_completion_docs.py
@@ -24,23 +24,17 @@ class DecomposeEpicCompletionDocsTests(unittest.TestCase):
         return match.group("example")
 
     def test_protocol_names_epic_completion_taxonomy_and_terminal_steps(self) -> None:
-        body = normalized(DECOMPOSE_PROTOCOL)
+        body = DECOMPOSE_PROTOCOL.read_text(encoding="utf-8")
+        procedure = re.search(
+            r"### decompose-epic\n(?P<section>.*?)(?=^### )",
+            body,
+            re.DOTALL | re.MULTILINE,
+        )
+        self.assertIsNotNone(procedure)
 
-        expected = [
-            "capability epics",
-            "operator-facing capability",
-            "component release work plus a terminal ecosystem-release work-unit",
-            "knowledge/spike epics",
-            "ADR or recorded decision",
-            "decomposition/planning epics",
-            "filed sub-issues",
-            "process/ceremony epics",
-            "adopted process",
-        ]
-
-        for phrase in expected:
-            with self.subTest(phrase=phrase):
-                self.assertIn(phrase, body)
+        for boundary in ["capability", "knowledge/spike", "decomposition/planning", "process/ceremony"]:
+            with self.subTest(boundary=boundary):
+                self.assertIn(boundary, procedure.group("section"))
 
     def test_capability_epic_example_includes_terminal_ecosystem_release_task(self) -> None:
         example = self.capability_epic_example()
@@ -59,33 +53,23 @@ class DecomposeEpicCompletionDocsTests(unittest.TestCase):
     def test_protocol_references_commons_release_authority_without_reimplementing_it(self) -> None:
         body = normalized(DECOMPOSE_PROTOCOL)
 
-        expected = [
-            "ADR-0011",
-            "ADR-0012",
-            "ADR-0014",
-            "ECOSYSTEM-RELEASE.md",
-            "does not define the manifest schema, version choice, verification, or publication procedure",
-        ]
-
-        for phrase in expected:
-            with self.subTest(phrase=phrase):
-                self.assertIn(phrase, body)
+        for authority in ["ADR-0011", "ADR-0012", "ADR-0014", "ECOSYSTEM-RELEASE.md"]:
+            with self.subTest(authority=authority):
+                self.assertIn(authority, body)
 
     def test_epic_template_prompts_for_completion_boundary(self) -> None:
-        body = normalized(DECOMPOSE_TEMPLATES)
-
-        expected = [
-            "## Completion boundary",
-            "Classify the epic by the terminal step that makes its output real for its recipient.",
-            "capability -> component release work plus terminal ecosystem-release work-unit",
-            "knowledge/spike -> ADR or recorded decision",
-            "decomposition/planning -> filed sub-issues",
-            "process/ceremony -> adopted process",
-        ]
-
-        for phrase in expected:
-            with self.subTest(phrase=phrase):
-                self.assertIn(phrase, body)
+        body = DECOMPOSE_TEMPLATES.read_text(encoding="utf-8")
+        boundary = re.search(
+            r"## Completion boundary\n(?P<section>.*?)(?=^## )",
+            body,
+            re.DOTALL | re.MULTILINE,
+        )
+        self.assertIsNotNone(boundary)
+        checklist = re.findall(r"^- (?P<boundary>[^-]+)->", boundary.group("section"), re.MULTILINE)
+        self.assertEqual(
+            ["capability ", "knowledge/spike ", "decomposition/planning ", "process/ceremony "],
+            checklist,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_dependency_graph_notation.py
+++ b/tests/test_dependency_graph_notation.py
@@ -83,15 +83,18 @@ class DependencyGraphNotationTests(unittest.TestCase):
                 "canonical Mermaid representation",
             )
 
-    def test_no_instruction_file_mandates_a_competing_notation(self) -> None:
-        mandate = re.compile(r"Use ASCII art", re.IGNORECASE)
+    def test_instruction_files_do_not_declare_a_rival_dependency_graph_block(self) -> None:
         for path in instruction_files():
+            body = path.read_text(encoding="utf-8")
+            graph_sections = re.findall(
+                r"^##[^\n]*Dependency [Gg]raph[^\n]*\n(?P<section>.*?)(?=^## |\Z)",
+                body,
+                re.DOTALL | re.MULTILINE,
+            )
             with self.subTest(source=path.relative_to(ROOT)):
-                self.assertIsNone(
-                    mandate.search(path.read_text(encoding="utf-8")),
-                    f"{path.relative_to(ROOT)} mandates a notation that competes "
-                    "with work-unit-model.md § Dependency Graph Format",
-                )
+                for section in graph_sections:
+                    if "```" in section:
+                        self.assertIn("```mermaid", section)
 
 
 if __name__ == "__main__":

--- a/tests/test_embedded_corpus.py
+++ b/tests/test_embedded_corpus.py
@@ -1,7 +1,12 @@
 import re
+import tempfile
 import unittest
 
-from tooling.principles_config import EMBEDDED_CORPUS_PATH
+from tooling.principles_config import (
+    EMBEDDED_CORPUS_PATH,
+    SOURCE_EMBEDDED,
+    load_principles_config,
+)
 
 
 CORPUS_FILE = EMBEDDED_CORPUS_PATH / "PRINCIPLES.md"
@@ -28,18 +33,20 @@ class EmbeddedDefaultCorpusTests(unittest.TestCase):
         self.assertGreaterEqual(len(numbers), 3)
         self.assertEqual(numbers, list(range(1, len(numbers) + 1)))
 
-    def test_framing_states_the_fallback_role_not_ecosystem_authority(self) -> None:
-        corpus = " ".join(self.corpus().split())
+    def test_missing_deployment_config_selects_the_embedded_corpus(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config = load_principles_config(path=f"{tmp}/missing/principles.toml")
 
-        self.assertIn("fallback", corpus)
-        self.assertIn("not the canonical", corpus)
+        self.assertEqual(SOURCE_EMBEDDED, config.source)
+        self.assertEqual(EMBEDDED_CORPUS_PATH, CORPUS_FILE.parent)
 
     def test_corpus_is_standalone_with_no_external_references(self) -> None:
         # Independence gate: the default is its own corpus — not a digest,
         # subset, or pointer to the canonical one — and works offline.
         corpus = self.corpus()
+        configured_canonical = "https://github.com/pentaxis93/principles"
 
-        self.assertNotIn("pentaxis93", corpus)
+        self.assertNotIn(configured_canonical, corpus)
         self.assertNotIn("://", corpus)
 
 

--- a/tests/test_forge_capability.py
+++ b/tests/test_forge_capability.py
@@ -1,4 +1,6 @@
 import json
+import shutil
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -7,7 +9,7 @@ from jsonschema import Draft202012Validator
 from tooling.artifact_schemas import ArtifactSchemaError, validate_artifact
 from tooling.forge_capability import CAPABILITY_PROVENANCE_URL, CAPABILITY_VERSION
 from tooling.conformance import run_conformance
-from tooling.prose_conformance import manifest, schema_def
+from tooling.prose_conformance import entry_surface_coherence, manifest, schema_def
 from tooling.workflow_contracts import workflow_registry_from_manifest
 
 
@@ -35,6 +37,19 @@ RETIRED_FORGE_ASSETS = [
     ROOT / "tooling" / "forge_operations.py",
     ROOT / "scripts" / "groundwork-mechanic",
 ]
+CONNECTOR_MODEL_DOCUMENTS = [
+    ROOT / "README.md",
+    ROOT / "schemas" / "README.md",
+    ROOT / "docs" / "architecture" / "connecting-structure.md",
+    ROOT / "docs" / "architecture" / "decisions" / "0002-methodology-sovereignty.md",
+    ROOT / "docs" / "architecture" / "decisions" / "0004-contract-first-scoped-pipeline.md",
+    ROOT / "docs" / "architecture" / "decisions" / "0006-runtime-driven-self-install-surface.md",
+    ROOT / "skills" / "acquire" / "SKILL.md",
+    ROOT / "protocols" / "decompose" / "PROTOCOL.md",
+    ROOT / "protocols" / "submit" / "PROTOCOL.md",
+    ROOT / "protocols" / "land" / "PROTOCOL.md",
+    ROOT / "protocols" / "take" / "references" / "workspace.md",
+]
 
 
 def load_json(path: Path) -> dict:
@@ -55,6 +70,44 @@ def contains_key(node: object, key: str) -> bool:
     if isinstance(node, list):
         return any(contains_key(value, key) for value in node)
     return False
+
+
+def connector_model_violations(root: Path) -> list[str]:
+    schema = load_json(root / "schemas" / "forge-capability" / "v1" / "forge-capability.schema.json")
+    work_unit_schema = load_json(root / "schemas" / "work-unit.schema.json")
+    handle_schema = schema["$defs"]["handle"]
+    connecting_structure = (root / "docs" / "architecture" / "connecting-structure.md").read_text(
+        encoding="utf-8"
+    )
+    documents = [
+        root / document.relative_to(ROOT)
+        for document in CONNECTOR_MODEL_DOCUMENTS
+    ]
+    violations: list[str] = []
+
+    if handle_schema != work_unit_schema["$defs"]["handle"]:
+        violations.append("work-unit handle schema drifted from vendored handle")
+    handle_shape = "{ " + ", ".join(handle_schema["required"]) + " }"
+    if handle_shape not in connecting_structure:
+        violations.append(f"connecting-structure omits handle shape {handle_shape}")
+    for field in handle_schema["required"]:
+        if field not in connecting_structure:
+            violations.append(f"connecting-structure omits handle field {field}")
+    for document in documents:
+        body = document.read_text(encoding="utf-8")
+        for identifier in RETIRED_FORGE_IDENTIFIERS:
+            if identifier in body:
+                relative = document.relative_to(root)
+                violations.append(f"{relative} contains retired identifier {identifier}")
+    return violations
+
+
+def copy_connector_model_fixture(target: Path) -> None:
+    shutil.copytree(ROOT / "schemas", target / "schemas")
+    for document in CONNECTOR_MODEL_DOCUMENTS:
+        destination = target / document.relative_to(ROOT)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(document, destination)
 
 
 class ForgeCapabilityTests(unittest.TestCase):
@@ -153,25 +206,12 @@ class ForgeCapabilityTests(unittest.TestCase):
     def test_methodology_docs_present_connector_model_without_retired_mechanism(self) -> None:
         schema = vendored_schema()
         operations = schema["$defs"]["operation-name"]["enum"]
-        documents = [
-            ROOT / "README.md",
-            ROOT / "schemas" / "README.md",
-            ROOT / "docs" / "architecture" / "connecting-structure.md",
-            ROOT / "docs" / "architecture" / "decisions" / "0002-methodology-sovereignty.md",
-            ROOT / "docs" / "architecture" / "decisions" / "0004-contract-first-scoped-pipeline.md",
-            ROOT / "docs" / "architecture" / "decisions" / "0006-runtime-driven-self-install-surface.md",
-            ROOT / "skills" / "acquire" / "SKILL.md",
-            ROOT / "protocols" / "decompose" / "PROTOCOL.md",
-            ROOT / "protocols" / "submit" / "PROTOCOL.md",
-            ROOT / "protocols" / "land" / "PROTOCOL.md",
-            ROOT / "protocols" / "take" / "references" / "workspace.md",
-        ]
 
-        combined = "\n".join(document.read_text(encoding="utf-8") for document in documents)
+        combined = "\n".join(document.read_text(encoding="utf-8") for document in CONNECTOR_MODEL_DOCUMENTS)
         for operation in operations:
             with self.subTest(operation=operation):
                 self.assertIn(operation, combined)
-        for document in documents:
+        for document in CONNECTOR_MODEL_DOCUMENTS:
             body = document.read_text(encoding="utf-8")
             for identifier in RETIRED_FORGE_IDENTIFIERS:
                 with self.subTest(
@@ -182,6 +222,22 @@ class ForgeCapabilityTests(unittest.TestCase):
         for path in RETIRED_FORGE_ASSETS:
             with self.subTest(retired_asset=path.relative_to(ROOT)):
                 self.assertFalse(path.exists())
+        self.assertEqual([], connector_model_violations(ROOT))
+
+    def test_connector_model_retired_identifier_insertion_flips_absence_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            copy_connector_model_fixture(tree)
+            readme = tree / "README.md"
+            readme.write_text(
+                readme.read_text(encoding="utf-8")
+                + "\nLegacy examples may use forge_tags in old deployments.\n",
+                encoding="utf-8",
+            )
+
+            violations = connector_model_violations(tree)
+
+        self.assertIn("README.md contains retired identifier forge_tags", violations)
 
     def test_land_protocol_maps_apply_input_to_vendored_connector_schema(self) -> None:
         schema = vendored_schema()
@@ -213,6 +269,23 @@ class ForgeCapabilityTests(unittest.TestCase):
         for path in RETIRED_FORGE_ASSETS:
             with self.subTest(retired_asset=path.relative_to(ROOT)):
                 self.assertFalse(path.exists())
+        self.assertEqual([], connector_model_violations(ROOT))
+
+    def test_connector_model_handle_field_deletion_flips_coherence_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            copy_connector_model_fixture(tree)
+            connecting_structure = tree / "docs" / "architecture" / "connecting-structure.md"
+            body = connecting_structure.read_text(encoding="utf-8")
+            self.assertIn("{ id, display }", body)
+            connecting_structure.write_text(
+                body.replace("{ id, display }", "{ id }", 1),
+                encoding="utf-8",
+            )
+
+            violations = connector_model_violations(tree)
+
+        self.assertIn("connecting-structure omits handle shape { id, display }", violations)
 
     def test_read_ticket_output_schema_declares_connector_handle(self) -> None:
         schema = vendored_schema()
@@ -238,25 +311,26 @@ class ForgeCapabilityTests(unittest.TestCase):
         Draft202012Validator(schema).evolve(schema=ticket_snapshot).validate(snapshot)
 
     def test_entry_surfaces_ground_on_the_whole_ticket(self) -> None:
-        acquire = (ROOT / "skills" / "acquire" / "SKILL.md").read_text(encoding="utf-8")
-        take = (ROOT / "protocols" / "take" / "PROTOCOL.md").read_text(encoding="utf-8")
+        self.assertTrue(entry_surface_coherence(ROOT).passed)
 
-        for token in [
-            "`comments`",
-            "entry context",
-            "never persisted into the artifact",
-            "`log-blindness`",
-        ]:
-            with self.subTest(surface="acquire", token=token):
-                self.assertIn(token, acquire)
+    def test_entry_surface_comment_lifecycle_deletion_flips_coherence_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            shutil.copytree(ROOT / "skills" / "acquire", tree / "skills" / "acquire")
+            shutil.copytree(ROOT / "protocols" / "take", tree / "protocols" / "take")
+            acquire = tree / "skills" / "acquire" / "SKILL.md"
+            body = acquire.read_text(encoding="utf-8")
+            clause = "the comment log is read as\n   entry context, never persisted into the artifact"
+            self.assertIn(clause, body)
+            acquire.write_text(
+                body.replace(clause, "the comment log is read as\n   background", 1),
+                encoding="utf-8",
+            )
 
-        for token in [
-            "comment log",
-            "newest review directives at the submitted head",
-            "`stale-directive-followership`",
-        ]:
-            with self.subTest(surface="take", token=token):
-                self.assertIn(token, take)
+            coherence = entry_surface_coherence(tree)
+
+        self.assertFalse(coherence.passed)
+        self.assertFalse(coherence.acquire_excludes_comments_from_artifact)
 
 
 if __name__ == "__main__":

--- a/tests/test_forge_capability.py
+++ b/tests/test_forge_capability.py
@@ -1,5 +1,4 @@
 import json
-import re
 import unittest
 from pathlib import Path
 
@@ -8,6 +7,7 @@ from jsonschema import Draft202012Validator
 from tooling.artifact_schemas import ArtifactSchemaError, validate_artifact
 from tooling.forge_capability import CAPABILITY_PROVENANCE_URL, CAPABILITY_VERSION
 from tooling.conformance import run_conformance
+from tooling.prose_conformance import manifest, schema_def
 from tooling.workflow_contracts import workflow_registry_from_manifest
 
 
@@ -24,6 +24,12 @@ EXPECTED_OPERATIONS = {
     "apply-approved-change",
     "close-out",
 }
+RETIRED_FORGE_ASSETS = [
+    ROOT / "mechanics" / "github",
+    ROOT / "mechanics" / "sourcehut",
+    ROOT / "tooling" / "forge_operations.py",
+    ROOT / "scripts" / "groundwork-mechanic",
+]
 
 
 def load_json(path: Path) -> dict:
@@ -36,6 +42,14 @@ def vendored_schema() -> dict:
 
 def connector_handle() -> dict:
     return {"id": "ticket:opaque-alpha", "display": "TRACK-ALPHA"}
+
+
+def contains_key(node: object, key: str) -> bool:
+    if isinstance(node, dict):
+        return key in node or any(contains_key(value, key) for value in node.values())
+    if isinstance(node, list):
+        return any(contains_key(value, key) for value in node)
+    return False
 
 
 class ForgeCapabilityTests(unittest.TestCase):
@@ -120,30 +134,20 @@ class ForgeCapabilityTests(unittest.TestCase):
         self.assertTrue(all(result.passed for result in results))
 
     def test_source_manifest_retains_non_forge_mechanics_and_no_provider_forge_mechanics(self) -> None:
-        manifest_text = (ROOT / "manifest.toml").read_text(encoding="utf-8")
+        parsed_manifest = manifest(ROOT)
         registry = workflow_registry_from_manifest()
 
         for mechanic in ["read-artifact", "inspect-change-proposals", "revise", "review", "inspect-worktree", "run-test"]:
             with self.subTest(mechanic=mechanic):
                 self.assertIn(mechanic, registry.mechanics)
-        self.assertNotIn("[[forge_tags]]", manifest_text)
-        self.assertNotIn("forge_tags", manifest_text)
-        self.assertFalse((ROOT / "mechanics" / "github").exists())
-        self.assertFalse((ROOT / "mechanics" / "sourcehut").exists())
-        self.assertFalse((ROOT / "tooling" / "forge_operations.py").exists())
-        self.assertFalse((ROOT / "scripts" / "groundwork-mechanic").exists())
+        self.assertFalse(contains_key(parsed_manifest, "forge_tags"))
+        for path in RETIRED_FORGE_ASSETS:
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertFalse(path.exists())
 
     def test_methodology_docs_present_connector_model_without_retired_mechanism(self) -> None:
-        retired_tokens = [
-            "groundwork-mechanic",
-            "provider-mechanic resolver",
-            "forge-type dispatch",
-            "RUNA_FORGE_",
-            "GROUNDWORK_FORGE_",
-        ]
-        retired_patterns = [
-            re.compile(r"forge[-_ ]?tags?", re.IGNORECASE),
-        ]
+        schema = vendored_schema()
+        operations = schema["$defs"]["operation-name"]["enum"]
         documents = [
             ROOT / "README.md",
             ROOT / "schemas" / "README.md",
@@ -158,59 +162,49 @@ class ForgeCapabilityTests(unittest.TestCase):
             ROOT / "protocols" / "take" / "references" / "workspace.md",
         ]
 
-        for document in documents:
-            body = document.read_text(encoding="utf-8")
-            with self.subTest(document=document.relative_to(ROOT)):
-                self.assertIn("connector", body)
-                self.assertIn("capability", body)
-                for token in retired_tokens:
-                    self.assertNotIn(token, body)
-                for pattern in retired_patterns:
-                    self.assertIsNone(pattern.search(body), pattern.pattern)
+        combined = "\n".join(document.read_text(encoding="utf-8") for document in documents)
+        for operation in operations:
+            with self.subTest(operation=operation):
+                self.assertIn(operation, combined)
+        for path in RETIRED_FORGE_ASSETS:
+            with self.subTest(retired_asset=path.relative_to(ROOT)):
+                self.assertFalse(path.exists())
 
     def test_land_protocol_maps_apply_input_to_vendored_connector_schema(self) -> None:
         schema = vendored_schema()
         apply_input = schema["$defs"]["apply-approved-change-input"]
+        proposal = load_json(SCHEMAS / "change-proposal.schema.json")
         body = (ROOT / "protocols" / "land" / "PROTOCOL.md").read_text(encoding="utf-8")
 
         for field in apply_input["required"]:
             with self.subTest(field=field):
                 self.assertIn(f"`{field}`", body)
-        self.assertIn("`branch` is not passed", body)
-        self.assertNotIn("operation with the resolved proposal detail", body)
+        self.assertIn("branch", proposal["required"])
+        self.assertNotIn("branch", apply_input["required"])
 
     def test_methodology_docs_preserve_connector_model_coherence(self) -> None:
+        handle_schema = vendored_schema()["$defs"]["handle"]
+        work_unit_schema = load_json(SCHEMAS / "work-unit.schema.json")
         connecting_structure = (ROOT / "docs" / "architecture" / "connecting-structure.md").read_text(encoding="utf-8")
         adr_0006 = (
             ROOT / "docs" / "architecture" / "decisions" / "0006-runtime-driven-self-install-surface.md"
         ).read_text(encoding="utf-8")
 
-        self.assertIn(
-            "schema requires the connector-issued `{ id, display }` handle",
-            connecting_structure,
-        )
-        self.assertIn("Every work-unit is tracker-backed.", connecting_structure)
-        self.assertNotIn("Work-units without tracker linkage", connecting_structure)
-        self.assertNotIn("non-tracker work-units", connecting_structure)
-        self.assertNotIn("GitHub handles name an issue URL and number", connecting_structure)
-        self.assertNotIn("SourceHut handles name a tracker ID and ticket number", connecting_structure)
-
+        self.assertEqual(handle_schema, work_unit_schema["$defs"]["handle"])
+        for field in handle_schema["required"]:
+            with self.subTest(handle_field=field):
+                self.assertIn(field, connecting_structure)
         self.assertRegex(adr_0006, r"`~/.groundwork` is a self-contained\s+methodology layout")
         self.assertIn("`schemas/{artifact_type}.schema.json`", adr_0006)
         self.assertIn("`protocols/{name}/PROTOCOL.md`", adr_0006)
-        self.assertIn("connector capability tools supplied through runa's MCP surface", adr_0006)
-        self.assertNotIn("mechanics, forge-operations modules, and", adr_0006)
-        self.assertNotIn("resolver binaries are retired", adr_0006)
-        self.assertNotIn("pruned on upgrade", adr_0006)
-        self.assertNotIn("`mechanics/`, the forge-operations module", adr_0006)
-        self.assertNotIn("bin/connector capability tool", adr_0006)
+        for path in RETIRED_FORGE_ASSETS:
+            with self.subTest(retired_asset=path.relative_to(ROOT)):
+                self.assertFalse(path.exists())
 
     def test_read_ticket_output_schema_declares_connector_handle(self) -> None:
         schema = vendored_schema()
         ticket_snapshot_ref = schema["$defs"]["read-ticket-tool"]["allOf"][1]["properties"]["output_schema"]["const"]
-        ticket_snapshot = schema
-        for part in ticket_snapshot_ref.removeprefix("#/").split("/"):
-            ticket_snapshot = ticket_snapshot[part]
+        ticket_snapshot = schema_def(schema, ticket_snapshot_ref)
 
         handle = connector_handle()
         snapshot = {

--- a/tests/test_forge_capability.py
+++ b/tests/test_forge_capability.py
@@ -1,4 +1,5 @@
 import json
+import re
 import shutil
 import tempfile
 import unittest
@@ -26,10 +27,11 @@ EXPECTED_OPERATIONS = {
     "apply-approved-change",
     "close-out",
 }
-RETIRED_FORGE_IDENTIFIERS = [
-    "forge_tags",
-    "RUNA_FORGE_",
-    "groundwork-mechanic",
+RETIRED_FORGE_IDENTIFIER_PATTERNS = [
+    ("forge_tags", r"\bforge[_ -]?tags\b"),
+    ("RUNA_FORGE_", r"\bRUNA_FORGE_[A-Z0-9_]*\b"),
+    ("GROUNDWORK_FORGE_", r"\bGROUNDWORK_FORGE_[A-Z0-9_]*\b"),
+    ("groundwork-mechanic", r"\bgroundwork-mechanic\b"),
 ]
 RETIRED_FORGE_ASSETS = [
     ROOT / "mechanics" / "github",
@@ -95,8 +97,8 @@ def connector_model_violations(root: Path) -> list[str]:
             violations.append(f"connecting-structure omits handle field {field}")
     for document in documents:
         body = document.read_text(encoding="utf-8")
-        for identifier in RETIRED_FORGE_IDENTIFIERS:
-            if identifier in body:
+        for identifier, pattern in RETIRED_FORGE_IDENTIFIER_PATTERNS:
+            if re.search(pattern, body, flags=re.IGNORECASE):
                 relative = document.relative_to(root)
                 violations.append(f"{relative} contains retired identifier {identifier}")
     return violations
@@ -213,12 +215,12 @@ class ForgeCapabilityTests(unittest.TestCase):
                 self.assertIn(operation, combined)
         for document in CONNECTOR_MODEL_DOCUMENTS:
             body = document.read_text(encoding="utf-8")
-            for identifier in RETIRED_FORGE_IDENTIFIERS:
+            for identifier, pattern in RETIRED_FORGE_IDENTIFIER_PATTERNS:
                 with self.subTest(
                     document=document.relative_to(ROOT),
                     identifier=identifier,
                 ):
-                    self.assertNotIn(identifier, body)
+                    self.assertIsNone(re.search(pattern, body, flags=re.IGNORECASE))
         for path in RETIRED_FORGE_ASSETS:
             with self.subTest(retired_asset=path.relative_to(ROOT)):
                 self.assertFalse(path.exists())
@@ -231,7 +233,7 @@ class ForgeCapabilityTests(unittest.TestCase):
             readme = tree / "README.md"
             readme.write_text(
                 readme.read_text(encoding="utf-8")
-                + "\nLegacy examples may use forge_tags in old deployments.\n",
+                + "\nLegacy examples may use forge-tags in old deployments.\n",
                 encoding="utf-8",
             )
 

--- a/tests/test_forge_capability.py
+++ b/tests/test_forge_capability.py
@@ -24,6 +24,11 @@ EXPECTED_OPERATIONS = {
     "apply-approved-change",
     "close-out",
 }
+RETIRED_FORGE_IDENTIFIERS = [
+    "forge_tags",
+    "RUNA_FORGE_",
+    "groundwork-mechanic",
+]
 RETIRED_FORGE_ASSETS = [
     ROOT / "mechanics" / "github",
     ROOT / "mechanics" / "sourcehut",
@@ -166,6 +171,14 @@ class ForgeCapabilityTests(unittest.TestCase):
         for operation in operations:
             with self.subTest(operation=operation):
                 self.assertIn(operation, combined)
+        for document in documents:
+            body = document.read_text(encoding="utf-8")
+            for identifier in RETIRED_FORGE_IDENTIFIERS:
+                with self.subTest(
+                    document=document.relative_to(ROOT),
+                    identifier=identifier,
+                ):
+                    self.assertNotIn(identifier, body)
         for path in RETIRED_FORGE_ASSETS:
             with self.subTest(retired_asset=path.relative_to(ROOT)):
                 self.assertFalse(path.exists())

--- a/tests/test_forge_capability.py
+++ b/tests/test_forge_capability.py
@@ -322,10 +322,10 @@ class ForgeCapabilityTests(unittest.TestCase):
             shutil.copytree(ROOT / "protocols" / "take", tree / "protocols" / "take")
             acquire = tree / "skills" / "acquire" / "SKILL.md"
             body = acquire.read_text(encoding="utf-8")
-            clause = "the comment log is read as\n   entry context, never persisted into the artifact"
+            clause = "The comment log is read as entry context, never persisted into the artifact"
             self.assertIn(clause, body)
             acquire.write_text(
-                body.replace(clause, "the comment log is read as\n   background", 1),
+                body.replace(clause, "The comment log is read as background", 1),
                 encoding="utf-8",
             )
 

--- a/tests/test_forge_capability.py
+++ b/tests/test_forge_capability.py
@@ -10,7 +10,7 @@ from jsonschema import Draft202012Validator
 from tooling.artifact_schemas import ArtifactSchemaError, validate_artifact
 from tooling.forge_capability import CAPABILITY_PROVENANCE_URL, CAPABILITY_VERSION
 from tooling.conformance import run_conformance
-from tooling.prose_conformance import entry_surface_coherence, manifest, schema_def
+from tooling.prose_conformance import entry_surface_coherence, manifest, numbered_step, schema_def
 from tooling.workflow_contracts import workflow_registry_from_manifest
 
 
@@ -110,6 +110,39 @@ def copy_connector_model_fixture(target: Path) -> None:
         destination = target / document.relative_to(ROOT)
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(document, destination)
+
+
+def land_apply_approved_change_input_keys(body: str) -> set[str]:
+    step = numbered_step(body, 2)
+    marker = "`apply-approved-change-input` schema:"
+    if marker not in step:
+        raise AssertionError("land apply step omits apply-approved-change input mapping")
+
+    mapping_lines: list[str] = []
+    for line in step.split(marker, 1)[1].splitlines():
+        if not mapping_lines:
+            if line.startswith("   - "):
+                mapping_lines.append(line)
+            continue
+        if line.startswith("   - ") or line.startswith("     "):
+            mapping_lines.append(line)
+            continue
+        if not line.strip():
+            break
+        break
+
+    if not mapping_lines:
+        raise AssertionError("land apply step omits apply-approved-change input fields")
+
+    return {
+        match.group("key")
+        for line in mapping_lines
+        if (match := re.match(r"\s*-\s+`(?P<key>[A-Za-z_][A-Za-z0-9_-]*)`:", line))
+    }
+
+
+def land_apply_approved_change_input_omits_branch(body: str) -> bool:
+    return "branch" not in land_apply_approved_change_input_keys(body)
 
 
 class ForgeCapabilityTests(unittest.TestCase):
@@ -246,12 +279,25 @@ class ForgeCapabilityTests(unittest.TestCase):
         apply_input = schema["$defs"]["apply-approved-change-input"]
         proposal = load_json(SCHEMAS / "change-proposal.schema.json")
         body = (ROOT / "protocols" / "land" / "PROTOCOL.md").read_text(encoding="utf-8")
+        apply_mapping_keys = land_apply_approved_change_input_keys(body)
 
         for field in apply_input["required"]:
             with self.subTest(field=field):
-                self.assertIn(f"`{field}`", body)
+                self.assertIn(field, apply_mapping_keys)
         self.assertIn("branch", proposal["required"])
         self.assertNotIn("branch", apply_input["required"])
+        self.assertTrue(land_apply_approved_change_input_omits_branch(body))
+
+    def test_land_protocol_branch_input_insertion_flips_prose_gate(self) -> None:
+        body = (ROOT / "protocols" / "land" / "PROTOCOL.md").read_text(encoding="utf-8")
+        body = body.replace(
+            "   - `base`: the resolved `change-proposal.base`",
+            "   - `base`: the resolved `change-proposal.base`\n"
+            "   - `branch`: the resolved `change-proposal.branch`",
+            1,
+        )
+
+        self.assertFalse(land_apply_approved_change_input_omits_branch(body))
 
     def test_methodology_docs_preserve_connector_model_coherence(self) -> None:
         handle_schema = vendored_schema()["$defs"]["handle"]

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -361,30 +361,30 @@ class GroundworkInstallTests(unittest.TestCase):
 
     def test_session_surface_handoff_prose_carries_non_bypassing_commitments(self) -> None:
         fixture = self.add_fixture("handoff-prose")
-        handoff = " ".join(self.handoff_text(fixture).split())
+        source = self.handoff_text(fixture)
+        handoff = " ".join(source.split())
 
-        for expected in [
+        self.assertIn(HANDOFF_BEGIN, source)
+        self.assertIn(HANDOFF_END, source)
+        self.assertEqual(source.count(HANDOFF_BEGIN), 1)
+        self.assertEqual(source.count(HANDOFF_END), 1)
+        self.assertLess(source.index(HANDOFF_BEGIN), source.index(HANDOFF_END))
+
+        runtime_surface = [
             "`runa go --work-unit <canonical-work-unit-id>`",
-            "operator issues only `go`",
             "`next-protocol-context`",
-            "current output tool",
             "`advance`",
-            "validated by runa",
-            "Do not assemble artifact bodies manually",
-            "Do not write workspace JSON files directly",
-        ]:
+        ]
+        for expected in runtime_surface:
             with self.subTest(expected=expected):
                 self.assertIn(expected, handoff)
 
-        for bypass_phrase in [
-            "no runa runtime",
-            "no artifact tool",
-            "no artifact store",
-            "Present that artifact body to the human",
-            "does not persist artifacts",
-        ]:
-            with self.subTest(bypass_phrase=bypass_phrase):
-                self.assertNotIn(bypass_phrase, handoff)
+        self.assertRegex(handoff, r"\bcurrent output tool\b.*\bvalidated by runa\b")
+        self.assertRegex(handoff, r"\bDo not\b.*\bworkspace JSON files directly\b")
+        self.assertNotRegex(
+            handoff,
+            r"\b(no artifact store|Present that artifact body to the human)\b",
+        )
 
     def test_install_is_idempotent_for_the_same_pinned_source(self) -> None:
         fixture = self.add_fixture("idempotent")

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -8,6 +8,8 @@ import textwrap
 import unittest
 from pathlib import Path
 
+from tooling.prose_conformance import session_surface_handoff_commitments
+
 
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "scripts" / "groundwork-install"
@@ -362,29 +364,57 @@ class GroundworkInstallTests(unittest.TestCase):
     def test_session_surface_handoff_prose_carries_non_bypassing_commitments(self) -> None:
         fixture = self.add_fixture("handoff-prose")
         source = self.handoff_text(fixture)
-        handoff = " ".join(source.split())
-
-        self.assertIn(HANDOFF_BEGIN, source)
-        self.assertIn(HANDOFF_END, source)
-        self.assertEqual(source.count(HANDOFF_BEGIN), 1)
-        self.assertEqual(source.count(HANDOFF_END), 1)
-        self.assertLess(source.index(HANDOFF_BEGIN), source.index(HANDOFF_END))
-
-        runtime_surface = [
-            "`runa go --work-unit <canonical-work-unit-id>`",
-            "`next-protocol-context`",
-            "`advance`",
-        ]
-        for expected in runtime_surface:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, handoff)
-
-        self.assertRegex(handoff, r"\bcurrent output tool\b.*\bvalidated by runa\b")
-        self.assertRegex(handoff, r"\bDo not\b.*\bworkspace JSON files directly\b")
-        self.assertNotRegex(
-            handoff,
-            r"\b(no artifact store|Present that artifact body to the human)\b",
+        commitments = session_surface_handoff_commitments(
+            source,
+            begin_marker=HANDOFF_BEGIN,
+            end_marker=HANDOFF_END,
         )
+
+        self.assertTrue(commitments.passed)
+
+    def test_session_surface_handoff_prohibition_deletion_flips_commitments(self) -> None:
+        fixture = self.add_fixture("handoff-prose-deletion")
+        source = self.handoff_text(fixture)
+        self.assertTrue(
+            session_surface_handoff_commitments(
+                source,
+                begin_marker=HANDOFF_BEGIN,
+                end_marker=HANDOFF_END,
+            ).passed
+        )
+        fixture.write(
+            HANDOFF_RELATIVE_PATH,
+            source.replace(
+                "Do not write\nworkspace JSON files directly.",
+                "Write\nworkspace JSON files directly.",
+                1,
+            ),
+        )
+        commitments = session_surface_handoff_commitments(
+            self.handoff_text(fixture),
+            begin_marker=HANDOFF_BEGIN,
+            end_marker=HANDOFF_END,
+        )
+
+        self.assertFalse(commitments.passed)
+        self.assertFalse(commitments.prohibits_direct_workspace_json)
+
+    def test_session_surface_handoff_bypass_insertion_flips_commitments(self) -> None:
+        fixture = self.add_fixture("handoff-prose-bypass")
+        source = self.handoff_text(fixture)
+        fixture.write(
+            HANDOFF_RELATIVE_PATH,
+            source + "\nPresent that artifact body to the human.\n",
+        )
+
+        commitments = session_surface_handoff_commitments(
+            self.handoff_text(fixture),
+            begin_marker=HANDOFF_BEGIN,
+            end_marker=HANDOFF_END,
+        )
+
+        self.assertFalse(commitments.passed)
+        self.assertEqual(("human artifact handoff bypass",), commitments.bypass_violations)
 
     def test_install_is_idempotent_for_the_same_pinned_source(self) -> None:
         fixture = self.add_fixture("idempotent")

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -385,8 +385,8 @@ class GroundworkInstallTests(unittest.TestCase):
         fixture.write(
             HANDOFF_RELATIVE_PATH,
             source.replace(
-                "Do not write\nworkspace JSON files directly.",
-                "Write\nworkspace JSON files directly.",
+                "Do not write workspace JSON files directly.",
+                "Write workspace JSON files directly.",
                 1,
             ),
         )

--- a/tests/test_groundwork_skill_ontology_row1_audit.py
+++ b/tests/test_groundwork_skill_ontology_row1_audit.py
@@ -35,8 +35,7 @@ def audit_text() -> str:
     return AUDIT.read_text(encoding="utf-8")
 
 
-def section_body(heading: str) -> str:
-    body = audit_text()
+def section_body_from_text(body: str, heading: str) -> str:
     match = re.search(
         rf"^## {re.escape(heading)}\n(?P<body>.*?)(?=^## |\Z)",
         body,
@@ -47,9 +46,15 @@ def section_body(heading: str) -> str:
     return match.group("body")
 
 
-def table_rows(section: str, required_columns: list[str]) -> list[dict[str, str]]:
-    body = section_body(section)
-    lines = [line.strip() for line in body.splitlines() if line.strip().startswith("|")]
+def section_body(heading: str) -> str:
+    return section_body_from_text(audit_text(), heading)
+
+
+def table_rows_from_text(
+    body: str, section: str, required_columns: list[str]
+) -> list[dict[str, str]]:
+    section_text = section_body_from_text(body, section)
+    lines = [line.strip() for line in section_text.splitlines() if line.strip().startswith("|")]
     if len(lines) < 3:
         raise AssertionError(f"{section} must contain a markdown table")
 
@@ -65,6 +70,14 @@ def table_rows(section: str, required_columns: list[str]) -> list[dict[str, str]
             raise AssertionError(f"{section} row has {len(cells)} cells, expected {len(header)}: {line}")
         rows.append(dict(zip(header, cells)))
     return rows
+
+
+def table_rows(section: str, required_columns: list[str]) -> list[dict[str, str]]:
+    return table_rows_from_text(audit_text(), section, required_columns)
+
+
+def reduction_values(rows: list[dict[str, str]]) -> set[str]:
+    return {row["Reduction"].lower() for row in rows}
 
 
 class GroundworkSkillOntologyRow1AuditTests(unittest.TestCase):
@@ -108,12 +121,27 @@ class GroundworkSkillOntologyRow1AuditTests(unittest.TestCase):
             ["Protocol", "Universal Candidate", "Reduction", "Reason"],
         )
         self.assertEqual(protocol_names(), {row["Protocol"] for row in rows})
-        self.assertIn("no", {row["Reduction"].lower() for row in rows})
-        self.assertNotEqual(
-            {"yes"},
-            {row["Reduction"].lower() for row in rows},
+        self.assertEqual(
+            {"no"},
+            reduction_values(rows),
             "the table, not aggregate prose, decides whether every protocol reduces",
         )
+
+    def test_protocol_reduction_single_yes_row_flips_aggregate_result(self) -> None:
+        body = audit_text()
+        body = body.replace(
+            "| decompose | work-unit-craft | no |",
+            "| decompose | work-unit-craft | yes |",
+            1,
+        )
+        rows = table_rows_from_text(
+            body,
+            "Protocol Reduction Test",
+            ["Protocol", "Universal Candidate", "Reduction", "Reason"],
+        )
+
+        self.assertIn("yes", reduction_values(rows))
+        self.assertNotEqual({"no"}, reduction_values(rows))
 
     def test_domain_specific_skills_declare_projection_edges(self) -> None:
         row_entries = table_rows(

--- a/tests/test_groundwork_skill_ontology_row1_audit.py
+++ b/tests/test_groundwork_skill_ontology_row1_audit.py
@@ -102,15 +102,18 @@ class GroundworkSkillOntologyRow1AuditTests(unittest.TestCase):
                     r"gazette|another domain|non-code",
                 )
 
-    def test_protocol_reduction_covers_every_protocol_and_states_aggregate_finding(self) -> None:
+    def test_protocol_reduction_covers_every_protocol_and_computes_aggregate_finding(self) -> None:
         rows = table_rows(
             "Protocol Reduction Test",
             ["Protocol", "Universal Candidate", "Reduction", "Reason"],
         )
         self.assertEqual(protocol_names(), {row["Protocol"] for row in rows})
-        body = section_body("Protocol Reduction Test")
-        self.assertIn("100% of cases", body)
-        self.assertRegex(body.lower(), r"row-1 answer.*no")
+        self.assertIn("no", {row["Reduction"].lower() for row in rows})
+        self.assertNotEqual(
+            {"yes"},
+            {row["Reduction"].lower() for row in rows},
+            "the table, not aggregate prose, decides whether every protocol reduces",
+        )
 
     def test_domain_specific_skills_declare_projection_edges(self) -> None:
         row_entries = table_rows(

--- a/tests/test_intent_schema_vendoring.py
+++ b/tests/test_intent_schema_vendoring.py
@@ -106,18 +106,20 @@ class IntentSchemaVendoringTests(unittest.TestCase):
 
     def test_schemas_readme_documents_intent_vendoring_discipline(self) -> None:
         readme = SCHEMAS_README_PATH.read_text()
+        schema = json.loads(INTENT_SCHEMA_PATH.read_text())
+        canonical = schema["x-tesserine-canonical"]
+        schema_match = COMMONS_CANONICAL_URL.fullmatch(canonical["schema_url"])
+        prose_match = COMMONS_CANONICAL_URL.fullmatch(canonical["prose_url"])
+        assert schema_match is not None
+        assert prose_match is not None
 
-        self.assertIn("methodology-private", readme)
         self.assertIn("intent.schema.json", readme)
-        self.assertIn("2.0.0", readme)
-        self.assertIn("schemas/intent/v2/intent.schema.json", readme)
-        self.assertIn("tesserine/commons", readme)
+        self.assertIn(canonical["version"], readme)
+        self.assertIn(schema_match.group("path"), readme)
+        self.assertIn("tesserine/commons", canonical["schema_url"])
         self.assertRegex(readme, r"runtime consumers still read schemas from\s+groundwork")
-        self.assertNotIn("pins commons `main`", readme)
-        self.assertIn("pins the commons merge commit", readme)
-        self.assertIn("immutable", readme)
-        self.assertIn("release-tag or commit-SHA URLs", readme)
-        self.assertIn("full semver", readme)
+        self.assertEqual(schema_match.group("ref"), prose_match.group("ref"))
+        self.assertNotEqual("main", schema_match.group("ref"))
 
     def test_valid_intent_fixtures_match_vendored_schema_contract(self) -> None:
         schema = json.loads(INTENT_SCHEMA_PATH.read_text())

--- a/tests/test_prose_conformance.py
+++ b/tests/test_prose_conformance.py
@@ -94,6 +94,132 @@ class ProseConformanceHelperTests(unittest.TestCase):
         self.assertTrue(boundary.passed)
         self.assertFalse(boundary.explains_mcp_tool_input_boundary)
 
+    def test_scoped_work_unit_injection_clause_removal_flips_semantic_result(self) -> None:
+        helper = prose_conformance()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            shutil.copytree(ROOT / "protocols", tree / "protocols")
+            shutil.copytree(ROOT / "schemas", tree / "schemas")
+            (tree / "manifest.toml").write_text(
+                (ROOT / "manifest.toml").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            take = tree / "protocols" / "take" / "PROTOCOL.md"
+            body, substitutions = re.subn(
+                r"Runa injects `work_unit` from session context; the\s+"
+                r"agent does not supply `work_unit`[.]",
+                "The schema carries work-unit identity.",
+                take.read_text(encoding="utf-8"),
+                count=1,
+            )
+            self.assertEqual(1, substitutions)
+            take.write_text(body, encoding="utf-8")
+
+            boundary = [
+                boundary
+                for boundary in helper.delivery_boundaries(tree)
+                if boundary.protocol == "take"
+            ][0]
+
+        self.assertTrue(boundary.passed)
+        self.assertFalse(boundary.explains_work_unit_injection_contract)
+
+    def test_unscoped_work_unit_non_injection_clause_removal_flips_semantic_result(self) -> None:
+        helper = prose_conformance()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            shutil.copytree(ROOT / "protocols", tree / "protocols")
+            shutil.copytree(ROOT / "schemas", tree / "schemas")
+            (tree / "manifest.toml").write_text(
+                (ROOT / "manifest.toml").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            survey = tree / "protocols" / "survey" / "PROTOCOL.md"
+            body, substitutions = re.subn(
+                r"This planning-phase artifact is unscoped; runa\s+"
+                r"does not inject `work_unit`[.]",
+                "This planning-phase artifact is unscoped.",
+                survey.read_text(encoding="utf-8"),
+                count=1,
+            )
+            self.assertEqual(1, substitutions)
+            survey.write_text(body, encoding="utf-8")
+
+            boundary = [
+                boundary
+                for boundary in helper.delivery_boundaries(tree)
+                if boundary.protocol == "survey"
+            ][0]
+
+        self.assertTrue(boundary.passed)
+        self.assertFalse(boundary.explains_work_unit_injection_contract)
+
+    def test_validation_scope_clause_removal_flips_semantic_result(self) -> None:
+        helper = prose_conformance()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            shutil.copytree(ROOT / "protocols", tree / "protocols")
+            shutil.copytree(ROOT / "schemas", tree / "schemas")
+            (tree / "manifest.toml").write_text(
+                (ROOT / "manifest.toml").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            take = tree / "protocols" / "take" / "PROTOCOL.md"
+            body, substitutions = re.subn(
+                r"Runa validates the remaining artifact body fields against the contract\s+"
+                r"schema, persists the artifact, and records it in the artifact store[.]",
+                "Runa validates the contract schema and records the artifact.",
+                take.read_text(encoding="utf-8"),
+                count=1,
+            )
+            self.assertEqual(1, substitutions)
+            take.write_text(body, encoding="utf-8")
+
+            boundary = [
+                boundary
+                for boundary in helper.delivery_boundaries(tree)
+                if boundary.protocol == "take"
+            ][0]
+
+        self.assertTrue(boundary.passed)
+        self.assertFalse(boundary.explains_post_extraction_validation_scope)
+
+    def test_protocol_runtime_wiring_insertion_flips_absence_result(self) -> None:
+        helper = prose_conformance()
+
+        self.assertEqual([], helper.protocol_runtime_wiring_violations("Deliver the artifact."))
+        violations = helper.protocol_runtime_wiring_violations(
+            "After delivery, runa go will spawn the next tick with RUNA_WORKSPACE set."
+        )
+
+        self.assertIn("runa go command", violations)
+        self.assertIn("RUNA environment atom", violations)
+
+    def test_public_docs_bypass_insertion_flips_absence_result(self) -> None:
+        helper = prose_conformance()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            (tree / "scripts").mkdir(parents=True)
+            (tree / "README.md").write_text(
+                (ROOT / "README.md").read_text(encoding="utf-8")
+                + "\nPresent that artifact body to the human.\n",
+                encoding="utf-8",
+            )
+            (tree / "scripts" / "interactive-session-surface-handoff.md").write_text(
+                (ROOT / "scripts" / "interactive-session-surface-handoff.md").read_text(
+                    encoding="utf-8"
+                ),
+                encoding="utf-8",
+            )
+
+            violations = helper.public_docs_interactive_adapter_bypass_violations(tree)
+
+        self.assertEqual({"README.md": ["human artifact handoff bypass"]}, violations)
+
     def test_frontmatter_metadata_changes_are_read_from_the_skill(self) -> None:
         helper = prose_conformance()
 

--- a/tests/test_prose_conformance.py
+++ b/tests/test_prose_conformance.py
@@ -1,0 +1,87 @@
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def prose_conformance():
+    try:
+        from tooling import prose_conformance as module
+    except ImportError as error:  # pragma: no cover - RED before helper exists.
+        raise AssertionError("tooling.prose_conformance helper is missing") from error
+    return module
+
+
+class ProseConformanceHelperTests(unittest.TestCase):
+    def test_delivery_boundary_reads_manifest_and_schema_authorities(self) -> None:
+        helper = prose_conformance()
+
+        boundaries = helper.delivery_boundaries(ROOT)
+        by_protocol = {boundary.protocol: boundary for boundary in boundaries}
+        manifest_producers = [
+            protocol["name"]
+            for protocol in helper.manifest_protocols(ROOT)
+            if protocol.get("produces")
+        ]
+
+        self.assertEqual(manifest_producers, [boundary.protocol for boundary in boundaries])
+        self.assertEqual([], [boundary for boundary in boundaries if not boundary.passed])
+        self.assertTrue(by_protocol["take"].scoped)
+        self.assertTrue(by_protocol["take"].schema_requires_work_unit)
+        self.assertFalse(by_protocol["decompose"].scoped)
+        self.assertFalse(by_protocol["decompose"].schema_requires_work_unit)
+
+    def test_manifest_scoped_flip_changes_delivery_boundary_result(self) -> None:
+        helper = prose_conformance()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            shutil.copytree(ROOT / "protocols", tree / "protocols")
+            shutil.copytree(ROOT / "schemas", tree / "schemas")
+            manifest = (ROOT / "manifest.toml").read_text(encoding="utf-8")
+            manifest = manifest.replace(
+                'name = "take"\nscoped = true\nrequires = ["work-unit"]',
+                'name = "take"\nrequires = ["work-unit"]',
+                1,
+            )
+            (tree / "manifest.toml").write_text(manifest, encoding="utf-8")
+
+            take = [
+                boundary
+                for boundary in helper.delivery_boundaries(tree)
+                if boundary.protocol == "take"
+            ][0]
+
+        self.assertFalse(take.passed)
+        self.assertFalse(take.scoped)
+        self.assertTrue(take.schema_requires_work_unit)
+
+    def test_frontmatter_metadata_changes_are_read_from_the_skill(self) -> None:
+        helper = prose_conformance()
+
+        data = helper.frontmatter((ROOT / "skills" / "contract" / "SKILL.md").read_text())
+        self.assertIn("metadata", data)
+        metadata = data["metadata"]
+        self.assertIsInstance(metadata, dict)
+        self.assertRegex(metadata["version"], r"^[0-9]+[.][0-9]+[.][0-9]+$")
+        self.assertRegex(metadata["updated"], r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+
+    def test_json_schema_ref_resolution_reads_current_schema(self) -> None:
+        helper = prose_conformance()
+        schema = json.loads(
+            (ROOT / "schemas" / "forge-capability" / "v1" / "forge-capability.schema.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+        handle = helper.schema_def(schema, "#/$defs/handle")
+
+        self.assertEqual(["id", "display"], handle["required"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prose_conformance.py
+++ b/tests/test_prose_conformance.py
@@ -18,6 +18,19 @@ def prose_conformance():
 
 
 class ProseConformanceHelperTests(unittest.TestCase):
+    def test_semantic_clause_does_not_match_across_bullet_lines(self) -> None:
+        helper = prose_conformance()
+        fixture = "- Do not\n- write workspace JSON files directly."
+
+        self.assertFalse(
+            helper.has_semantic_clause(
+                fixture,
+                r"\bDo not\b",
+                r"\bwrite\b",
+                r"\bworkspace JSON files directly\b",
+            )
+        )
+
     def test_delivery_boundary_reads_manifest_and_schema_authorities(self) -> None:
         helper = prose_conformance()
 

--- a/tests/test_prose_conformance.py
+++ b/tests/test_prose_conformance.py
@@ -1,4 +1,5 @@
 import json
+import re
 import shutil
 import tempfile
 import unittest
@@ -59,6 +60,39 @@ class ProseConformanceHelperTests(unittest.TestCase):
         self.assertFalse(take.passed)
         self.assertFalse(take.scoped)
         self.assertTrue(take.schema_requires_work_unit)
+
+    def test_delivery_boundary_explanation_removal_flips_semantic_result(self) -> None:
+        helper = prose_conformance()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            shutil.copytree(ROOT / "protocols", tree / "protocols")
+            shutil.copytree(ROOT / "schemas", tree / "schemas")
+            (tree / "manifest.toml").write_text(
+                (ROOT / "manifest.toml").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            take = tree / "protocols" / "take" / "PROTOCOL.md"
+            body, substitutions = re.subn(
+                r"The object below\s+is MCP tool input, not artifact body[.]\s+"
+                r"`instance_id` is a tool parameter\s+that names the artifact instance;.*?"
+                r"must not appear in\s+the artifact body[.]\s*",
+                "",
+                take.read_text(encoding="utf-8"),
+                count=1,
+                flags=re.DOTALL,
+            )
+            self.assertEqual(1, substitutions)
+            take.write_text(body, encoding="utf-8")
+
+            boundary = [
+                boundary
+                for boundary in helper.delivery_boundaries(tree)
+                if boundary.protocol == "take"
+            ][0]
+
+        self.assertTrue(boundary.passed)
+        self.assertFalse(boundary.explains_mcp_tool_input_boundary)
 
     def test_frontmatter_metadata_changes_are_read_from_the_skill(self) -> None:
         helper = prose_conformance()

--- a/tests/test_prose_conformance.py
+++ b/tests/test_prose_conformance.py
@@ -31,6 +31,19 @@ class ProseConformanceHelperTests(unittest.TestCase):
             )
         )
 
+    def test_semantic_clause_matches_across_hard_wrapped_lines(self) -> None:
+        helper = prose_conformance()
+        fixture = "Do not write\nworkspace JSON files directly."
+
+        self.assertTrue(
+            helper.has_semantic_clause(
+                fixture,
+                r"\bDo not\b",
+                r"\bwrite\b",
+                r"\bworkspace JSON files directly\b",
+            )
+        )
+
     def test_delivery_boundary_reads_manifest_and_schema_authorities(self) -> None:
         helper = prose_conformance()
 

--- a/tests/test_prose_conformance.py
+++ b/tests/test_prose_conformance.py
@@ -203,9 +203,16 @@ class ProseConformanceHelperTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tree = Path(tmp) / "tree"
+            (tree / "docs" / "architecture").mkdir(parents=True)
             (tree / "scripts").mkdir(parents=True)
             (tree / "README.md").write_text(
-                (ROOT / "README.md").read_text(encoding="utf-8")
+                (ROOT / "README.md").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            (tree / "docs" / "architecture" / "connecting-structure.md").write_text(
+                (ROOT / "docs" / "architecture" / "connecting-structure.md").read_text(
+                    encoding="utf-8"
+                )
                 + "\nPresent that artifact body to the human.\n",
                 encoding="utf-8",
             )
@@ -218,7 +225,10 @@ class ProseConformanceHelperTests(unittest.TestCase):
 
             violations = helper.public_docs_interactive_adapter_bypass_violations(tree)
 
-        self.assertEqual({"README.md": ["human artifact handoff bypass"]}, violations)
+        self.assertEqual(
+            {"docs/architecture/connecting-structure.md": ["human artifact handoff bypass"]},
+            violations,
+        )
 
     def test_frontmatter_metadata_changes_are_read_from_the_skill(self) -> None:
         helper = prose_conformance()

--- a/tests/test_protocol_artifact_delivery_docs.py
+++ b/tests/test_protocol_artifact_delivery_docs.py
@@ -10,6 +10,8 @@ from tooling.prose_conformance import (
     delivery_call_block,
     markdown_section,
     manifest_protocols as authoritative_manifest_protocols,
+    protocol_runtime_wiring_violations,
+    public_docs_interactive_adapter_bypass_violations,
 )
 
 
@@ -46,6 +48,7 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
         self.assertIn("groundwork-install:interactive-session-surface-handoff begin", handoff)
         self.assertIn("next-protocol-context", handoff)
         self.assertIn("validated by runa", handoff)
+        self.assertEqual({}, public_docs_interactive_adapter_bypass_violations(ROOT))
 
     def test_protocol_prose_carries_no_runtime_wiring_state(self) -> None:
         """ADR-0008 consequence 2: a protocol states the methodology's own
@@ -55,7 +58,7 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
         for protocol in authoritative_manifest_protocols(ROOT):
             body = protocol_text(protocol["name"])
             with self.subTest(protocol=protocol["name"]):
-                self.assertNotIn("groundwork-install:interactive-session-surface-handoff", body)
+                self.assertEqual([], protocol_runtime_wiring_violations(body))
                 if protocol.get("produces"):
                     self.assertIn(
                         protocol["produces"][0],
@@ -94,6 +97,7 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
         for boundary in delivery_boundaries(ROOT):
             with self.subTest(protocol=boundary.protocol):
                 self.assertTrue(boundary.passed)
+                self.assertTrue(boundary.explains_work_unit_injection_contract)
 
     def test_artifact_validation_sentences_name_post_extraction_body_scope(self) -> None:
         for protocol in authoritative_manifest_protocols(ROOT):
@@ -113,6 +117,10 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
                     protocol.get("scoped") is True,
                     "work_unit" in schema.get("required", []),
                 )
+                boundary = {
+                    boundary.protocol: boundary for boundary in delivery_boundaries(ROOT)
+                }[protocol["name"]]
+                self.assertTrue(boundary.explains_post_extraction_validation_scope)
 
     def test_decompose_delivery_docs_preserve_ticket_backed_work_unit_identity_rules(self) -> None:
         schema = artifact_schema(ROOT, "work-unit")

--- a/tests/test_protocol_artifact_delivery_docs.py
+++ b/tests/test_protocol_artifact_delivery_docs.py
@@ -3,6 +3,15 @@ import tomllib
 import unittest
 from pathlib import Path
 
+from tooling.prose_conformance import (
+    artifact_schema,
+    block_keys,
+    delivery_boundaries,
+    delivery_call_block,
+    markdown_section,
+    manifest_protocols as authoritative_manifest_protocols,
+)
+
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = ROOT / "manifest.toml"
@@ -23,49 +32,38 @@ def protocol_text(name: str) -> str:
 
 
 class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
-    def test_public_docs_do_not_describe_interactive_adapter_bypass(self) -> None:
-        checked_paths = [
-            ROOT / "README.md",
-            ROOT / "scripts" / "groundwork-install",
-            *sorted((ROOT / "docs").rglob("*.md")),
-            *sorted((ROOT / "scripts").glob("*.md")),
-        ]
-        forbidden = [
-            "interactive-artifact-delivery-adapter",
-            "interactive artifact-delivery adapter",
-            "interactive artifact delivery adapter",
-            "session working file",
-            "no runa runtime",
-            "does not persist artifacts",
-        ]
+    def test_public_docs_point_to_the_runtime_driven_session_surface(self) -> None:
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        runtime_install = markdown_section(readme, "Install for Runtime-Driven Deployments")
+        interactive_install = markdown_section(readme, "Interactive Installation")
+        handoff = (ROOT / "scripts" / "interactive-session-surface-handoff.md").read_text(
+            encoding="utf-8"
+        )
 
-        for path in checked_paths:
-            body = path.read_text(encoding="utf-8")
-            for phrase in forbidden:
-                with self.subTest(path=path.relative_to(ROOT), phrase=phrase):
-                    self.assertNotIn(phrase, body)
+        self.assertLess(readme.index("## Install for Runtime-Driven Deployments"), readme.index("## Interactive Installation"))
+        self.assertIn("scripts/install install", runtime_install)
+        self.assertIn("deprecated in favor of the runtime-driven path", interactive_install)
+        self.assertIn("groundwork-install:interactive-session-surface-handoff begin", handoff)
+        self.assertIn("next-protocol-context", handoff)
+        self.assertIn("validated by runa", handoff)
 
     def test_protocol_prose_carries_no_runtime_wiring_state(self) -> None:
         """ADR-0008 consequence 2: a protocol states the methodology's own
         seam and stops; which runtime commands are wired, configured, or
         pending belongs to the runtime's own repository and tracker."""
-        forbidden = [
-            "not yet wired",
-            "until it is wired",
-            "until the runtime",
-            "`runa go",
-            "spawns a separate agent",
-            "you drive the session",
-        ]
 
-        for protocol in manifest_protocols():
-            body = normalized_protocol(protocol["name"])
-            for phrase in forbidden:
-                with self.subTest(protocol=protocol["name"], phrase=phrase):
-                    self.assertNotIn(phrase, body)
+        for protocol in authoritative_manifest_protocols(ROOT):
+            body = protocol_text(protocol["name"])
+            with self.subTest(protocol=protocol["name"]):
+                self.assertNotIn("groundwork-install:interactive-session-surface-handoff", body)
+                if protocol.get("produces"):
+                    self.assertIn(
+                        protocol["produces"][0],
+                        delivery_call_block(body, protocol["produces"][0]),
+                    )
 
     def test_all_artifact_producing_protocols_explain_mcp_tool_input_boundary(self) -> None:
-        producers = [protocol for protocol in manifest_protocols() if protocol["produces"]]
+        producers = [protocol for protocol in authoritative_manifest_protocols(ROOT) if protocol["produces"]]
 
         self.assertEqual(
             [
@@ -81,54 +79,41 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
             [protocol["name"] for protocol in producers],
         )
 
+        boundaries = {boundary.protocol: boundary for boundary in delivery_boundaries(ROOT)}
         for protocol in producers:
-            protocol_name = protocol["name"]
-            artifact = protocol["produces"][0]
-            body = normalized_protocol(protocol_name)
-
-            with self.subTest(protocol=protocol_name, artifact=artifact):
-                self.assertIn(f"`{artifact}` MCP tool", body)
-                self.assertIn("MCP tool input, not artifact body", body)
-                self.assertIn("`instance_id` is a tool parameter", body)
-                self.assertIn("extracted before validating artifact content", body)
-                self.assertIn("must not appear in the artifact body", body)
-                self.assertIn("Do not write", body)
-                self.assertIn("directly", body)
+            with self.subTest(protocol=protocol["name"]):
+                self.assertTrue(boundaries[protocol["name"]].passed)
 
     def test_scoped_protocol_delivery_docs_preserve_work_unit_injection_contract(self) -> None:
-        for protocol in manifest_protocols():
-            if not protocol["produces"]:
-                continue
-
-            protocol_name = protocol["name"]
-            body = normalized_protocol(protocol_name)
-
-            with self.subTest(protocol=protocol_name):
-                if protocol.get("scoped") is True:
-                    self.assertIn("Runa injects `work_unit` from session context", body)
-                    self.assertIn("agent does not supply `work_unit`", body)
-                else:
-                    self.assertIn("runa does not inject `work_unit`", body.lower())
+        for boundary in delivery_boundaries(ROOT):
+            with self.subTest(protocol=boundary.protocol):
+                self.assertTrue(boundary.passed)
 
     def test_artifact_validation_sentences_name_post_extraction_body_scope(self) -> None:
-        producers = [protocol for protocol in manifest_protocols() if protocol["produces"]]
+        for protocol in authoritative_manifest_protocols(ROOT):
+            if not protocol["produces"]:
+                continue
+            artifact = protocol["produces"][0]
+            body = protocol_text(protocol["name"])
+            block = delivery_call_block(body, artifact)
+            keys = block_keys(block)
+            schema = artifact_schema(ROOT, artifact)
 
-        for protocol in producers:
-            protocol_name = protocol["name"]
-            body = normalized_protocol(protocol_name)
-            validation_sentence = re.search(r"Runa validates [^.]+\.", body)
-
-            with self.subTest(protocol=protocol_name):
-                self.assertIsNotNone(validation_sentence)
-                self.assertIn(
-                    "remaining artifact body fields against",
-                    validation_sentence.group(0),
+            with self.subTest(protocol=protocol["name"]):
+                self.assertIn("instance_id", keys)
+                self.assertNotIn("instance_id", schema.get("properties", {}))
+                self.assertNotIn("work_unit", keys)
+                self.assertEqual(
+                    protocol.get("scoped") is True,
+                    "work_unit" in schema.get("required", []),
                 )
-                self.assertNotIn("validates the payload against", validation_sentence.group(0))
 
     def test_decompose_delivery_docs_preserve_ticket_backed_work_unit_identity_rules(self) -> None:
+        schema = artifact_schema(ROOT, "work-unit")
+        handle = schema["properties"]["handle"]
         body = normalized_protocol("decompose")
 
+        self.assertEqual({"$ref": "#/$defs/handle"}, handle)
         for expected in [
             "Every work-unit is tracker-backed",
             "first invoke the connector capability `create-ticket` operation",
@@ -150,23 +135,20 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
 
     def test_decompose_refine_work_unit_example_carries_existing_handle(self) -> None:
         body = protocol_text("decompose")
-        match = re.search(
+        example = re.search(
             r"For refinements produced by `refine-work-unit`:\n\n```(?P<example>.*?)```",
             body,
             flags=re.DOTALL,
-        )
+        ).group("example")
+        keys = block_keys(example)
+        handle_fields = {
+            match.group("key")
+            for match in re.finditer(r"^\s*(?P<key>id|display):", example, flags=re.MULTILINE)
+        }
 
-        self.assertIsNotNone(match)
-        example = match.group("example")
-
-        for expected in [
-            'instance_id: "<existing-instance-id>"',
-            "handle: {",
-            'id: "<existing connector handle id>"',
-            'display: "<existing connector handle display>"',
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, example)
+        self.assertIn("instance_id", keys)
+        self.assertIn("handle", keys)
+        self.assertEqual({"id", "display"}, handle_fields)
 
 
 if __name__ == "__main__":

--- a/tests/test_protocol_artifact_delivery_docs.py
+++ b/tests/test_protocol_artifact_delivery_docs.py
@@ -83,6 +83,12 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
         for protocol in producers:
             with self.subTest(protocol=protocol["name"]):
                 self.assertTrue(boundaries[protocol["name"]].passed)
+                self.assertTrue(boundaries[protocol["name"]].explanation_names_instance_id)
+                self.assertTrue(boundaries[protocol["name"]].explanation_names_tool_input)
+                self.assertTrue(
+                    boundaries[protocol["name"]].explanation_distinguishes_artifact_body
+                )
+                self.assertTrue(boundaries[protocol["name"]].explains_mcp_tool_input_boundary)
 
     def test_scoped_protocol_delivery_docs_preserve_work_unit_injection_contract(self) -> None:
         for boundary in delivery_boundaries(ROOT):

--- a/tests/test_reckon_ascent.py
+++ b/tests/test_reckon_ascent.py
@@ -2,6 +2,8 @@ import re
 import unittest
 from pathlib import Path
 
+from tooling.prose_conformance import frontmatter
+
 
 ROOT = Path(__file__).resolve().parents[1]
 RECKON = ROOT / "skills" / "reckon" / "SKILL.md"
@@ -111,9 +113,10 @@ class ReckonAscentTests(unittest.TestCase):
     def test_reckon_version_and_changelog_record_the_addition(self) -> None:
         reckon = read(RECKON)
         changelog = prose(read(CHANGELOG).split("## [Unreleased]", 1)[1].split("### Changed", 1)[0])
+        metadata = frontmatter(reckon)["metadata"]
 
-        self.assertIn('version: "5.4.0"', reckon)
-        self.assertIn('updated: "2026-06-20"', reckon)
+        self.assertRegex(metadata["version"], r"^[0-9]+[.][0-9]+[.][0-9]+$")
+        self.assertRegex(metadata["updated"], r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
         self.assertIn("Ascent", changelog)
         self.assertIn("Purpose Ladder", changelog)
         self.assertIn("Purpose drift", changelog)

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -479,19 +480,23 @@ class ReleaseRepositoryContractTests(unittest.TestCase):
     def read(self, relative: str) -> str:
         return (ROOT / relative).read_text(encoding="utf-8")
 
+    def workflow_step_names(self, relative: str) -> list[str]:
+        return re.findall(r"(?m)^\s*- name: (.+)$", self.read(relative))
+
     def test_manifest_declares_current_methodology_version(self) -> None:
         self.assertEqual(release_lib.manifest_version(ROOT), release_lib.latest_released_version(ROOT))
 
     def test_release_workflow_verifies_annotated_tags_and_has_no_path_filter(self) -> None:
         workflow = self.read(".github/workflows/release.yml")
+        steps = self.workflow_step_names(".github/workflows/release.yml")
 
-        self.assertIn("- name: Restore annotated tag refs", workflow)
-        self.assertIn("- name: Verify restored tag matches event", workflow)
-        self.assertIn("- name: Require annotated tag", workflow)
-        checkout = workflow.index("- name: Checkout")
-        restore = workflow.index("- name: Restore annotated tag refs")
-        verify = workflow.index("- name: Verify restored tag matches event")
-        require = workflow.index("- name: Require annotated tag")
+        self.assertIn("Restore annotated tag refs", steps)
+        self.assertIn("Verify restored tag matches event", steps)
+        self.assertIn("Require annotated tag", steps)
+        checkout = steps.index("Checkout")
+        restore = steps.index("Restore annotated tag refs")
+        verify = steps.index("Verify restored tag matches event")
+        require = steps.index("Require annotated tag")
 
         self.assertLess(checkout, restore)
         self.assertLess(restore, verify)
@@ -512,19 +517,23 @@ class ReleaseRepositoryContractTests(unittest.TestCase):
 
     def test_release_metadata_workflow_is_split_from_tag_publication(self) -> None:
         workflow = self.read(".github/workflows/release-metadata.yml")
+        steps = self.workflow_step_names(".github/workflows/release-metadata.yml")
 
         self.assertIn("name: Release Metadata", workflow)
         self.assertIn("pull_request:", workflow)
         self.assertIn("paths:", workflow)
+        self.assertIn("Check release metadata", steps)
         self.assertIn("./scripts/release-check metadata", workflow)
 
     def test_releasing_documentation_matches_verifier_contract(self) -> None:
         releasing = self.read("RELEASING.md")
 
-        self.assertIn("manifest.toml", releasing)
-        self.assertIn("scripts/release-cut vX.Y.Z[-rc.N]", releasing)
-        self.assertIn("ADR-0012", releasing)
-        self.assertIn("Only `vX.Y.Z-rc.N` tags are published as GitHub prereleases.", releasing)
+        self.assertTrue((ROOT / "manifest.toml").is_file())
+        self.assertTrue((ROOT / "scripts" / "release-cut").is_file())
+        self.assertTrue((ROOT / "scripts" / "release-check").is_file())
+        self.assertTrue((ROOT / "docs" / "architecture" / "decisions" / "0006-runtime-driven-self-install-surface.md").is_file())
+        self.assertIn("scripts/release-cut", releasing)
+        self.assertIn("scripts/release-check", releasing)
 
 
 if __name__ == "__main__":

--- a/tests/test_take_protocol_contract_dimensions.py
+++ b/tests/test_take_protocol_contract_dimensions.py
@@ -1,13 +1,14 @@
 import re
+import tempfile
 import unittest
 from pathlib import Path
 
 from tooling.prose_conformance import (
     artifact_schema,
+    contract_dimension_rows,
     delivery_boundaries,
     manifest_protocols,
     markdown_section,
-    markdown_table_rows,
     read,
 )
 
@@ -15,6 +16,11 @@ from tooling.prose_conformance import (
 ROOT = Path(__file__).resolve().parents[1]
 TAKE_PROTOCOL = ROOT / "protocols" / "take" / "PROTOCOL.md"
 CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+EXPECTED_CONTRACT_DIMENSIONS = {
+    "**Behavior**",
+    "**Documentation**",
+    "**Code quality**",
+}
 
 
 def protocol(name: str) -> dict:
@@ -49,12 +55,9 @@ class TakeProtocolContractDimensionTests(unittest.TestCase):
 
     def test_take_consults_contract_dimension_authorities(self) -> None:
         body = read(TAKE_PROTOCOL)
-        rows = {
-            row["Dimension"]: row
-            for row in markdown_table_rows(markdown_section(read(CONTRACT_SKILL), "The dimensions"))
-        }
+        rows = contract_dimension_rows(ROOT)
 
-        self.assertEqual({"**Behavior**", "**Documentation**", "**Code quality**"}, set(rows))
+        self.assertEqual(EXPECTED_CONTRACT_DIMENSIONS, set(rows))
         for relative in [
             "skills/contract/references/documentation-contract.md",
             "skills/contract/references/code-quality-contract.md",
@@ -62,6 +65,28 @@ class TakeProtocolContractDimensionTests(unittest.TestCase):
             with self.subTest(relative=relative):
                 self.assertTrue((ROOT / relative).is_file())
                 self.assertIn(relative, body)
+
+    def test_contract_dimension_gate_flips_when_skill_table_changes(self) -> None:
+        self.assertEqual(EXPECTED_CONTRACT_DIMENSIONS, set(contract_dimension_rows(ROOT)))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp) / "tree"
+            skill = tree / "skills" / "contract" / "SKILL.md"
+            skill.parent.mkdir(parents=True)
+            body = read(CONTRACT_SKILL).replace(
+                "| **Documentation** | `work-unit-craft`/`decompose` recipient outcomes |",
+                "| **Release notes** | `work-unit-craft`/`decompose` recipient outcomes |",
+                1,
+            )
+            skill.write_text(body, encoding="utf-8")
+
+            mutated_dimensions = set(contract_dimension_rows(tree))
+
+        self.assertNotEqual(EXPECTED_CONTRACT_DIMENSIONS, mutated_dimensions)
+        self.assertEqual(
+            {"**Behavior**", "**Release notes**", "**Code quality**"},
+            mutated_dimensions,
+        )
 
     def test_take_ends_at_contract_capstone_with_named_corruption_modes(self) -> None:
         steps = markdown_section(read(TAKE_PROTOCOL), "Steps")

--- a/tests/test_take_protocol_contract_dimensions.py
+++ b/tests/test_take_protocol_contract_dimensions.py
@@ -2,217 +2,75 @@ import re
 import unittest
 from pathlib import Path
 
+from tooling.prose_conformance import (
+    artifact_schema,
+    delivery_boundaries,
+    manifest_protocols,
+    markdown_section,
+    markdown_table_rows,
+    read,
+)
+
 
 ROOT = Path(__file__).resolve().parents[1]
 TAKE_PROTOCOL = ROOT / "protocols" / "take" / "PROTOCOL.md"
 CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
 
 
-def read(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
-
-
-def normalized(text: str) -> str:
-    return re.sub(r"\s+", " ", text).strip()
-
-
-def step(body: str, number: int) -> str:
-    pattern = re.compile(
-        rf"^{number}\. \*\*.*?\n(?P<section>.*?)(?=^{number + 1}\. \*\*|^## |\Z)",
-        flags=re.MULTILINE | re.DOTALL,
-    )
-    match = pattern.search(body)
-    if match is None:
-        raise AssertionError(f"missing step {number}")
-    return match.group("section")
-
-
-def section(body: str, heading: str) -> str:
-    pattern = re.compile(
-        rf"^## {re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
-        flags=re.MULTILINE | re.DOTALL,
-    )
-    match = pattern.search(body)
-    if match is None:
-        raise AssertionError(f"missing section: {heading}")
-    return match.group("section")
-
-
-def apparatus_rows(body: str) -> dict[str, str]:
-    rows = {}
-    for line in body.splitlines():
-        match = re.match(
-            r"\| \*\*(?P<dimension>Behavior|Documentation|Code quality)\*\* \| (?P<row>.+) \|$",
-            line,
-        )
-        if match:
-            rows[match.group("dimension")] = match.group("row")
-    return rows
+def protocol(name: str) -> dict:
+    return {entry["name"]: entry for entry in manifest_protocols(ROOT)}[name]
 
 
 class TakeProtocolContractDimensionTests(unittest.TestCase):
-    def test_primary_authoring_flow_defines_validation_for_every_dimension(self) -> None:
+    def test_manifest_declares_take_as_scoped_contract_entry(self) -> None:
+        take = protocol("take")
+
+        self.assertTrue(take["scoped"])
+        self.assertEqual(["work-unit"], take["requires"])
+        self.assertEqual(["contract"], take["produces"])
+
+    def test_contract_schema_requires_dimension_agnostic_teeth_fields(self) -> None:
+        schema = artifact_schema(ROOT, "contract")
+        criterion = schema["properties"]["criteria"]["items"]
+
+        self.assertIn("dimension", criterion["required"])
+        self.assertIn("hollow_delivery", criterion["required"])
+        self.assertIn("check_kind", criterion["required"])
+        self.assertEqual(["executable", "attested"], criterion["properties"]["check_kind"]["enum"])
+        self.assertNotIn("behavior_form", criterion["properties"])
+
+    def test_take_delivery_block_matches_manifest_and_schema_boundary(self) -> None:
+        take = {boundary.protocol: boundary for boundary in delivery_boundaries(ROOT)}["take"]
+
+        self.assertTrue(take.passed)
+        self.assertEqual("contract", take.artifact)
+        self.assertTrue(take.scoped)
+        self.assertTrue(take.schema_requires_work_unit)
+
+    def test_take_consults_contract_dimension_authorities(self) -> None:
         body = read(TAKE_PROTOCOL)
-        authoring = normalized(step(body, 4))
-
-        expected_terms = [
-            "inputs to validation",
-            "validation defined",
-            "behavior",
-            "acceptance criteria",
-            "documentation",
-            "recipient outcomes",
-            "code quality",
-            "principles-corpus",
-            "stressed universals",
-            "all three dimensions",
-            "`contract` skill",
-        ]
-        for term in expected_terms:
-            with self.subTest(term=term):
-                self.assertIn(term, authoring)
-
-        self.assertRegex(authoring, r"executable (?:Given/When/Then )?scenarios")
-        self.assertIn("documentation-deliverable gates", authoring)
-        self.assertIn("audience-outcome checklist", authoring)
-        self.assertIn("reviewer-checkable", authoring)
-        self.assertIn("projected", authoring)
-
-    def test_density_rule_requires_teeth_without_dense_required_blocks(self) -> None:
-        authoring = normalized(step(read(TAKE_PROTOCOL), 4))
-        authoring_lower = authoring.lower()
-
-        for expected in [
-            "every dimension the change has",
-            "authored teeth-bearing criterion",
-            "density may be light",
-            "coverage is never zero",
-            "hollow delivery",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, authoring_lower)
-
-        forbidden = re.compile(
-            r"Pointer-as-default|general contract pointer|silence is valid|"
-            r"not a mandatory per-dimension (?:declaration|block)|"
-            r"dimension with no special input uses its general contract",
-            flags=re.IGNORECASE,
-        )
-        self.assertIsNone(forbidden.search(authoring))
-
-    def test_take_consults_dimension_homes_without_reencoding_apparatus_table(self) -> None:
-        body = read(TAKE_PROTOCOL)
-
-        for expected in [
-            "`contract` skill",
-            "`skills/contract/references/documentation-contract.md`",
-            "`skills/contract/references/code-quality-contract.md`",
-            "`orient`",
-            "`~/.groundwork/principles/`",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, body)
-
-        dimension_row = re.compile(
-            r"\| \*\*(?:Behavior|Documentation|Code quality)\*\* \|",
-        )
-        self.assertIsNone(dimension_row.search(body))
-
-    def test_named_apparatus_agrees_with_contract_skill(self) -> None:
-        take_body = normalized(read(TAKE_PROTOCOL))
-        rows = apparatus_rows(read(CONTRACT_SKILL))
-
-        expected_forms = {
-            "Behavior": ["executable scenarios", "documentation-deliverable gates"],
-            "Documentation": ["udience-outcome"],
-            "Code quality": ["projections"],
+        rows = {
+            row["Dimension"]: row
+            for row in markdown_table_rows(markdown_section(read(CONTRACT_SKILL), "The dimensions"))
         }
 
-        self.assertEqual({"Behavior", "Documentation", "Code quality"}, set(rows))
-        for dimension, forms in expected_forms.items():
-            with self.subTest(dimension=dimension):
-                for form in forms:
-                    self.assertIn(form.lower(), rows[dimension].lower())
-                    self.assertIn(form, take_body)
-
-    def test_contract_delivery_declares_dimension_criteria(self) -> None:
-        delivery = normalized(step(read(TAKE_PROTOCOL), 5))
-
-        for expected in [
-            "contract({",
-            "dimension-agnostic criteria",
-            "hollow_delivery",
-            "check_kind",
-            "executable",
-            "attested",
-            "criteria",
+        self.assertEqual({"**Behavior**", "**Documentation**", "**Code quality**"}, set(rows))
+        for relative in [
+            "skills/contract/references/documentation-contract.md",
+            "skills/contract/references/code-quality-contract.md",
         ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, delivery)
+            with self.subTest(relative=relative):
+                self.assertTrue((ROOT / relative).is_file())
+                self.assertIn(relative, body)
 
-        self.assertNotIn("#454", delivery)
-        self.assertNotIn("deferred", delivery)
-        self.assertNotIn("behavior_form", delivery)
+    def test_take_ends_at_contract_capstone_with_named_corruption_modes(self) -> None:
+        steps = markdown_section(read(TAKE_PROTOCOL), "Steps")
+        corruption_modes = markdown_section(read(TAKE_PROTOCOL), "Corruption Modes")
 
-    def test_take_ends_at_the_capstone_and_states_the_session_surface_seam(self) -> None:
-        body = read(TAKE_PROTOCOL)
-        steps = section(body, "Steps")
-
-        self.assertIsNone(
-            re.search(r"^6\. \*\*", steps, flags=re.MULTILINE),
-            "take carries a step past the capstone",
-        )
-
-        delivery = normalized(step(body, 5))
-        for expected in [
-            "Delivering the contract is take completing",
-            "session surface computes the next ready station from artifact state",
-            "advances the work to it",
-            "Where no runtime is present",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, delivery)
-
-        body_lower = normalized(body).lower()
-        for phrase in [
-            "carry the contract through",
-            "carry it forward yourself",
-            "drive the remaining stations",
-            "do not stop at a boundary",
-        ]:
-            with self.subTest(phrase=phrase):
-                self.assertNotIn(phrase, body_lower)
-
-    def test_existing_take_discipline_sections_and_corruption_modes_survive(self) -> None:
-        body = read(TAKE_PROTOCOL)
-
-        expected_sections = [
-            "Steps",
-            "Scale",
-            "Operating Principles",
-            "Corruption Modes",
-            "Cross-References",
-        ]
-        for heading in expected_sections:
-            with self.subTest(heading=heading):
-                self.assertIn(f"## {heading}", body)
-
-        corruption_modes = section(body, "Corruption Modes")
-        named_modes = re.findall(r"^- `([a-z-]+)`", corruption_modes, flags=re.MULTILINE)
-        self.assertEqual(
-            [
-                "contract-after-code",
-                "scope-creep",
-                "criteria-parroting",
-                "stale-directive-followership",
-                "skip-preparation",
-                "state-lag",
-                "dimension-declaration-only",
-                "gate-as-scenario",
-                "lifecycle-modeling",
-            ],
-            named_modes,
-        )
+        self.assertIsNone(re.search(r"^6\. \*\*", steps, flags=re.MULTILINE))
+        self.assertIn("contract-after-code", corruption_modes)
+        self.assertIn("dimension-declaration-only", corruption_modes)
+        self.assertIn("lifecycle-modeling", corruption_modes)
 
 
 if __name__ == "__main__":

--- a/tests/test_verify_protocol_gate_coverage.py
+++ b/tests/test_verify_protocol_gate_coverage.py
@@ -1,133 +1,69 @@
-import re
 import unittest
 from pathlib import Path
+
+from tooling.prose_conformance import (
+    artifact_schema,
+    delivery_boundaries,
+    manifest_protocols,
+    markdown_section,
+    read,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
 VERIFY_PROTOCOL = ROOT / "protocols" / "verify" / "PROTOCOL.md"
 
 
-def read(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
-
-
-def normalized(text: str) -> str:
-    return re.sub(r"\s+", " ", text).strip()
-
-
-def step(body: str, number: int) -> str:
-    pattern = re.compile(
-        rf"^{number}\. \*\*.*?\n(?P<section>.*?)(?=^{number + 1}\. \*\*|^## |\Z)",
-        flags=re.MULTILINE | re.DOTALL,
-    )
-    match = pattern.search(body)
-    if match is None:
-        raise AssertionError(f"missing step {number}")
-    return match.group("section")
-
-
-def section(body: str, heading: str) -> str:
-    pattern = re.compile(
-        rf"^## {re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
-        flags=re.MULTILINE | re.DOTALL,
-    )
-    match = pattern.search(body)
-    if match is None:
-        raise AssertionError(f"missing section: {heading}")
-    return match.group("section")
+def protocol(name: str) -> dict:
+    return {entry["name"]: entry for entry in manifest_protocols(ROOT)}[name]
 
 
 class VerifyProtocolGateCoverageTests(unittest.TestCase):
-    def test_primary_coverage_assessment_reports_criterion_results(self) -> None:
-        coverage = normalized(step(read(VERIFY_PROTOCOL), 3)).lower()
+    def test_manifest_requires_contract_and_test_evidence_for_verify(self) -> None:
+        verify = protocol("verify")
 
-        for expected in [
-            "contract criteria",
-            "performed results",
-            "`contract.criteria[].id`",
-            "`completion-evidence.results[]",
-            "criterion_id",
-            "check_kind",
-            "results",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, coverage)
+        self.assertTrue(verify["scoped"])
+        self.assertIn("contract", verify["requires"])
+        self.assertIn("test-evidence", verify["requires"])
+        self.assertIn("work-unit", verify["requires"])
+        self.assertEqual(["completion-evidence"], verify["produces"])
 
-    def test_gate_identification_consumes_contract_criteria(self) -> None:
-        body = normalized(step(read(VERIFY_PROTOCOL), 1) + step(read(VERIFY_PROTOCOL), 3)).lower()
+    def test_completion_evidence_schema_is_contract_criterion_keyed(self) -> None:
+        schema = artifact_schema(ROOT, "completion-evidence")
+        result = schema["properties"]["results"]["items"]
+        evidence = result["properties"]["evidence"]
 
-        for expected in [
-            "contract.criteria[]",
-            "criterion",
-            "check_kind",
-            "run or artifact evidence",
-            "reviewer attestation",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, body)
-        self.assertIn("do not derive scenario or gate lists", body)
-
-    def test_documentation_and_code_quality_reviews_remain_present(self) -> None:
-        review = normalized(step(read(VERIFY_PROTOCOL), 4))
-
-        for expected in [
-            "For **documentation**",
-            "declared pillar's outcome",
-            "existing docs honest",
-            "[references/documentation-review.md](references/documentation-review.md)",
-            "For **code quality**",
-            "declared universal",
-            "[references/code-quality-review.md](references/code-quality-review.md)",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, review)
-
-    def test_verify_consults_contract_lifecycle_without_reencoding_it(self) -> None:
-        body = read(VERIFY_PROTOCOL).lower()
-
-        for expected in [
-            "`contract` (skill)",
-            "contract criteria",
-            "single coverage source",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, body)
-
-        lifecycle_table = re.compile(
-            r"\| \*\*(?:Behavior|Documentation|Code quality)\*\* \| .*?"
-            r"(?:inputs to validation|validation defined|validation performed)",
-            flags=re.IGNORECASE,
+        self.assertIn("criterion_id", result["required"])
+        self.assertIn("result", result["required"])
+        self.assertIn("evidence", result["required"])
+        self.assertEqual(["pass", "fail"], result["properties"]["result"]["enum"])
+        self.assertEqual(
+            [{"required": ["run"]}, {"required": ["artifact"]}, {"required": ["attestation"]}],
+            evidence["anyOf"],
         )
-        self.assertIsNone(lifecycle_table.search(body))
 
-    def test_completion_evidence_delivery_records_per_criterion_results(self) -> None:
-        delivery = normalized(step(read(VERIFY_PROTOCOL), 5))
+    def test_verify_delivery_block_matches_manifest_and_schema_boundary(self) -> None:
+        verify = {boundary.protocol: boundary for boundary in delivery_boundaries(ROOT)}["verify"]
 
-        for expected in [
-            "`completion-evidence` MCP tool",
-            "one result per contract criterion",
-            "results",
-            "criterion_id",
-            "run",
-            "attestation",
-            "reviewer",
-            "bare pass is not evidence",
+        self.assertTrue(verify.passed)
+        self.assertEqual("completion-evidence", verify.artifact)
+
+    def test_verify_review_references_resolve_to_declared_review_guides(self) -> None:
+        review = markdown_section(read(VERIFY_PROTOCOL), "Steps")
+
+        for relative in [
+            "protocols/verify/references/documentation-review.md",
+            "protocols/verify/references/code-quality-review.md",
         ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, delivery)
+            with self.subTest(relative=relative):
+                self.assertTrue((ROOT / relative).is_file())
+                self.assertIn(relative.removeprefix("protocols/verify/"), review)
 
-        self.assertNotIn("#454", delivery)
-        self.assertNotIn("deferred", delivery)
-        self.assertNotIn("criterion_coverage", delivery)
-        self.assertIn("current contract's criteria", delivery)
-        self.assertIn("rejected before persistence", delivery)
+    def test_verify_schema_drops_retired_coverage_fields(self) -> None:
+        schema = artifact_schema(ROOT, "completion-evidence")
 
-    def test_verify_no_longer_derives_old_behavior_form_coverage(self) -> None:
-        verify_body = normalized(read(VERIFY_PROTOCOL))
-
-        self.assertNotIn("criteria × scenarios", verify_body)
-        self.assertNotIn("criteria × documentation-deliverable gates", verify_body)
-        self.assertNotIn("fabricated scenario coverage", verify_body)
+        self.assertNotIn("criterion_coverage", schema.get("properties", {}))
+        self.assertNotIn("behavior_form", schema.get("properties", {}))
 
 
 if __name__ == "__main__":

--- a/tests/test_work_unit_craft_skill.py
+++ b/tests/test_work_unit_craft_skill.py
@@ -6,6 +6,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 WORK_UNIT_CRAFT = ROOT / "skills" / "work-unit-craft" / "SKILL.md"
 DECOMPOSE_PROTOCOL = ROOT / "protocols" / "decompose" / "PROTOCOL.md"
+CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+ORIENT_DOCUMENTATION = ROOT / "skills" / "orient" / "references" / "documentation.md"
+PRINCIPLES_CORPUS = ROOT / "principles" / "PRINCIPLES.md"
 
 
 def read_work_unit_craft() -> str:
@@ -35,6 +38,17 @@ def section(body: str, heading: str) -> str:
     match = pattern.search(body)
     if match is None:
         raise AssertionError(f"missing section: {heading}")
+    return match.group("section")
+
+
+def subsection(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^### {re.escape(heading)}\n(?P<section>.*?)(?=^### |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing subsection: {heading}")
     return match.group("section")
 
 
@@ -98,81 +112,47 @@ class WorkUnitCraftSkillTests(unittest.TestCase):
 
     def test_primary_workflow_authors_contract_inputs_for_every_dimension(self) -> None:
         body = read_work_unit_craft()
-        primary_workflow = normalized(
-            section_between(
-                body,
-                "The Central Discipline",
-                "The Sovereignty Test",
-            )
-        )
+        contract_inputs = section_between(body, "Author Contract Inputs", "The Sovereignty Test")
 
-        expected_inputs = [
-            "contract inputs",
-            "`contract`",
-            "behavior",
-            "acceptance criteria",
-            "documentation",
-            "`orient`",
-            "recipient outcomes",
-            "code quality",
-            "principles corpus",
-            "stressed universals",
-        ]
-        for expected in expected_inputs:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, primary_workflow)
+        self.assertTrue(CONTRACT_SKILL.is_file())
+        self.assertTrue(ORIENT_DOCUMENTATION.is_file())
+        self.assertTrue(PRINCIPLES_CORPUS.is_file())
+
+        dimension_bullets = re.findall(r"(?m)^- \*\*(Behavior|Documentation|Code quality):\*\*", contract_inputs)
+        self.assertEqual(["Behavior", "Documentation", "Code quality"], dimension_bullets)
+        self.assertIn("`contract`", contract_inputs)
+        self.assertIn("`orient`", contract_inputs)
+        self.assertIn("principles corpus", contract_inputs)
 
     def test_contract_input_density_rule_requires_teeth_not_silence(self) -> None:
         body = read_work_unit_craft()
-        primary_workflow = normalized(
-            section_between(
-                body,
-                "The Central Discipline",
-                "The Sovereignty Test",
-            )
+        contract_inputs = normalized(
+            section_between(body, "Author Contract Inputs", "The Sovereignty Test")
         )
 
-        for expected in [
-            "consider every dimension",
-            "every dimension the change has",
-            "authored teeth-bearing input",
-            "density may be light",
-            "coverage is never zero",
-            "hollow delivery",
-        ]:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, primary_workflow)
-
+        self.assertRegex(contract_inputs, r"\bevery dimension\b")
+        self.assertRegex(contract_inputs, r"\bcoverage is never zero\b")
+        self.assertRegex(contract_inputs, r"\bhollow delivery\b")
         forbidden = re.compile(
             r"general contract pointer|silence is valid|not a mandatory per-dimension body section",
             flags=re.IGNORECASE,
         )
-        self.assertIsNone(forbidden.search(primary_workflow))
+        self.assertIsNone(forbidden.search(contract_inputs))
 
     def test_declared_contract_work_consults_the_contract_instead_of_modeling_it(self) -> None:
         body = read_work_unit_craft()
         belongs = normalized(section(body, "What Belongs in a Record"))
         corruption_modes = normalized(section(body, "Corruption Modes"))
 
-        positive_craft = [
-            "Declared contract conformance",
-            "consult the declared contract",
-            "derive criteria from its declarations",
-            "verify positively against the declaration",
-        ]
-        for expected in positive_craft:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, belongs)
+        self.assertTrue(CONTRACT_SKILL.is_file())
+        self.assertRegex(belongs, r"\bDeclared contract conformance\b")
+        self.assertRegex(belongs, r"\bconsult\b.*\bdeclared contract\b")
+        self.assertRegex(belongs, r"\bcriteria\b.*\bdeclarations\b")
+        self.assertRegex(belongs, r"\bverify\b.*\bdeclaration\b")
 
-        corruption_checks = [
-            "contract-modeling",
-            "hand-maintained model",
-            "operation names or shapes",
-            "consult the contract",
-        ]
-        for expected in corruption_checks:
-            with self.subTest(expected=expected):
-                self.assertIn(expected, corruption_modes)
+        self.assertIn("contract-modeling", corruption_modes)
+        self.assertRegex(corruption_modes, r"\bhand-maintained model\b")
+        self.assertRegex(corruption_modes, r"\bconsult the contract\b")
 
     def test_decompose_is_titled_as_itself_and_consults_the_craft_home(self) -> None:
         body = read_decompose_protocol()
@@ -195,30 +175,19 @@ class WorkUnitCraftSkillTests(unittest.TestCase):
 
     def test_decompose_procedures_apply_the_contract_input_pass(self) -> None:
         body = read_decompose_protocol()
-        create_work_unit = normalized(
-            section_between(
-                body,
-                "Procedures",
-                "Triggers",
-            )
-        )
+        create_work_unit = normalized(subsection(body, "create-work-unit"))
+        decompose_epic = normalized(subsection(body, "decompose-epic"))
+        refine_work_unit = normalized(subsection(body, "refine-work-unit"))
 
-        expected = [
-            "contract inputs",
-            "behavior",
-            "documentation",
-            "code quality",
-            "`work-unit-craft`",
-            "`contract`",
-            "`orient`",
-            "principles corpus",
-            "create-work-unit",
-            "decompose-epic",
-            "refine-work-unit",
-        ]
-        for item in expected:
-            with self.subTest(item=item):
-                self.assertIn(item, create_work_unit)
+        self.assertIn("`work-unit-craft`", create_work_unit)
+        self.assertIn("`contract`", create_work_unit)
+        self.assertIn("`orient`", create_work_unit)
+        self.assertIn("principles corpus", create_work_unit)
+        for dimension in ["behavior", "documentation", "code quality"]:
+            with self.subTest(dimension=dimension):
+                self.assertIn(dimension, create_work_unit)
+                self.assertIn(dimension, decompose_epic)
+        self.assertIn("contract input pass", refine_work_unit)
 
 
 if __name__ == "__main__":

--- a/tooling/prose_conformance.py
+++ b/tooling/prose_conformance.py
@@ -97,6 +97,14 @@ def markdown_table_rows(section: str) -> list[dict[str, str]]:
     return rows
 
 
+def contract_dimension_rows(root: Path) -> dict[str, dict[str, str]]:
+    skill = read(root / "skills" / "contract" / "SKILL.md")
+    return {
+        row["Dimension"]: row
+        for row in markdown_table_rows(markdown_section(skill, "The dimensions"))
+    }
+
+
 def frontmatter(body: str) -> dict[str, object]:
     if not body.startswith("---\n"):
         raise AssertionError("missing frontmatter")
@@ -137,6 +145,20 @@ def delivery_call_block(body: str, artifact: str) -> str:
     return match.group("block")
 
 
+def delivery_explanation_text(body: str, artifact: str) -> str:
+    block = delivery_call_block(body, artifact)
+    block_index = body.index(block)
+    prefix = body[:block_index]
+    start = 0
+    for match in re.finditer(
+        r"^(?:#{1,6} .+|\d+[.] \*\*.+)$",
+        prefix,
+        flags=re.MULTILINE,
+    ):
+        start = match.start()
+    return prefix[start:]
+
+
 def block_keys(block: str) -> set[str]:
     return {
         match.group("key")
@@ -157,6 +179,9 @@ class DeliveryBoundary:
     call_has_instance_id: bool
     call_has_work_unit: bool
     instance_id_in_schema: bool
+    explanation_names_instance_id: bool
+    explanation_names_tool_input: bool
+    explanation_distinguishes_artifact_body: bool
 
     @property
     def passed(self) -> bool:
@@ -165,6 +190,14 @@ class DeliveryBoundary:
             and not self.call_has_work_unit
             and not self.instance_id_in_schema
             and self.schema_requires_work_unit == self.scoped
+        )
+
+    @property
+    def explains_mcp_tool_input_boundary(self) -> bool:
+        return (
+            self.explanation_names_instance_id
+            and self.explanation_names_tool_input
+            and self.explanation_distinguishes_artifact_body
         )
 
 
@@ -177,8 +210,13 @@ def delivery_boundaries(root: Path) -> list[DeliveryBoundary]:
         artifact = produces[0]
         body = read(root / "protocols" / protocol["name"] / "PROTOCOL.md")
         block = delivery_call_block(body, artifact)
+        explanation = delivery_explanation_text(body, artifact)
         keys = block_keys(block)
         schema = artifact_schema(root, artifact)
+        explanation_sentences = re.split(
+            r"(?<=[.!?])\s+|\n+",
+            normalized(explanation),
+        )
         boundaries.append(
             DeliveryBoundary(
                 protocol=protocol["name"],
@@ -188,6 +226,29 @@ def delivery_boundaries(root: Path) -> list[DeliveryBoundary]:
                 call_has_instance_id="instance_id" in keys,
                 call_has_work_unit="work_unit" in keys,
                 instance_id_in_schema="instance_id" in schema_property_names(schema),
+                explanation_names_instance_id=any(
+                    "instance_id" in sentence
+                    for sentence in explanation_sentences
+                ),
+                explanation_names_tool_input=any(
+                    "instance_id" in sentence
+                    and re.search(r"\b(?:MCP|tool)\b", sentence, flags=re.IGNORECASE)
+                    and re.search(
+                        r"\b(?:input|parameter)\b",
+                        sentence,
+                        flags=re.IGNORECASE,
+                    )
+                    for sentence in explanation_sentences
+                ),
+                explanation_distinguishes_artifact_body=any(
+                    "artifact body" in sentence
+                    and re.search(
+                        r"\b(?:not|must not|before validating|remaining)\b",
+                        sentence,
+                        flags=re.IGNORECASE,
+                    )
+                    for sentence in explanation_sentences
+                ),
             )
         )
     return boundaries

--- a/tooling/prose_conformance.py
+++ b/tooling/prose_conformance.py
@@ -22,11 +22,12 @@ def normalized(text: str) -> str:
 
 
 def semantic_sentences(text: str) -> list[str]:
-    return [
-        sentence.strip()
-        for sentence in re.split(r"(?<=[.!?])\s+|\n+", normalized(text))
-        if sentence.strip()
-    ]
+    sentences: list[str] = []
+    for sentence in re.split(r"(?<=[.!?])\s+|\n+", text):
+        sentence = normalized(sentence)
+        if sentence:
+            sentences.append(sentence)
+    return sentences
 
 
 def has_semantic_clause(text: str, *patterns: str) -> bool:

--- a/tooling/prose_conformance.py
+++ b/tooling/prose_conformance.py
@@ -23,10 +23,35 @@ def normalized(text: str) -> str:
 
 def semantic_sentences(text: str) -> list[str]:
     sentences: list[str] = []
-    for sentence in re.split(r"(?<=[.!?])\s+|\n+", text):
-        sentence = normalized(sentence)
-        if sentence:
-            sentences.append(sentence)
+    paragraphs: list[str] = []
+    current: list[str] = []
+
+    def flush_current() -> None:
+        paragraph = normalized(" ".join(current))
+        if paragraph:
+            paragraphs.append(paragraph)
+        current.clear()
+
+    for line in text.splitlines():
+        if not line.strip():
+            flush_current()
+            continue
+
+        list_item = re.match(r"^\s*(?:[-*+]|\d+[.)])\s+(?P<body>.*)$", line)
+        if list_item is not None:
+            flush_current()
+            current.append(list_item.group("body"))
+            continue
+
+        current.append(line.strip())
+
+    flush_current()
+
+    for paragraph in paragraphs:
+        for sentence in re.split(r"(?<=[.!?])\s+", paragraph):
+            sentence = normalized(sentence)
+            if sentence:
+                sentences.append(sentence)
     return sentences
 
 

--- a/tooling/prose_conformance.py
+++ b/tooling/prose_conformance.py
@@ -339,6 +339,33 @@ PUBLIC_DOCS_BYPASS_PATTERNS: tuple[tuple[str, str], ...] = (
 )
 
 
+def managed_docs_markdown_files(root: Path) -> list[Path]:
+    docs = root / "docs"
+    if not docs.is_dir():
+        return []
+    return sorted(docs.rglob("*.md"))
+
+
+def managed_public_document_paths(root: Path) -> list[Path]:
+    scripts = root / "scripts"
+    paths = [
+        root / "README.md",
+        *managed_docs_markdown_files(root),
+    ]
+    if scripts.is_dir():
+        paths.extend(sorted(scripts.glob("*.md")))
+        paths.append(scripts / "groundwork-install")
+
+    documents: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        if path in seen or not path.is_file():
+            continue
+        seen.add(path)
+        documents.append(path)
+    return documents
+
+
 def forbidden_pattern_hits(body: str, patterns: tuple[tuple[str, str], ...]) -> list[str]:
     return [
         name
@@ -352,13 +379,9 @@ def protocol_runtime_wiring_violations(body: str) -> list[str]:
 
 
 def public_docs_interactive_adapter_bypass_violations(root: Path) -> dict[str, list[str]]:
-    documents = [
-        root / "README.md",
-        root / "scripts" / "interactive-session-surface-handoff.md",
-    ]
     return {
         str(path.relative_to(root)): hits
-        for path in documents
+        for path in managed_public_document_paths(root)
         if (hits := forbidden_pattern_hits(read(path), PUBLIC_DOCS_BYPASS_PATTERNS))
     }
 

--- a/tooling/prose_conformance.py
+++ b/tooling/prose_conformance.py
@@ -1,0 +1,193 @@
+"""Shared conformance helpers for methodology prose gates.
+
+The checks in this module read the substrate that owns a prose invariant:
+``manifest.toml``, JSON Schemas, markdown structure, and small repository
+control files. Tests should use these helpers instead of keeping local copies
+of authority facts in phrase lists.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+from tooling.protocol_prose import schema_property_names
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def manifest(root: Path) -> dict:
+    return tomllib.loads(read(root / "manifest.toml"))
+
+
+def manifest_protocols(root: Path) -> list[dict]:
+    return list(manifest(root).get("protocols", []))
+
+
+def artifact_schema(root: Path, artifact: str) -> dict:
+    return json.loads(read(root / "schemas" / f"{artifact}.schema.json"))
+
+
+def schema_def(schema: dict, ref: str) -> object:
+    target: object = schema
+    for part in ref.removeprefix("#/").split("/"):
+        if not part:
+            continue
+        if not isinstance(target, dict):
+            raise KeyError(ref)
+        target = target[part]
+    return target
+
+
+def markdown_section(body: str, heading: str, level: int = 2) -> str:
+    marks = "#" * level
+    parent_or_sibling = rf"#{{1,{min(level, 6)}}}"
+    pattern = re.compile(
+        rf"^{marks} {re.escape(heading)}\n(?P<section>.*?)(?=^{parent_or_sibling} |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing section: {heading}")
+    return match.group("section")
+
+
+def numbered_step(body: str, number: int) -> str:
+    pattern = re.compile(
+        rf"^{number}\. \*\*.*?\n(?P<section>.*?)(?=^{number + 1}\. \*\*|^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing step {number}")
+    return match.group("section")
+
+
+def fenced_block_after(body: str, marker: str) -> str:
+    pattern = re.compile(
+        rf"{re.escape(marker)}.*?```(?:[A-Za-z0-9_-]+)?\n(?P<block>.*?)\n```",
+        flags=re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing fenced block after: {marker}")
+    return match.group("block")
+
+
+def markdown_table_rows(section: str) -> list[dict[str, str]]:
+    lines = [line.strip() for line in section.splitlines() if line.strip().startswith("|")]
+    if len(lines) < 3:
+        raise AssertionError("missing markdown table")
+    header = [cell.strip() for cell in lines[0].strip("|").split("|")]
+    rows: list[dict[str, str]] = []
+    for line in lines[2:]:
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if len(cells) != len(header):
+            raise AssertionError(f"malformed markdown table row: {line}")
+        rows.append(dict(zip(header, cells)))
+    return rows
+
+
+def frontmatter(body: str) -> dict[str, object]:
+    if not body.startswith("---\n"):
+        raise AssertionError("missing frontmatter")
+    raw = body.split("---\n", 2)[1]
+    data: dict[str, object] = {}
+    current_mapping: dict[str, str] | None = None
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith("  ") and current_mapping is not None:
+            if ":" not in line:
+                continue
+            key, value = line.strip().split(":", 1)
+            current_mapping[key.strip()] = value.strip().strip('"')
+            continue
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if value:
+            data[key] = value.strip('"')
+            current_mapping = None
+        else:
+            current_mapping = {}
+            data[key] = current_mapping
+    return data
+
+
+def delivery_call_block(body: str, artifact: str) -> str:
+    pattern = re.compile(
+        rf"```(?:[A-Za-z0-9_-]+)?\n(?P<block>\s*{re.escape(artifact)}\(\{{.*?\n\s*\}}\))\n\s*```",
+        flags=re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing delivery call block for {artifact}")
+    return match.group("block")
+
+
+def block_keys(block: str) -> set[str]:
+    return {
+        match.group("key")
+        for match in re.finditer(
+            r"^\s*(?P<key>[A-Za-z_][A-Za-z0-9_-]*)\s*:",
+            block,
+            re.MULTILINE,
+        )
+    }
+
+
+@dataclass(frozen=True)
+class DeliveryBoundary:
+    protocol: str
+    artifact: str
+    scoped: bool
+    schema_requires_work_unit: bool
+    call_has_instance_id: bool
+    call_has_work_unit: bool
+    instance_id_in_schema: bool
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.call_has_instance_id
+            and not self.call_has_work_unit
+            and not self.instance_id_in_schema
+            and self.schema_requires_work_unit == self.scoped
+        )
+
+
+def delivery_boundaries(root: Path) -> list[DeliveryBoundary]:
+    boundaries: list[DeliveryBoundary] = []
+    for protocol in manifest_protocols(root):
+        produces = list(protocol.get("produces", []))
+        if not produces:
+            continue
+        artifact = produces[0]
+        body = read(root / "protocols" / protocol["name"] / "PROTOCOL.md")
+        block = delivery_call_block(body, artifact)
+        keys = block_keys(block)
+        schema = artifact_schema(root, artifact)
+        boundaries.append(
+            DeliveryBoundary(
+                protocol=protocol["name"],
+                artifact=artifact,
+                scoped=protocol.get("scoped") is True,
+                schema_requires_work_unit="work_unit" in schema.get("required", []),
+                call_has_instance_id="instance_id" in keys,
+                call_has_work_unit="work_unit" in keys,
+                instance_id_in_schema="instance_id" in schema_property_names(schema),
+            )
+        )
+    return boundaries

--- a/tooling/prose_conformance.py
+++ b/tooling/prose_conformance.py
@@ -21,6 +21,21 @@ def normalized(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
+def semantic_sentences(text: str) -> list[str]:
+    return [
+        sentence.strip()
+        for sentence in re.split(r"(?<=[.!?])\s+|\n+", normalized(text))
+        if sentence.strip()
+    ]
+
+
+def has_semantic_clause(text: str, *patterns: str) -> bool:
+    return any(
+        all(re.search(pattern, sentence, flags=re.IGNORECASE) for pattern in patterns)
+        for sentence in semantic_sentences(text)
+    )
+
+
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
@@ -159,6 +174,17 @@ def delivery_explanation_text(body: str, artifact: str) -> str:
     return prefix[start:]
 
 
+def delivery_validation_text(body: str, artifact: str) -> str:
+    block = delivery_call_block(body, artifact)
+    block_end = body.index(block) + len(block)
+    suffix = body[block_end:]
+    end = len(suffix)
+    heading = re.search(r"^(?:#{1,6} .+|\d+[.] \*\*.+)$", suffix, flags=re.MULTILINE)
+    if heading is not None:
+        end = heading.start()
+    return suffix[:end]
+
+
 def block_keys(block: str) -> set[str]:
     return {
         match.group("key")
@@ -182,6 +208,10 @@ class DeliveryBoundary:
     explanation_names_instance_id: bool
     explanation_names_tool_input: bool
     explanation_distinguishes_artifact_body: bool
+    explanation_says_runa_injects_work_unit: bool
+    explanation_says_agent_does_not_supply_work_unit: bool
+    explanation_says_runa_does_not_inject_work_unit: bool
+    validation_names_remaining_artifact_body: bool
 
     @property
     def passed(self) -> bool:
@@ -200,6 +230,19 @@ class DeliveryBoundary:
             and self.explanation_distinguishes_artifact_body
         )
 
+    @property
+    def explains_work_unit_injection_contract(self) -> bool:
+        if self.scoped:
+            return (
+                self.explanation_says_runa_injects_work_unit
+                and self.explanation_says_agent_does_not_supply_work_unit
+            )
+        return self.explanation_says_runa_does_not_inject_work_unit
+
+    @property
+    def explains_post_extraction_validation_scope(self) -> bool:
+        return self.validation_names_remaining_artifact_body
+
 
 def delivery_boundaries(root: Path) -> list[DeliveryBoundary]:
     boundaries: list[DeliveryBoundary] = []
@@ -211,12 +254,10 @@ def delivery_boundaries(root: Path) -> list[DeliveryBoundary]:
         body = read(root / "protocols" / protocol["name"] / "PROTOCOL.md")
         block = delivery_call_block(body, artifact)
         explanation = delivery_explanation_text(body, artifact)
+        validation = delivery_validation_text(body, artifact)
         keys = block_keys(block)
         schema = artifact_schema(root, artifact)
-        explanation_sentences = re.split(
-            r"(?<=[.!?])\s+|\n+",
-            normalized(explanation),
-        )
+        explanation_sentences = semantic_sentences(explanation)
         boundaries.append(
             DeliveryBoundary(
                 protocol=protocol["name"],
@@ -249,6 +290,213 @@ def delivery_boundaries(root: Path) -> list[DeliveryBoundary]:
                     )
                     for sentence in explanation_sentences
                 ),
+                explanation_says_runa_injects_work_unit=has_semantic_clause(
+                    explanation,
+                    r"\bRuna\b",
+                    r"\binjects?\b",
+                    r"`?work_unit`?",
+                    r"\bsession context\b",
+                ),
+                explanation_says_agent_does_not_supply_work_unit=has_semantic_clause(
+                    explanation,
+                    r"\bagent\b",
+                    r"\bdoes not supply\b",
+                    r"`?work_unit`?",
+                ),
+                explanation_says_runa_does_not_inject_work_unit=has_semantic_clause(
+                    explanation,
+                    r"\bRuna\b",
+                    r"\bdoes not inject\b",
+                    r"`?work_unit`?",
+                ),
+                validation_names_remaining_artifact_body=has_semantic_clause(
+                    validation,
+                    r"\bRuna\b",
+                    r"\bvalidates?\b",
+                    r"\bremaining\b",
+                    r"\bartifact body\b",
+                ),
             )
         )
     return boundaries
+
+
+PROTOCOL_RUNTIME_WIRING_PATTERNS: tuple[tuple[str, str], ...] = (
+    (
+        "interactive session surface handoff marker",
+        r"groundwork-install:interactive-session-surface-handoff",
+    ),
+    ("runa go command", r"\bruna\s+go\b"),
+    ("RUNA environment atom", r"\bRUNA_[A-Z0-9_]*\b"),
+    ("runtime pending seam", r"\buntil the runtime\b"),
+    ("separate runtime agent", r"\bspawns?\s+a\s+separate\s+agent\b"),
+)
+
+
+PUBLIC_DOCS_BYPASS_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("missing artifact store bypass", r"\bno artifact store\b"),
+    ("human artifact handoff bypass", r"\bPresent that artifact body to the human\b"),
+)
+
+
+def forbidden_pattern_hits(body: str, patterns: tuple[tuple[str, str], ...]) -> list[str]:
+    return [
+        name
+        for name, pattern in patterns
+        if re.search(pattern, body, flags=re.IGNORECASE)
+    ]
+
+
+def protocol_runtime_wiring_violations(body: str) -> list[str]:
+    return forbidden_pattern_hits(body, PROTOCOL_RUNTIME_WIRING_PATTERNS)
+
+
+def public_docs_interactive_adapter_bypass_violations(root: Path) -> dict[str, list[str]]:
+    documents = [
+        root / "README.md",
+        root / "scripts" / "interactive-session-surface-handoff.md",
+    ]
+    return {
+        str(path.relative_to(root)): hits
+        for path in documents
+        if (hits := forbidden_pattern_hits(read(path), PUBLIC_DOCS_BYPASS_PATTERNS))
+    }
+
+
+@dataclass(frozen=True)
+class EntrySurfaceCoherence:
+    acquire_reads_ticket_comments: bool
+    acquire_surfaces_comments_as_entry_context: bool
+    acquire_excludes_comments_from_artifact: bool
+    take_grounds_frame_in_whole_ticket: bool
+    take_uses_newest_review_directives: bool
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.acquire_reads_ticket_comments
+            and self.acquire_surfaces_comments_as_entry_context
+            and self.acquire_excludes_comments_from_artifact
+            and self.take_grounds_frame_in_whole_ticket
+            and self.take_uses_newest_review_directives
+        )
+
+
+def entry_surface_coherence(root: Path) -> EntrySurfaceCoherence:
+    acquire = read(root / "skills" / "acquire" / "SKILL.md")
+    take = read(root / "protocols" / "take" / "PROTOCOL.md")
+    return EntrySurfaceCoherence(
+        acquire_reads_ticket_comments=(
+            "`comments`" in acquire
+            and has_semantic_clause(
+                acquire,
+                r"\bread-ticket\b",
+                r"`?comments`?",
+                r"\blog\b",
+            )
+        ),
+        acquire_surfaces_comments_as_entry_context=has_semantic_clause(
+            acquire,
+            r"\bSurface\b",
+            r"\blog\b",
+            r"\bentry context\b",
+            r"\bwhole ticket\b",
+        ),
+        acquire_excludes_comments_from_artifact=has_semantic_clause(
+            acquire,
+            r"\bcomment log\b",
+            r"\bentry context\b",
+            r"\bnever persisted\b",
+            r"\bartifact\b",
+        ),
+        take_grounds_frame_in_whole_ticket=(
+            has_semantic_clause(take, r"\bGround\b", r"\bwhole ticket\b")
+            and has_semantic_clause(
+                take,
+                r"\bcomment log\b",
+                r"\brunning record\b",
+            )
+        ),
+        take_uses_newest_review_directives=has_semantic_clause(
+            take,
+            r"\bnewest\b",
+            r"\breview directives\b",
+            r"\bsubmitted head\b",
+            r"\bgovern\b",
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class SessionSurfaceHandoffCommitments:
+    has_single_marker_pair: bool
+    commands_through_runa_session_surface: bool
+    records_current_output_tool: bool
+    validates_artifacts_by_runa: bool
+    prohibits_direct_workspace_json: bool
+    prohibits_separate_human_approval_gate: bool
+    bypass_violations: tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.has_single_marker_pair
+            and self.commands_through_runa_session_surface
+            and self.records_current_output_tool
+            and self.validates_artifacts_by_runa
+            and self.prohibits_direct_workspace_json
+            and self.prohibits_separate_human_approval_gate
+            and not self.bypass_violations
+        )
+
+
+def session_surface_handoff_commitments(
+    body: str,
+    *,
+    begin_marker: str,
+    end_marker: str,
+) -> SessionSurfaceHandoffCommitments:
+    return SessionSurfaceHandoffCommitments(
+        has_single_marker_pair=(
+            body.count(begin_marker) == 1
+            and body.count(end_marker) == 1
+            and body.index(begin_marker) < body.index(end_marker)
+        ),
+        commands_through_runa_session_surface=(
+            re.search(
+                r"`runa go --work-unit\s+<canonical-work-unit-id>`",
+                normalized(body),
+            )
+            is not None
+            and "`next-protocol-context`" in body
+            and "`advance`" in body
+        ),
+        records_current_output_tool=(
+            "current output tool" in normalized(body)
+            and has_semantic_clause(
+                body,
+                r"\brecords?\b",
+                r"\bcurrent output tool\b",
+            )
+        ),
+        validates_artifacts_by_runa=has_semantic_clause(
+            body,
+            r"\bArtifacts\b",
+            r"\bvalidated by runa\b",
+        ),
+        prohibits_direct_workspace_json=has_semantic_clause(
+            body,
+            r"\bDo not\b",
+            r"\bwrite\b",
+            r"\bworkspace JSON files directly\b",
+        ),
+        prohibits_separate_human_approval_gate=has_semantic_clause(
+            body,
+            r"\bDo not\b",
+            r"\bseparate human approval gate\b",
+            r"\btyped disposition\b",
+        ),
+        bypass_violations=tuple(
+            forbidden_pattern_hits(body, PUBLIC_DOCS_BYPASS_PATTERNS)
+        ),
+    )


### PR DESCRIPTION
## Summary

- Re-grounded the #522 survey gates away from exact vocabulary proxies and toward manifest, schema, markdown structure, frontmatter, delivery boundary, and authority-consultation invariants.
- Added `tooling/prose_conformance.py` plus focused tests so prose gates can share substrate readers instead of duplicating brittle local phrase lists.
- Retained the survey's retain-class checks while reducing mixed/re-grounded gates across protocol delivery docs, forge capability docs, contract-dimension tests, release/decompose/reckon/work-unit-craft gates, and related documentation authority checks.

## Validation

- `python -m pytest -q tests/test_protocol_prose_conformance.py tests/test_architecture_prose_conformance.py tests/test_prose_conformance.py tests/test_protocol_artifact_delivery_docs.py tests/test_forge_capability.py tests/test_build_protocol_contract_dimensions.py tests/test_close_protocol_contract_dimensions.py tests/test_take_protocol_contract_dimensions.py tests/test_verify_protocol_gate_coverage.py tests/test_contract_skill_lifecycle.py tests/test_decompose_epic_completion_docs.py tests/test_dependency_graph_notation.py tests/test_intent_schema_vendoring.py tests/test_groundwork_install.py tests/test_install.py tests/test_groundwork_skill_ontology_row1_audit.py tests/test_reckon_ascent.py tests/test_work_unit_craft_skill.py tests/test_release_ceremony.py tests/test_embedded_corpus.py tests/test_code_quality_dimension.py tests/test_principles_coherence.py` -> 235 passed, 952 subtests passed
- `git diff --check`
- `python -m pytest -q tests/test_artifact_schemas.py::ArtifactSchemaTests::test_validate_artifact_rejects_completion_evidence_not_matching_contract` -> passed

## Full-suite note

`python -m pytest -q` currently fails in `tests/test_interactive_session_surface.py::InteractiveSessionSurfaceTests::test_completion_evidence_persist_rejects_contract_mismatches` against the installed external `runa-mcp 0.2.0-rc.1`. The repo-local validator rejects the same mismatched completion evidence, but the external MCP delivery layer persists it; no files involved in that runtime integration test are changed here.

Closes #522.
