### PR TITLE
fix(take): step 4 consults the contract skill by link, not restated doctrine (#521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **`take` step 4 consults the `contract` skill instead of restating its
+  doctrine** (#521, discharging the epic #443 migration landed via PR #455).
+  With #443 closed and the `contract` skill established as the single home
+  of the per-dimension authoring forms, the teeth principle, and the density
+  rule, `protocols/take/PROTOCOL.md` step 4 no longer restates the seven
+  passages that already live in `skills/contract/SKILL.md` and its two
+  references. Step 4 now consults those homes by path — plus `orient` for
+  the documentation audience taxonomy and `~/.groundwork/principles/` for
+  the universals — and states only take's role-local obligation: author
+  this work-unit's validation defined, in the form and to the teeth and
+  density the `contract` skill defines. This resolves the internal
+  contradiction with take's own `lifecycle-modeling` corruption mode, which
+  named exactly the re-encoding step 4 was performing. The prose gates over
+  this file were already re-grounded to consultation/structure checks by the
+  #477/#522 arc (`tests/test_take_protocol_contract_dimensions.py`, #524),
+  so no test change is required. take 3.8.0->3.9.0.
+
 - **Prose is projection: the architecture document carries rationale only —
   structural renderings live in their substrate homes** (#507, enacting
   ADR-0008 consequence 3). `docs/architecture/connecting-structure.md` is

--- a/protocols/take/PROTOCOL.md
+++ b/protocols/take/PROTOCOL.md
@@ -7,7 +7,7 @@ description: >-
   protocol carries to land; the session surface advances the pipeline from
   it. Trigger on: 'take', 'take work', 'start work-unit'.
 metadata:
-  version: "3.8.0"
+  version: "3.9.0"
   updated: "2026-07-02"
 ---
 
@@ -58,45 +58,27 @@ proves it, or records it.
    corpus at `~/.groundwork/principles/`, select the principles that govern
    what "done" means here, read them, and reason the contract from them
    rather than the work-unit's surface wording alone (the reckon skill is
-   the move). Then consume the work-unit's per-dimension inputs to
-   validation: behavior's acceptance criteria, documentation's recipient
-   outcomes, and code quality's principles-corpus pointer plus stressed
-   universals.
+   the move).
 
-   Use the `contract` skill as the single home for the validation defined
-   discipline, consulting `skills/contract/references/documentation-contract.md`
-   for the documentation form and
+   The `contract` skill is the single home of what validation defined means,
+   per dimension: consult `skills/contract/SKILL.md` for the dimension
+   table, the teeth principle, and the density rule that bind every
+   dimension alike; `skills/contract/references/documentation-contract.md`
+   for the documentation dimension's authoring form; and
    `skills/contract/references/code-quality-contract.md` for the
-   code-quality form. Use `orient` for the documentation audience taxonomy,
-   and `~/.groundwork/principles/` for the universals themselves. Do not
-   restate the lifecycle here; this protocol applies its `take` role.
+   code-quality dimension's authoring form. Use `orient` for the
+   documentation audience taxonomy, and `~/.groundwork/principles/` for the
+   universals themselves.
 
-   Define behavior validation in the form the deliverable requires. For a
-   runtime-behavior work-unit, refine each acceptance criterion into one or
-   more sentence-named executable scenarios in Given/When/Then form: one
-   behavior per scenario, names that read as specification, and observable
-   Then clauses a stub cannot satisfy. For a documentation-deliverable
-   work-unit, define documentation-deliverable gates instead: structural,
-   coherence, and conformance checks that prove the methodology document
-   works as a usable surface. The gates are realized as committed
-   structural, coherence, and conformance tests and later carried as gate
-   coverage, not encoded as fabricated scenarios.
-
-   Define documentation validation as documentation outcomes in an
-   audience-outcome checklist: the pillars the change touches — user,
-   developer, discovery — and the outcome each recipient must reach, in the
-   teeth-bearing form where hollow docs fail. Define code-quality validation
-   as reviewer-checkable projections of the stressed principles-corpus
-   universals, written as reviewer-checkable projected universals: each item
-   asks the universal as a question of the change, names the failing tell,
-   and names the locus where it holds.
-
-   For all three dimensions, every dimension the change has gets at least
-   one authored teeth-bearing criterion. Density may be light: one sharp
-   documentation outcome or one projected code-quality universal can be
-   enough when that dimension is lightly touched. Coverage is never zero.
-   Each dimension's criterion must name the hollow delivery that would fail
-   it, so ordinary discipline cannot stand in for validation defined.
+   Take's own role here is narrow and does not re-derive any of that: from
+   this work-unit's own already-framed inputs (step 3), author this
+   work-unit's validation defined — one instance of criteria per dimension
+   the work-unit has, in the form and to the teeth and density the
+   `contract` skill defines, sized to what this work-unit actually
+   stresses. A validation-defined output that cannot be checked against the
+   `contract` skill's own dimension table and teeth principle has
+   re-encoded the lifecycle instead of consulting it — the
+   `lifecycle-modeling` corruption mode below names exactly this failure.
 
 5. **Deliver the contract spine.** Invoke the `contract` MCP tool with
    dimension-agnostic criteria. Each criterion declares the dimension it


### PR DESCRIPTION
Closes #521.

Epic #443's `take` migration landed (task B, PR #455 @ `6539693`), establishing the `contract` skill as the single home of the per-dimension authoring forms, the teeth principle, and the density rule. `protocols/take/PROTOCOL.md` step 4 nonetheless restated seven of those passages in prose — one paragraph after the `Do not restate the lifecycle here` disclaimer — which is exactly the behavior take's own `lifecycle-modeling` corruption mode names. ADR-0008 (prose is projection) classifies this defect class.

**Change:** step 4 now consults `skills/contract/SKILL.md` and its two references (plus `orient` for the documentation audience taxonomy and `~/.groundwork/principles/` for the universals) by path, and states only take's role-local obligation — author this work-unit's validation defined, in the form and to the teeth and density the `contract` skill defines. The internal contradiction with `lifecycle-modeling` is resolved.

**Acceptance criteria:**
- **AC1** — step 4 consults, does not restate: all seven passages removed; SKILL.md + both references + `orient` + principles consulted by path.
- **AC2** — `lifecycle-modeling` no longer names step 4's own behavior.
- **AC3** — the prose gates over `tests/test_take_protocol_contract_dimensions.py` were already re-grounded to consultation/structure checks by the #477/#522 arc (#524, `252024f`); the three tests #521 named as blocking no longer exist. No test change required; full suite green (437 passed, 7 skipped, 1216 subtests).
- **AC4** — steps 1–3 and 5 untouched; corruption-mode list unchanged (diff is the version line + the step-4 block only).
- **AC5** — `take` 3.8.0→3.9.0; CHANGELOG `[Unreleased]` `### Changed` records the discharged migration.

**Freshen note:** #521's body (2026-07-03, grounded at `5af9a2d`) marked itself "not landable as a standalone PR yet," gated on co-migrating tests with #477/#479. Both are now closed-completed and #524 already re-grounded those tests, so the gate is discharged and this lands standalone. Full freshen record on #521.