### PR TITLE
docs: add verification craft surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Verification-craft surface for vocabulary-proxy gates** (#523).
+  `skills/verification-craft/SKILL.md` gives contributors the durable rule
+  from the #477/#522 arc: a prose/text-artifact gate consults the invariant,
+  owning authority, or substrate structure instead of matching authored
+  vocabulary as a proxy for correctness. The surface names the three
+  re-grounded forms (authority-consultation, model-coherence, structural),
+  teaches the token-is-invariant retain boundary, and records the
+  paraphrase-residual boundary so forbidden-state gates do not regrow synonym
+  lists. README links the skill from the discovery path, and
+  `tests/test_verification_craft_skill.py` pins the rule, examples,
+  boundaries, sibling-face structure, and reachability.
+
 - **Entry grounds on the whole ticket** (#516). Forge-capability re-vendored
   at `1.2.0` (immutable pin `b229fb1`): the `read-ticket` snapshot carries an
   optional ordered `comments` log. `acquire` (v1.1.0) reads the ticket whole

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ stage-specific judgment:
 - **research** — external evidence gathering when facts are missing
 - **contract** — the BDD home: contract authoring at entry, traceability through execution
 - **work-unit-craft** — the discipline for authoring work-unit tracker records
+- **verification-craft** — [`skills/verification-craft/SKILL.md`](skills/verification-craft/SKILL.md),
+  the discipline for authoring verification gates over prose and text artifacts
 - **code-review** — review judgment for submitted change proposals
 - **acquire** — entry from an existing forge ticket: materializes the work-unit artifact take activates on
 

--- a/docs/architecture/groundwork-skill-ontology-row-1-audit.md
+++ b/docs/architecture/groundwork-skill-ontology-row-1-audit.md
@@ -15,7 +15,7 @@ before the ADR distills the seam.
 
 ## Method
 
-The audit reads the 18 live row-1 assets: 9 skills under `skills/` and 9
+The audit reads the 19 live row-1 assets: 10 skills under `skills/` and 9
 protocols under `protocols/`. Each asset is placed on the two axes from the
 foundation note:
 
@@ -45,6 +45,7 @@ Groundwork scoped pipeline.
 | reckon | skill | universal | skill | First-principles grounding and traceable reasoning are domain-neutral; gazette's editorial choices also need constraints before inherited frames. |
 | research | skill | universal | skill | Systematic external-evidence gathering projects directly to non-code work, including gazette's source and historical evidence questions. |
 | resolve | skill | universal | skill | Structural friction resolution applies whenever tooling, configuration, convention, or process blocks work in another domain. |
+| verification-craft | skill | universal | skill | Another domain still needs verification gates that consult authorities, model coherence, or substrate structure instead of matching vocabulary as a proxy; only the artifact surfaces change. |
 | work-unit-craft | skill | universal | skill | Another domain still needs delegation-record craft: outcome-first records, body-as-spec authority, and criteria that transfer intent across contexts. The artifact name may change. |
 | decompose | protocol | domain:software | protocol | The cognitive craft projects, but this shell produces `work-unit` artifacts and tracker-backed handles, not gazette's non-code artifact crossings. |
 | implement | protocol | domain:software | protocol | Another domain can reuse test-first construction, but this shell consumes implementation plans and emits `test-evidence` for software work-unit behavior. |

--- a/skills/verification-craft/SKILL.md
+++ b/skills/verification-craft/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: verification-craft
+description: >-
+  Use when authoring or reviewing a verification gate over methodology prose,
+  generated text, or other text artifacts. The discipline for proving the
+  protected invariant by consulting its authority, reading model coherence, or
+  asserting substrate structure instead of matching vocabulary as a proxy.
+metadata:
+  version: "1.0.0"
+  updated: "2026-07-04"
+---
+
+# Verification Craft
+
+Verification gates exist to prove an invariant. A gate consults the
+invariant, the owning authority, or substrate structure; it does not match
+literal vocabulary against authored prose as a proxy for whether that prose is
+correct.
+
+This skill currently states the vocabulary-proxy face of the rule. A later
+positive-form face can join this same home as a sibling section: new faces add
+their form and boundary under the same craft, without rewriting the rule below.
+
+## The Rule
+
+A prose or text-artifact gate names the protected invariant first, then chooses
+the form whose red state is the invariant being false. The correct form is the
+smallest one that would fail for a hollow delivery and keep passing through a
+meaning-preserving rewrite.
+
+## Re-Grounded Forms
+
+### Authority-Consultation
+
+Use authority-consultation when another substrate owns the truth: a manifest,
+schema, workflow contract, script, or declared skill home. The gate reads that
+authority at run time and derives the expected surface from it, so changing the
+authority flips the gate without editing a copied list.
+
+Worked example: the artifact-delivery boundary gate in
+[`tests/test_protocol_artifact_delivery_docs.py`](https://github.com/tesserine/groundwork/blob/252024f/tests/test_protocol_artifact_delivery_docs.py)
+uses `tooling.prose_conformance.delivery_boundaries` to derive producing
+protocols from `manifest.toml`, read each artifact schema, and verify the
+delivery prose against those authorities.
+
+### Model-Coherence
+
+Use model-coherence when the invariant is that text presents the current
+model, boundary, or lifecycle. The gate reads the text against the named model:
+required commitments are present, retired states are absent only when their
+tokens are the invariant, and a meaning-preserving rewrite still passes.
+
+Worked example: `test_entry_surfaces_ground_on_the_whole_ticket` in
+[`tests/test_forge_capability.py`](https://github.com/tesserine/groundwork/blob/252024f/tests/test_forge_capability.py)
+uses `tooling.prose_conformance.entry_surface_coherence` to check the
+read-ticket comment-log lifecycle across `acquire` and `take` instead of
+pinning one sentence about entry context.
+
+### Structural
+
+Use a structural gate when the substrate shape is the invariant: a parsed
+example, a table row, a link target, a workflow command, a fenced block, or a
+serialized field. The gate parses or extracts the structure and asserts that
+shape directly.
+
+Worked example: `test_every_templates_dependency_graph_block_is_mermaid` in
+[`tests/test_dependency_graph_notation.py`](https://github.com/tesserine/groundwork/blob/252024f/tests/test_dependency_graph_notation.py)
+checks the dependency-graph blocks as Markdown structure and requires the
+canonical Mermaid representation, rather than checking surrounding prose for a
+preferred explanation.
+
+## Retain Boundary: Token Is Invariant
+
+A literal-token check is legitimate when the token is the invariant. Retain
+that form for retired identifiers, schema fields that must be absent or
+present, hard-code detectors, URL schemes, command strings, and other concrete
+atoms whose occurrence is itself the state being tested.
+
+Worked example: `RETIRED_FORGE_IDENTIFIER_PATTERNS` in
+[`tests/test_forge_capability.py`](https://github.com/tesserine/groundwork/blob/252024f/tests/test_forge_capability.py)
+retains per-document absence checks for retired forge identifiers such as
+`forge_tags` and `RUNA_FORGE_`. Those identifiers are not prose proxies; their
+presence is the forbidden state. The retained detector scans the full owning
+surface and tolerates trivial casing or separator variants of the same
+identifier.
+
+Do not re-ground token-is-invariant checks away merely because they are literal
+matches. Re-ground only the checks where a phrase stands in for whether prose
+is correct.
+
+## Paraphrase-Residual Boundary
+
+A forbidden-state gate does not enumerate anticipated paraphrases. Its
+completeness rests on two parts together:
+
+- the positive authority-consultation or model-coherence check that proves the
+  current state is present; and
+- token-is-invariant detectors for the specific retired identifiers or retired
+  text over the full owning surface.
+
+That boundary accepts a residual: a novel paraphrase with no retired token may
+pass. Closing that residual by adding guessed phrasings recreates the
+vocabulary proxy. If the residual becomes too large, strengthen the positive
+authority or coherence check; do not grow a synonym list.
+
+## Authoring Procedure
+
+1. Name the protected invariant.
+2. Name the owning authority or substrate, or state that the text's coherence
+   against a model is the authority.
+3. Classify the gate as authority-consultation, model-coherence, structural,
+   or token-is-invariant.
+4. Add a proof fixture: mutate the authority, remove the required content,
+   change the structure, or insert the specific retired identifier or text
+   that the gate claims to catch.
+5. Scan the full owning surface. A hand-listed pair of files is not enough
+   when the invariant belongs to the docs tree, every protocol, or every
+   installed skill.
+
+## Corruption Modes
+
+- `vocabulary-proxy`: a phrase list is treated as proof that prose is correct.
+- `authority-copy`: the gate copies the current manifest, schema, or skill
+  facts instead of reading the authority at run time.
+- `paraphrase-chase`: a forbidden-state gate grows a list of imagined
+  rewordings instead of relying on the positive check plus token-is-invariant
+  detectors.
+- `token-overcorrection`: a literal detector is removed even though the token
+  is the invariant.
+- `surface-undercount`: the gate checks one or two convenient files while the
+  invariant belongs to a wider owning surface.
+
+## Cross-References
+
+- [`tooling/prose_conformance.py`](https://github.com/tesserine/groundwork/blob/252024f/tooling/prose_conformance.py) carries
+  the shared helper forms for the current re-grounded gates.
+- [`docs/architecture/decisions/0008-prose-is-projection.md`](../../docs/architecture/decisions/0008-prose-is-projection.md)
+  records why prose must consult its owning substrate or be gate-bound.
+- [`skills/contract/SKILL.md`](../contract/SKILL.md) owns the hollow-delivery
+  tooth every verification gate must satisfy.

--- a/tests/test_verification_craft_skill.py
+++ b/tests/test_verification_craft_skill.py
@@ -1,0 +1,140 @@
+import re
+import unittest
+from pathlib import Path
+
+from tooling.prose_conformance import frontmatter, has_semantic_clause, markdown_section
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFICATION_CRAFT = ROOT / "skills" / "verification-craft" / "SKILL.md"
+README = ROOT / "README.md"
+
+
+def read_skill() -> str:
+    return VERIFICATION_CRAFT.read_text(encoding="utf-8")
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+class VerificationCraftSkillTests(unittest.TestCase):
+    def test_skill_frontmatter_declares_discoverable_verification_craft(self) -> None:
+        body = read_skill()
+        data = frontmatter(body)
+
+        self.assertEqual("verification-craft", data["name"])
+        self.assertIn("Use when authoring or reviewing a verification gate", body)
+        self.assertIn("matching vocabulary as a proxy", body)
+        self.assertIn("metadata", data)
+        self.assertEqual("1.0.0", data["metadata"]["version"])
+        self.assertRegex(data["metadata"]["updated"], r"^2026-07-04$")
+
+    def test_readme_skill_index_links_the_discovery_path(self) -> None:
+        readme = README.read_text(encoding="utf-8")
+        skills = markdown_section(readme, "The Shape of the Methodology")
+
+        self.assertIn("[`skills/verification-craft/SKILL.md`](skills/verification-craft/SKILL.md)", skills)
+        self.assertIn("verification gates", skills)
+
+    def test_rule_is_positive_and_names_the_three_regrounded_forms(self) -> None:
+        body = read_skill()
+
+        self.assertTrue(
+            has_semantic_clause(
+                body,
+                r"\bgate\b",
+                r"\bconsults?\b",
+                r"\binvariant\b",
+                r"\bowning authority\b",
+                r"\bsubstrate structure\b",
+            )
+        )
+        self.assertTrue(
+            has_semantic_clause(
+                body,
+                r"\bdoes not match\b",
+                r"\bliteral vocabulary\b",
+                r"\bproxy\b",
+            )
+        )
+        for heading in ["Authority-Consultation", "Model-Coherence", "Structural"]:
+            with self.subTest(heading=heading):
+                self.assertIn(f"### {heading}", body)
+
+    def test_each_regrounded_form_points_to_a_live_head_example(self) -> None:
+        body = read_skill()
+
+        expected_examples = {
+            "Authority-Consultation": [
+                "tests/test_protocol_artifact_delivery_docs.py",
+                "delivery_boundaries",
+                "manifest.toml",
+            ],
+            "Model-Coherence": [
+                "test_entry_surfaces_ground_on_the_whole_ticket",
+                "entry_surface_coherence",
+                "comment-log lifecycle",
+            ],
+            "Structural": [
+                "test_every_templates_dependency_graph_block_is_mermaid",
+                "tests/test_dependency_graph_notation.py",
+                "Markdown structure",
+            ],
+        }
+        for heading, expected_terms in expected_examples.items():
+            section = markdown_section(body, heading, level=3)
+            with self.subTest(heading=heading):
+                for term in expected_terms:
+                    self.assertIn(term, section)
+
+    def test_retain_boundary_teaches_token_is_invariant_with_a_retained_example(self) -> None:
+        body = read_skill()
+        section = normalized(markdown_section(body, "Retain Boundary: Token Is Invariant"))
+
+        self.assertRegex(section, r"\bliteral-token check is legitimate\b")
+        self.assertRegex(section, r"\btoken is the invariant\b")
+        self.assertRegex(section, r"\bretired identifiers\b")
+        self.assertRegex(section, r"\bschema fields\b")
+        self.assertIn("RETIRED_FORGE_IDENTIFIER_PATTERNS", section)
+        self.assertIn("forge_tags", section)
+        self.assertIn("RUNA_FORGE_", section)
+        self.assertRegex(section, r"\bfull owning surface\b")
+
+    def test_paraphrase_residual_boundary_rejects_synonym_lists(self) -> None:
+        body = read_skill()
+        section = normalized(markdown_section(body, "Paraphrase-Residual Boundary"))
+
+        self.assertRegex(section, r"\bdoes not enumerate anticipated paraphrases\b")
+        self.assertRegex(section, r"\bpositive authority-consultation or model-coherence check\b")
+        self.assertRegex(section, r"\btoken-is-invariant detectors\b")
+        self.assertRegex(section, r"\bfull owning surface\b")
+        self.assertRegex(section, r"\bnovel paraphrase\b")
+        self.assertRegex(section, r"\bdo not grow a synonym list\b")
+        for invented_phrase in ["not yet wired", "until it is wired", "you drive the session"]:
+            with self.subTest(invented_phrase=invented_phrase):
+                self.assertNotIn(invented_phrase, section)
+
+    def test_surface_is_structured_for_the_sibling_positive_form_face(self) -> None:
+        body = normalized(read_skill())
+
+        self.assertRegex(body, r"\bvocabulary-proxy face\b")
+        self.assertRegex(body, r"\bpositive-form face\b")
+        self.assertRegex(body, r"\bsibling section\b")
+
+    def test_procedure_requires_authority_classification_fixture_and_full_surface(self) -> None:
+        procedure = normalized(markdown_section(read_skill(), "Authoring Procedure"))
+
+        for expected in [
+            "Name the protected invariant",
+            "Name the owning authority",
+            "Classify the gate",
+            "Add a proof fixture",
+            "Scan the full owning surface",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, procedure)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `skills/verification-craft/SKILL.md` as the contributor-facing home for the vocabulary-proxy verification rule from #523.
- Teach the three re-grounded forms from #522/#524: authority-consultation, model-coherence, and structural gates.
- Capture the token-is-invariant retain boundary and the paraphrase-residual boundary, with worked examples at the landed #522 head.
- Link the skill from README, update the changelog, and keep the row-1 ontology audit complete for the new skill.

## Validation

- `python -m pytest -q tests/test_verification_craft_skill.py tests/test_reference_links.py tests/test_groundwork_skill_ontology_row1_audit.py` -> 18 passed, 101 subtests passed
- `python -m pytest -q tests/test_verification_craft_skill.py tests/test_reference_links.py tests/test_install.py tests/test_groundwork_install.py tests/test_conformance.py` -> 133 passed, 129 subtests passed
- `python -m pytest -q tests/test_groundwork_skill_ontology_row1_audit.py tests/test_verification_craft_skill.py tests/test_reference_links.py tests/test_install.py tests/test_groundwork_install.py tests/test_conformance.py` -> 140 passed, 164 subtests passed
- `git diff --check` -> passed
- `python -m pytest -q` -> fails only in the known external `runa-mcp 0.2.0-rc.1` completion-evidence mismatch test documented from #524; local result: 441 passed, 3 skipped, 1219 subtests passed before that external failure

Closes #523.
