### PR TITLE
[codex] rename entry protocol to define

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Breaking vocabulary rename: entry protocol `take` becomes `define`**
+  (#529). The contract-first entry stage is now registered and installed as
+  `define` (protocol version 4.0.0), matching the stage's act: authoring
+  the contract that defines done. Consumers must update manifest protocol
+  names, `protocols/define/` paths, tests, fixtures, and any entry-stage
+  references that named `take`. Protocol capstones now stop at their
+  delivered artifact; `define` records the `contract` and ends there, with
+  the runtime-less fallback preserved. The `contract` artifact is stable:
+  its name, schema, and MCP tool are unchanged, so integrations that consume
+  `contract` artifacts need no migration.
+
 - **`take` step 4 consults the `contract` skill instead of restating its
   doctrine** (#521, discharging the epic #443 migration landed via PR #455).
   With #443 closed and the `contract` skill established as the single home

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ units with acceptance criteria and dependency edges.
 
 **Entry** into the scoped pipeline happens one of two ways: a work-unit newly
 created by decompose, or one the acquire skill materializes from an existing
-forge ticket (the "start on ticket #N" path). Either way take activates on a
+forge ticket (the "start on ticket #N" path). Either way define activates on a
 work-unit artifact.
 
 **The scoped pipeline** takes one work-unit and carries it through to a merged
-increment: take prepares the workspace and writes the dimension-agnostic
+increment: define prepares the workspace and writes the dimension-agnostic
 contract — the spine threaded through every later stage → plan converges on a
 decision-complete design → implement executes through RED-GREEN-REFACTOR →
 verify gates completion with performed evidence and documentation review →
@@ -63,7 +63,7 @@ stage-specific judgment:
 - **verification-craft** — [`skills/verification-craft/SKILL.md`](skills/verification-craft/SKILL.md),
   the discipline for authoring verification gates over prose and text artifacts
 - **code-review** — review judgment for submitted change proposals
-- **acquire** — entry from an existing forge ticket: materializes the work-unit artifact take activates on
+- **acquire** — entry from an existing forge ticket: materializes the work-unit artifact define activates on
 
 Not every piece of work needs every stage. A bug with an existing work-unit enters
 at execution. A new capability enters at planning. The constraint is sequence,
@@ -261,12 +261,12 @@ define interfaces and decisions, not scripts to follow.
 
 ### How work is executed
 
-**The contract is the thread.** The contract written at take — the entry —
+**The contract is the thread.** The contract written at define — the entry —
 traces through every subsequent stage. Plans link design decisions to declared
 criteria. Implementation produces evidence. Verification records each
 criterion result in one performed-evidence shape. Review judges against the
 contract. Landing records what shipped.
-→ [`protocols/take/PROTOCOL.md`](protocols/take/PROTOCOL.md),
+→ [`protocols/define/PROTOCOL.md`](protocols/define/PROTOCOL.md),
 [`skills/contract/SKILL.md`](skills/contract/SKILL.md)
 
 **Evidence before assertion.** No completion claims without fresh verification

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -51,10 +51,10 @@ The work-unit artifact bridges two phases, both declared in
   the one type nothing inside the system produces — survey turns intent
   into requirements, and decompose breaks requirements into work-unit
   artifacts.
-- **Scoped pipeline**: take → plan → implement → verify → submit →
-  review → land. Take picks up a work-unit whose dependencies are
-  satisfied, authors the contract, and the forward flow produces
-  artifacts that runa tracks and threads by work-unit identity. The
+- **Scoped pipeline**: define → plan → implement → verify → submit →
+  review → land. Define authors the contract for a work-unit whose
+  dependencies are satisfied, and the forward flow produces artifacts
+  that runa tracks and threads by work-unit identity. The
   pipeline-shape decision is
   [ADR-0007](decisions/0007-dimension-agnostic-contract-machine.md).
 
@@ -63,7 +63,8 @@ what needs doing at any scope — a new tool, a feature, a migration —
 and is the project-level specification. The **contract** declares how a
 single work-unit is validated, criterion by criterion, and is the
 implementation-level specification. Decompose bridges the scales: it
-consumes requirements and produces the work-units that take picks up.
+consumes requirements and produces the work-units that define turns into
+contracts.
 
 The contract is the spine of the scoped pipeline: authored at entry,
 required by every judgment station, and the surface every downstream
@@ -88,11 +89,11 @@ Planning-phase artifacts predate work-unit identity and are scoped
 through trigger evaluation against specific instances instead — see
 *Common envelope* below for the schema side of this split.
 
-## The Entry: Contract-First Take
+## The Entry: Contract-First Define
 
-In work-unit-first entry, selection is not take's job: the work-unit is
-already the entry, and runa activates take on it. What entry truly is —
-once selection is gone — is the place where done gets defined. Take
+In work-unit-first entry, selection is not define's job: the work-unit is
+already the entry, and runa activates define on it. What entry truly is —
+once selection is gone — is the place where done gets defined. Define
 prepares the workspace, frames the work, and authors the contract.
 
 The contract is the root of the scoped artifact chain. No separate
@@ -100,7 +101,7 @@ threading artifact is needed: work-unit identity is runtime-enforced —
 runa injects `work_unit` into every scoped artifact and validates
 canonical ids — so the entry's capstone is the contract itself.
 
-The `work-unit` artifact take activates on arrives one of two ways:
+The `work-unit` artifact define activates on arrives one of two ways:
 created by `decompose`, or materialized from an existing forge ticket by
 the [`acquire`](../../skills/acquire/SKILL.md) skill. Acquisition is
 skill-side intake — the mirror of decompose's create path — and reaches
@@ -346,7 +347,7 @@ the agent supplies it and runa validates it.
 owns the derivation rules, the eligibility rules, and how unscoped
 sessions interact with `work_unit`-bearing schemas. Each producing
 protocol's `PROTOCOL.md` carries its own delivery-call form, gate-bound
-to the owning schema (ADR-0008, consequence 1) — the take protocol's
+to the owning schema (ADR-0008, consequence 1) — the define protocol's
 contract delivery is the worked example.
 
 The MCP server validates the payload, writes the artifact to the

--- a/docs/architecture/groundwork-skill-ontology-row-1-audit.md
+++ b/docs/architecture/groundwork-skill-ontology-row-1-audit.md
@@ -37,7 +37,7 @@ Groundwork scoped pipeline.
 
 | Asset | Kind | Domain Coupling | Form | Membership-Test Ground |
 |---|---|---|---|---|
-| acquire | skill | domain:software | skill | Gazette or another non-code methodology may need entry from an existing planning record, but this skill materializes a forge ticket as a `work-unit` snapshot with a `handle` for `take`. |
+| acquire | skill | domain:software | skill | Gazette or another non-code methodology may need entry from an existing planning record, but this skill materializes a forge ticket as a `work-unit` snapshot with a `handle` for `define`. |
 | code-review | skill | domain:software | skill | Gazette needs independent quality judgment, but code-review's criteria are software-specific: behavior regressions, schemas, interfaces, tests, and documentation impact for code changes. |
 | contract | skill | universal | skill | Gazette or another domain still needs an executable definition of done across behavior, documentation, and quality dimensions; only the evidence form changes. |
 | debug | skill | universal | skill | Root-cause-before-fix applies to non-code failures as well as software failures; gazette grounding or publication failures still need evidence before correction. |
@@ -54,7 +54,7 @@ Groundwork scoped pipeline.
 | review | protocol | domain:software | protocol | Another domain can reuse independent judgment, but this shell routes Groundwork `change-proposal` artifacts through `change-approved` or `change-needs-revision`. |
 | submit | protocol | domain:software | protocol | Another domain can reuse proposal packaging, but this shell delivers verified software changes through forge mechanics into a `change-proposal`. |
 | survey | protocol | domain:software | protocol | The inquiry discipline projects and gazette also has a `survey` protocol, but this shell transforms `intent` into Groundwork `requirements`. |
-| take | protocol | domain:software | protocol | Another domain can reuse contract-first entry, but this shell claims a work-unit issue, prepares a feature branch, and authors a `contract` for a software work-unit. |
+| define | protocol | domain:software | protocol | Another domain can reuse contract-first entry, but this shell claims a work-unit issue, prepares a feature branch, and authors a `contract` for a software work-unit. |
 | verify | protocol | domain:software | protocol | Another domain can reuse evidence-before-claim, but this shell gates software completion with `completion-evidence` tied to work-unit criteria, tests, and documentation review. |
 
 ## Protocol Reduction Test
@@ -73,7 +73,7 @@ obligations in the protocol boundary.
 | review | quality-review | no | The protocol depends on `code-review`, a software projection. The universal quality-review parent is predicted but not yet extracted. |
 | submit | proposal-submission | no | The cognitive band is packaging verified work for review, but forge delivery and `change-proposal` shape are wrapper concerns. |
 | survey | disciplined-inquiry | no | The cognitive band is separating descriptive state from normative need, but the wrapper turns `intent` into `requirements`. |
-| take | contract-first-entry | no | The core band is contract-first entry, but the current body also owns workspace preparation, tracker claiming, and temporary carry-through to later stations. |
+| define | contract-first-entry | no | The core band is contract-first entry, but the current body also owns workspace preparation, tracker claiming, and contract artifact delivery. |
 | verify | evidence-gate | no | The cognitive band is evidence before completion claims, but the wrapper records Groundwork gate or scenario coverage in `completion-evidence`. |
 
 ## Projection Seams
@@ -84,7 +84,7 @@ skills.
 
 | Domain Skill | Domain Scope | Projects From | Inherited Discipline | Domain Delta |
 |---|---|---|---|---|
-| acquire | domain:software | acquisition | Materialize an execution artifact from an authorized planning record without fabricating content. | Reads a forge ticket, preserves `handle`, derives a `work-unit` body, and hands execution to `take`. |
+| acquire | domain:software | acquisition | Materialize an execution artifact from an authorized planning record without fabricating content. | Reads a forge ticket, preserves `handle`, derives a `work-unit` body, and hands execution to `define`. |
 | code-review | domain:software | quality-review | Judge proposed work against scope, contract, evidence, and recipient impact before approval. | Adds software-specific correctness checks: code semantics, schemas, interfaces, tests, regressions, and current documentation accuracy. |
 
 ## Lateral Harmonics
@@ -92,9 +92,9 @@ skills.
 | Atomic Bead | Kin Assets | Shared Invariant | Extraction Value |
 |---|---|---|---|
 | Ground before design | reckon, survey, decompose, plan, work-unit-craft | The current substrate is evidence, not the need; the next artifact must derive from verified constraints. | High: shared by the planning front and record-craft surfaces. |
-| Contract carries forward | contract, take, plan, implement, verify, review, land | Validation defined at entry remains the measure through planning, execution, evidence, judgment, and close. | High: this is the pipeline's spine and the clearest single-home pressure. |
+| Contract carries forward | contract, define, plan, implement, verify, review, land | Validation defined at entry remains the measure through planning, execution, evidence, judgment, and close. | High: this is the pipeline's spine and the clearest single-home pressure. |
 | Evidence before claim | debug, implement, verify, review, land | A claim is accepted only after fresh evidence or an independent finding decides it. | High: repeated across failure handling, build, completion, review, and governance. |
-| Artifact delivery boundary | decompose, take, plan, implement, verify, submit, land | Tool parameters are not artifact body, `work_unit` injection is scoped, and runa validates the remaining body fields. | Medium: repeated protocol-shell text points at an extractable delivery wrapper discipline. |
+| Artifact delivery boundary | decompose, define, plan, implement, verify, submit, land | Tool parameters are not artifact body, `work_unit` injection is scoped, and runa validates the remaining body fields. | Medium: repeated protocol-shell text points at an extractable delivery wrapper discipline. |
 | Forge containment | acquire, decompose, submit, land | Provider-specific operations stay in mechanics and handles, while protocol and skill language stays forge-invariant. | Medium: strongest where tracker or proposal mechanics touch the outside world. |
 
 ## Mendeleev Gaps
@@ -121,7 +121,7 @@ skills.
 | Finding | Witness Marks | Disposition |
 |---|---|---|
 | `review` is graded by the domain-skill graduation, not the wrapped-universal graduation. | `protocols/review` names `skills/code-review` as its evaluation discipline, while the foundation note predicts domain review skills project from a universal quality-review parent. | Surface for row 2 and ADR-0007; do not extract in this unit. |
-| `take` carries temporary station-bridging content in addition to contract-first entry. | `protocols/take` owns workspace preparation and says it must carry through later stations until runtime sequencing is wired. | Record as a substrate fine-tuning candidate; no protocol rewrite in this unit. |
+| `define` carries workspace and tracker preparation in addition to contract-first entry. | `protocols/define` owns workspace preparation, tracker claiming, and delivery of the contract artifact. | Record as a substrate fine-tuning candidate; no extraction in this unit. |
 | `decompose` and `work-unit-craft` still duplicate substantial record-craft teaching. | `protocols/decompose` contains the same outcome-first record discipline that `skills/work-unit-craft` owns. | Candidate for the factoring work after the seam ADR. |
 | Producer protocols repeat artifact-delivery shell language. | The producer protocols share the same `instance_id`, MCP-input, scoped `work_unit`, and validation boundary paragraphs. | Candidate extraction to a protocol-shell or delivery-wrapper reference. |
 

--- a/docs/architecture/skill-ontology-and-core-protocol-seam.md
+++ b/docs/architecture/skill-ontology-and-core-protocol-seam.md
@@ -46,7 +46,7 @@ domains is the loudest signal that it is core, not delivery.
 
 What differs is purely domain: the artifact types (`work-unit`,
 `contract`, `implementation-plan` vs. `brief`, `beat`, `dispatch`,
-`draft`), the pipeline steps (`take → … → land` vs. `survey → … → publish`), and
+`draft`), the pipeline steps (`define → … → land` vs. `survey → … → publish`), and
 the forge mechanics.
 
 The decisive observation: gazette today has schemas and a manifest and **no
@@ -117,7 +117,7 @@ Every asset has a coordinate on two orthogonal axes.
 **Axis 1 — domain coupling.** Neutral ↔ domain-specific. The membership test:
 *an asset is core iff it is reusable by a methodology in another domain.* Run
 each asset through the projection to gazette. `reckon`, `orient`, `research`
-survive; the `take → land` pipeline, the software schemas, the forge mechanics
+survive; the `define → land` pipeline, the software schemas, the forge mechanics
 do not.
 
 **Axis 2 — form.** How the asset is consumed: **skill** (advisory cognition,
@@ -197,7 +197,7 @@ different basis.
 
 The same cut recurs at several scales — protocol↔skill, universal↔projection,
 and contract↔review-skill across the whole pipeline (the multidimensional
-contract is the standing WHAT the pipeline's HOW answers to, declared at `take`
+contract is the standing WHAT the pipeline's HOW answers to, declared at `define`
 and binding every judgment station). One boundary, many scales.
 
 ## Phase is sequence, not a type

--- a/manifest.toml
+++ b/manifest.toml
@@ -81,7 +81,7 @@ name = "run-test"
 #
 # Planning phase (unscoped): survey → decompose
 # Scoped pipeline (per work unit):
-#   take → plan → implement → verify → submit → review → land
+#   define → plan → implement → verify → submit → review → land
 #
 # `decompose` is also the acquisition surface: it is the sole unscoped
 # producer of `work-unit`. Ordinary planning still reaches it through the
@@ -89,7 +89,7 @@ name = "run-test"
 # trigger so acquisition can materialize the work-unit before requirements
 # exist.
 #
-# The contract is the spine: take produces it at entry, and every
+# The contract is the spine: define produces it at entry, and every
 # judgment station (plan, implement, verify, submit, review) requires it.
 # land, the mechanical applier, accepts it for the completion record.
 
@@ -109,7 +109,7 @@ may_produce = ["research-record"]
 trigger = { type = "on_artifact", name = "requirements" }
 
 [[protocols]]
-name = "take"
+name = "define"
 scoped = true
 requires = ["work-unit"]
 accepts = ["research-record"]

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -215,7 +215,7 @@ work-unit({
   title: "<type(scope): what>",
   description: "<what needs doing and why>",
   acceptance_criteria: ["..."],
-  scope: ["decompose delivery", "take framing"],
+  scope: ["decompose delivery", "define framing"],
   out_of_scope: ["submit protocol", "land protocol"],
   dependencies: ["work-unit-122-artifact-store-cleanup"],
   handle: {
@@ -233,7 +233,7 @@ work-unit({
   title: "<type(scope): what>",
   description: "<what needs doing and why>",
   acceptance_criteria: ["..."],
-  scope: ["decompose delivery", "take framing"],
+  scope: ["decompose delivery", "define framing"],
   out_of_scope: ["submit protocol", "land protocol"],
   dependencies: ["work-unit-122-artifact-store-cleanup"],
   handle: {
@@ -297,7 +297,8 @@ decompose's own — epic, graph, and delivery misuse.
   creates the ticket it delivers; acquire adopts the ticket it is given and
   creates none. A ticket-quality gap acquire surfaces routes to
   `refine-work-unit` here.
-- `take`: session-level prioritization and execution discipline.
+- `define`: contract-authoring entry discipline that states what done means
+  for one work-unit.
 - `contract` (skill): behavior framing and scenario naming discipline.
 - `plan`: design convergence before implementation.
 - `land`: merge-and-close completion events.

--- a/protocols/define/PROTOCOL.md
+++ b/protocols/define/PROTOCOL.md
@@ -1,24 +1,24 @@
 ---
-name: take
+name: define
 description: >-
   Contract-first entry of the scoped pipeline: receive an already-selected
   work-unit, prepare the workspace, and establish the contract that
   defines done. The contract produced here is the spine every downstream
-  protocol carries to land; the session surface advances the pipeline from
-  it. Trigger on: 'take', 'take work', 'start work-unit'.
+  protocol carries to land. Trigger on: 'define', 'define work',
+  'start work-unit'.
 metadata:
-  version: "3.9.0"
-  updated: "2026-07-02"
+  version: "4.0.0"
+  updated: "2026-07-04"
 ---
 
-# Take — Contract-First Entry
+# Define — Contract-First Entry
 
-Take opens work on a single work-unit. Selection happened upstream — the
-work-unit artifact exists and runa activates take on it, having arrived
-either from `decompose` (a newly created work-unit) or from the `acquire`
-skill (materialized from an existing forge ticket). Entry's real job is to
-stand on prepared ground and state, precisely and verifiably, what will be
-true when this work is done.
+Define authors the contract for a single work-unit. Selection happened
+upstream — the work-unit artifact exists and runa activates define on it,
+having arrived either from `decompose` (a newly created work-unit) or from
+the `acquire` skill (materialized from an existing forge ticket). Entry's
+job is to stand on prepared ground and state, precisely and verifiably,
+what will be true when this work is done.
 
 That statement is the `contract`: development here is
 contract-driven, and it begins at the door. The contract authored in this
@@ -70,7 +70,7 @@ proves it, or records it.
    documentation audience taxonomy, and `~/.groundwork/principles/` for the
    universals themselves.
 
-   Take's own role here is narrow and does not re-derive any of that: from
+   Define's own role here is narrow and does not re-derive any of that: from
    this work-unit's own already-framed inputs (step 3), author this
    work-unit's validation defined — one instance of criteria per dimension
    the work-unit has, in the form and to the teeth and density the
@@ -111,15 +111,13 @@ proves it, or records it.
    Runa validates the remaining artifact body fields against the contract
    schema, persists the artifact, and records it in the artifact store.
 
-   Delivering the contract is take completing: the session surface computes
-   the next ready station from artifact state and advances the work to it —
-   the seam runa's session-surface contract
-   (`docs/session-surface-contract.md` in the runa repository) and the
-   manifest's trigger declarations own. Where no runtime is present
-   to accept the MCP tool — a checkout that is not an initialized runa
-   project — author the same contract as a committed workspace artifact (the
-   contract JSON, or the work-unit issue if there is no workspace store) so
-   the spine exists and binds the test-first cycle either way.
+   Delivering the contract is define completing. The stage ends with the
+   recorded contract as the spine every downstream station consumes. Where
+   no runtime is present to accept the MCP tool — a checkout that is not an
+   initialized runa project — author the same contract as a committed
+   workspace artifact (the contract JSON, or the work-unit issue if there is
+   no workspace store) so the spine exists and binds the test-first cycle
+   either way.
 
 ## Scale
 
@@ -167,7 +165,7 @@ begins — the dose is proportional.
   documentation-deliverable unit whose behavior is actually proved by
   structural, coherence, and conformance gates.
 - `lifecycle-modeling`: re-encoding the contract lifecycle or dimension
-  authority in `take` instead of consulting the `contract` skill, `orient`,
+  authority in `define` instead of consulting the `contract` skill, `orient`,
   and the principles corpus as their single homes.
 
 ## Cross-References
@@ -184,8 +182,8 @@ begins — the dose is proportional.
 - `decompose` (protocol): owns work-unit boundaries and acceptance-criteria
   quality. A work-unit that cannot be framed or contracted routes back there.
 - `acquire` (skill): the other entry source — materializes the work-unit
-  artifact from an existing forge ticket before take activates on it.
+  artifact from an existing forge ticket before define activates on it.
 - `plan` (protocol): the next station — consumes the contract and converges
   on a decision-complete design.
-- `land` (protocol): the closing bookend — take establishes what done means;
+- `land` (protocol): the closing bookend — define establishes what done means;
   land records that it was done.

--- a/protocols/define/references/workspace.md
+++ b/protocols/define/references/workspace.md
@@ -1,6 +1,6 @@
 # Workspace Preparation
 
-Reference for take Step 2. States the outcomes preparation must establish
+Reference for define Step 2. States the outcomes preparation must establish
 and the repository-local conventions for reaching them. Command sequences
 are illustrative; the outcomes are the contract.
 

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -12,7 +12,7 @@ metadata:
 # Land
 
 Land is the approved-disposition gate and the pipeline's closing bookend:
-take established what done means; land records that it was done. It
+define established what done means; land records that it was done. It
 activates only from `change-approved`, applies exactly the proposal version
 that approval names, reflects the disposition, and records completion.
 
@@ -129,5 +129,5 @@ The protocol is not a forge operation. It must not activate from a raw
   code-quality results enter close-out context as committed evidence.
 - `contract` (skill): owns the lifecycle this protocol consults while
   recording validation-performed.
-- `take` (protocol): the opening bookend — the contract established there
+- `define` (protocol): the opening bookend — the contract established there
   is what this record closes.

--- a/protocols/plan/PROTOCOL.md
+++ b/protocols/plan/PROTOCOL.md
@@ -147,7 +147,7 @@ long. Multi-subsystem or interface-changing work earns the full convergence.
   the existing system or an adjacent example. Per reckon's own trigger
   (every generative act, not a sequence position); dose proportional to the
   change, the discipline constant.
-- `take` (protocol): produced validation defined in the contract dimensions
+- `define` (protocol): produced validation defined in the contract dimensions
   this plan serves.
 - `implement` (protocol): executes this plan through RED-GREEN-REFACTOR over
   each contract criterion the plan orders.

--- a/protocols/survey/PROTOCOL.md
+++ b/protocols/survey/PROTOCOL.md
@@ -258,5 +258,5 @@ rejection, or judgment.
 - `research`: evidence gathering when local inspection is insufficient.
 - `decompose`: consumes `requirements` and turns the selected work into executable
   work-units.
-- `take`: starts a session once the work-unit graph reflects the work chosen
-  through survey.
+- `define`: authors the contract that defines done once the work-unit graph
+  reflects the work chosen through survey.

--- a/protocols/verify/references/code-quality-review.md
+++ b/protocols/verify/references/code-quality-review.md
@@ -4,7 +4,7 @@ Reference for verify step 4: auditing the change against the declared
 **code-quality contract** (the contract skill's code-quality dimension)
 before the change is packaged for review.
 
-The contract declared, at `take`, the principles-corpus universals this
+The contract declared, at `define`, the principles-corpus universals this
 change most stresses. This review audits the diff against each one. The
 review is the gate; a self-report of cleanliness is not the evidence
 (**Verifiable Completion**, **Honest Signal**).

--- a/protocols/verify/references/documentation-review.md
+++ b/protocols/verify/references/documentation-review.md
@@ -20,7 +20,7 @@ is packaged for review.
 ## Method
 
 Begin from the declared contract. From the documentation contract authored
-at `take`, list the pillars it declared (user / developer / discovery) and
+at `define`, list the pillars it declared (user / developer / discovery) and
 the outcome each must reach; those outcomes are what this audit confirms.
 The steps below keep the surrounding documentation honest against drift.
 

--- a/scripts/interactive-session-surface-handoff.md
+++ b/scripts/interactive-session-surface-handoff.md
@@ -9,7 +9,7 @@ the runa MCP tools.
 
 Inside that cascade, the configured agent calls `next-protocol-context`, follows
 the rendered protocol prompt, records the protocol output through the current
-output tool, calls `advance`, and stops. For example, a ready `take` step
+output tool, calls `advance`, and stops. For example, a ready `define` step
 records `contract` through the current output tool; the operator does not call
 `contract` or `advance` beside `go`.
 

--- a/skills/acquire/SKILL.md
+++ b/skills/acquire/SKILL.md
@@ -2,9 +2,9 @@
 name: acquire
 description: >-
   Entry from an existing forge ticket. Use to start scoped work from a ticket
-  reference that is already on the tracker (e.g. "take runa#14") when no
+  reference that is already on the tracker (e.g. "define runa#14") when no
   work-unit artifact exists yet — acquisition reads the ticket and
-  materializes the work-unit artifact that take then proceeds on. The mirror
+  materializes the work-unit artifact that define then proceeds on. The mirror
   of decompose's create path: decompose creates the ticket it delivers;
   acquire adopts the ticket it is given, and creates no ticket.
 metadata:
@@ -18,7 +18,7 @@ The scoped pipeline activates on a `work-unit` artifact, but the live
 planning surface is the forge tracker. Acquisition is the bridge for the
 natural developer entry — "start on ticket #N" — when that ticket already
 exists and no work-unit artifact does yet. It reads the ticket and
-materializes the work-unit artifact; `take` then proceeds unchanged on that
+materializes the work-unit artifact; `define` then proceeds unchanged on that
 artifact through its existing contract.
 
 Acquisition is **one-way**: the ticket is the planning home, the artifact is
@@ -95,17 +95,17 @@ cold start.
    ```
 
    Runa validates the body against the `work-unit` schema, persists it, and
-   records it. The cascade then computes `take` as the next station on the
+   records it. The cascade then computes `define` as the next station on the
    acquired artifact.
 
-5. **Hand off to `take`.** Acquisition materializes; `take` claims. Tracker
-   claiming (assigning the ticket, marking it in progress) is `take`'s
+5. **Hand off to `define`.** Acquisition materializes; `define` claims. Tracker
+   claiming (assigning the ticket, marking it in progress) is `define`'s
    workspace-preparation step, not acquisition's — keep the one-way boundary
    clean.
 
 ## Corruption Modes
 
-- `log-blindness`: handing off to `take` with the ticket's comment log
+- `log-blindness`: handing off to `define` with the ticket's comment log
   unread and unsurfaced. The snapshot carries the running record so the
   session grounds on the whole ticket; an entry that reads the spec alone
   executes blind to its own live corrections.
@@ -115,7 +115,7 @@ cold start.
 - `content-fabrication`: hand-filling acceptance criteria or a description
   the ticket does not contain, instead of routing the gap to refinement. The
   artifact must be a faithful snapshot of the planning home.
-- `write-back`: editing the ticket from acquisition (beyond `take`'s later
+- `write-back`: editing the ticket from acquisition (beyond `define`'s later
   claim). Derivation is one-way.
 - `handle-drift`: re-deriving or altering the `handle` instead of carrying
   the ticket's identity through verbatim — breaks the back-link and risks a
@@ -125,7 +125,7 @@ cold start.
 
 - `decompose` (protocol): the create path acquisition mirrors, and the home
   of `refine-work-unit` — where a ticket-quality gap surfaced here is fixed.
-- `take` (protocol): proceeds on the acquired artifact through its existing
+- `define` (protocol): proceeds on the acquired artifact through its existing
   contract; owns tracker claiming.
 - `read-ticket` (connector capability operation): emits
   `{handle, title, body, state}` and, per forge-capability `1.2.0`, the

--- a/skills/contract/SKILL.md
+++ b/skills/contract/SKILL.md
@@ -117,7 +117,7 @@ The stage boundary is part of the contract lifecycle:
 
 - `work-unit-craft`/`decompose` produces inputs to validation: the work-unit criteria,
   recipient outcomes, and corpus pointers each dimension must consider.
-- `take` consumes inputs to validation and produces validation defined:
+- `define` consumes inputs to validation and produces validation defined:
   typed criteria in `contract.criteria[]` — every dimension in the same
   surface.
 - `plan` consumes validation defined and maps every criterion to
@@ -134,7 +134,7 @@ The stage boundary is part of the contract lifecycle:
 In short: the lifecycle is inputs to validation -> validation defined ->
 validation performed, and it is one lifecycle for every dimension: inputs
 become validation defined as typed criteria in `contract.criteria[]` at
-`take`; validation is carried through `implement` by `criterion_id`;
+`define`; validation is carried through `implement` by `criterion_id`;
 `verify` produces validation performed as one result per criterion in
 `completion-evidence.results[]`, the evidence shaped by each criterion's
 `check_kind`; and `land` records the result from that uniform evidence
@@ -467,7 +467,7 @@ declared dimension proves qualification-to-remain.
 
 - `work-unit-craft` and `decompose`: produce the inputs each dimension
   considers before validation is defined.
-- `take` (protocol): consumes dimension inputs and defines validation using
+- `define` (protocol): consumes dimension inputs and defines validation using
   this discipline.
 - `plan` (protocol): maps scenarios to a decision-complete design.
 - `implement` (protocol): executes RED-GREEN-REFACTOR per named scenario.

--- a/skills/contract/references/code-quality-contract.md
+++ b/skills/contract/references/code-quality-contract.md
@@ -64,7 +64,7 @@ what its check actually is.
 ## Projecting the corpus
 
 The projection is generated, not hardcoded. When `work-unit-craft`/`decompose`
-supplies inputs or `take` defines validation, consult the resolved corpus
+supplies inputs or `define` defines validation, consult the resolved corpus
 (`~/.groundwork/principles/`), select the universals this change most
 stresses, and write each as a typed `contract.criteria[]` entry whose
 statement carries one shape:
@@ -100,7 +100,7 @@ demand.
 ## Lifecycle
 
 `work-unit-craft`/`decompose` supplies corpus pointers and stressed
-universals as inputs to validation. `take` turns those inputs into
+universals as inputs to validation. `define` turns those inputs into
 validation defined: the subset of universals the change puts under real
 pressure, named from the resolved corpus, not a ritual recital, and emitted
 as typed criteria into the uniform contract surface. `verify` performs

--- a/skills/contract/references/documentation-contract.md
+++ b/skills/contract/references/documentation-contract.md
@@ -34,7 +34,7 @@ on the criterion.
 ## Lifecycle
 
 `work-unit-craft`/`decompose` supplies recipient outcomes as inputs to
-validation. `take` turns those inputs into validation defined: typed
+validation. `define` turns those inputs into validation defined: typed
 criteria in the uniform contract surface naming the pillar, recipient
 outcome, hollow delivery, `check_kind`, and check descriptor. `verify`
 performs validation by auditing whether those recipients can reach the

--- a/skills/orient/SKILL.md
+++ b/skills/orient/SKILL.md
@@ -52,13 +52,13 @@ work-units with acceptance criteria and dependency edges.
 **Entry.** A work-unit reaches the scoped pipeline one of two ways: newly
 created by `decompose`, or materialized from an existing forge ticket by the
 `acquire` skill (the "start on ticket #N" path). Either way the result is a
-work-unit artifact, indistinguishable downstream, that `take` activates on.
+work-unit artifact, indistinguishable downstream, that `define` activates on.
 
 **The scoped pipeline (per work-unit).** Seven stations carry one selected
 work-unit to a landed change. The contract is the spine: created
 at entry, threaded unbroken to the close.
 
-1. **`take`** — contract-first entry: prepare the workspace, frame the
+1. **`define`** — contract-first entry: prepare the workspace, frame the
    work, author the contract that defines done.
 2. **`plan`** — converge on a decision-complete design that maps scenarios
    to implementation steps.
@@ -94,7 +94,7 @@ These are not stations; they engage when their trigger fires, at any stage.
   every generative act — planning and diagnosis included — the trigger is
   creation, not sequence position.
 - **`contract`** — the BDD discipline: authoring the contract at
-  `take`, carrying traceability through every station after.
+  `define`, carrying traceability through every station after.
 - **`work-unit-craft`** — the discipline for authoring a work-unit's tracker
   record: outcomes over prescription, so the record does not mis-steer the
   agent that reads it. Fires when a work-unit record is written or re-scoped.
@@ -110,7 +110,7 @@ These are not stations; they engage when their trigger fires, at any stage.
 - **`code-review`** — the evaluation discipline `review` applies to a
   change proposal.
 - **`acquire`** — entry from an existing forge ticket: reads the ticket and
-  materializes the work-unit artifact `take` activates on. Fires at the
+  materializes the work-unit artifact `define` activates on. Fires at the
   cold-start boundary, when work begins from a ticket reference.
 
 ## Integration Principles
@@ -125,7 +125,7 @@ These are not stations; they engage when their trigger fires, at any stage.
   comments are a log. When authoring or re-scoping a record, `work-unit-craft`
   provides the discipline: outcomes over prescription, and the corruption
   modes that make records mis-steer their readers.
-- **Behavior traceability.** The contract from `take` is traceable at every
+- **Behavior traceability.** The contract from `define` is traceable at every
   station: plans link decisions to scenarios, tests prove named scenarios,
   verification reports scenario-level coverage, review judges against the
   contract, landing records what coverage shipped.

--- a/skills/verification-craft/SKILL.md
+++ b/skills/verification-craft/SKILL.md
@@ -53,7 +53,7 @@ tokens are the invariant, and a meaning-preserving rewrite still passes.
 Worked example: `test_entry_surfaces_ground_on_the_whole_ticket` in
 [`tests/test_forge_capability.py`](https://github.com/tesserine/groundwork/blob/252024f/tests/test_forge_capability.py)
 uses `tooling.prose_conformance.entry_surface_coherence` to check the
-read-ticket comment-log lifecycle across `acquire` and `take` instead of
+read-ticket comment-log lifecycle across `acquire` and `define` instead of
 pinning one sentence about entry context.
 
 ### Structural

--- a/skills/work-unit-craft/SKILL.md
+++ b/skills/work-unit-craft/SKILL.md
@@ -68,7 +68,7 @@ Every dimension the change has must leave an authored teeth-bearing input
 for the later contract; every dimension the change has is covered that way.
 The rule is that density may be light, but coverage is never zero: one sharp
 recipient outcome or one corpus projection can be enough, while silence
-cannot. Each input should make the hollow delivery visible enough that `take`
+cannot. Each input should make the hollow delivery visible enough that `define`
 can turn it into a criterion with a statement of done,
 `check_kind`, check descriptor, and result path.
 

--- a/tests/fixtures/artifacts/valid-completion-evidence-attested.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-attested.json
@@ -19,7 +19,7 @@
       "CHANGELOG.md"
     ],
     "verified_accurate": [
-      "protocols/take/PROTOCOL.md",
+      "protocols/define/PROTOCOL.md",
       "protocols/verify/PROTOCOL.md"
     ],
     "follow_up_work_units": []

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -302,7 +302,7 @@ class AcquisitionEntryEndToEndTests(unittest.TestCase):
             self.assertEqual(payload["execution_plan"][0]["projection"], "current")
             projected = [
                 entry for entry in payload["execution_plan"]
-                if entry["protocol"] == "take" and entry["projection"] == "projected"
+                if entry["protocol"] == "define" and entry["projection"] == "projected"
             ]
             self.assertEqual(1, len(projected), payload["execution_plan"])
             self.assertEqual("work-unit-499", projected[0]["work_unit"])
@@ -368,7 +368,7 @@ class AcquisitionEntryEndToEndTests(unittest.TestCase):
             }
             self.assertEqual("ready", requirements_state["decompose"]["status"], requirements_state)
 
-    def test_acquired_work_unit_makes_take_the_next_ready_station(self) -> None:
+    def test_acquired_work_unit_makes_define_the_next_ready_station(self) -> None:
         runa = runa_bin()
         runa_mcp = runa_mcp_bin(runa)
         if runa_mcp is None:
@@ -421,16 +421,16 @@ class AcquisitionEntryEndToEndTests(unittest.TestCase):
             body = json.loads(recorded.read_text(encoding="utf-8"))
             self.assertEqual(ticket["handle"], body["handle"])
 
-            # The cascade now computes take as the next READY station for the
-            # acquired work-unit — entry from an existing ticket reached take.
+            # The cascade now computes define as the next READY station for the
+            # acquired work-unit — entry from an existing ticket reached define.
             state = subprocess.run(
                 [str(runa), "state", "--work-unit", instance_id],
                 cwd=project, capture_output=True, text=True,
             )
             self.assertEqual(state.returncode, 0, f"{state.stdout}\n{state.stderr}")
             ready_block = state.stdout.split("BLOCKED")[0]
-            self.assertIn("take", ready_block,
-                          f"take not READY after acquisition:\n{state.stdout}")
+            self.assertIn("define", ready_block,
+                          f"define not READY after acquisition:\n{state.stdout}")
 
 
 if __name__ == "__main__":

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -551,18 +551,18 @@ name = "survey"
         self.assertFalse(results[0].passed)
         self.assertIn("protocol `survey` leaks forge-specific token `gh`", " ".join(results[0].errors))
 
-    def test_manifest_forge_leakage_scan_covers_take_protocol(self) -> None:
+    def test_manifest_forge_leakage_scan_covers_define_protocol(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             manifest = root / "manifest.toml"
             manifest.write_text(
                 """
 [[protocols]]
-name = "take"
+name = "define"
 """.lstrip(),
                 encoding="utf-8",
             )
-            protocol = root / "protocols" / "take"
+            protocol = root / "protocols" / "define"
             protocol.mkdir(parents=True)
             (protocol / "PROTOCOL.md").write_text("Fallback: run `gh issue view 353`.\n", encoding="utf-8")
 
@@ -570,7 +570,7 @@ name = "take"
 
         self.assertEqual("C-5 manifest", results[0].category)
         self.assertFalse(results[0].passed)
-        self.assertIn("protocol `take` leaks forge-specific token `gh`", " ".join(results[0].errors))
+        self.assertIn("protocol `define` leaks forge-specific token `gh`", " ".join(results[0].errors))
 
     def test_malformed_directory_manifest_does_not_abort_sibling_registry_checks(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_contract_skill_lifecycle.py
+++ b/tests/test_contract_skill_lifecycle.py
@@ -15,7 +15,7 @@ CONTRACT_SURFACE = [
 ]
 AUTHORING_DOCTRINE_SURFACE = [
     CONTRACT_SKILL,
-    ROOT / "protocols" / "take" / "PROTOCOL.md",
+    ROOT / "protocols" / "define" / "PROTOCOL.md",
     ROOT / "protocols" / "decompose" / "PROTOCOL.md",
     ROOT / "skills" / "work-unit-craft" / "SKILL.md",
 ]
@@ -34,7 +34,7 @@ MIGRATED_LIFECYCLE_CONSUMERS = {
     ROOT / "protocols" / "implement" / "PROTOCOL.md",
     ROOT / "protocols" / "review" / "PROTOCOL.md",
     ROOT / "protocols" / "submit" / "PROTOCOL.md",
-    ROOT / "protocols" / "take" / "PROTOCOL.md",
+    ROOT / "protocols" / "define" / "PROTOCOL.md",
     ROOT / "protocols" / "verify" / "PROTOCOL.md",
 }
 UNMIGRATED_LIFECYCLE_CONSUMERS = [
@@ -304,7 +304,7 @@ outside content
 
         for expected in [
             "one lifecycle for every dimension",
-            "typed criteria in `contract.criteria[]` at `take`",
+            "typed criteria in `contract.criteria[]` at `define`",
             "carried through `implement` by `criterion_id`",
             "one result per criterion in `completion-evidence.results[]`",
             "`check_kind`",
@@ -356,7 +356,7 @@ outside content
         handoffs = normalized(section(read(CONTRACT_SKILL), "Stage Handoffs"))
         expected_handoffs = [
             "`work-unit-craft`/`decompose` produces inputs to validation",
-            "`take` consumes inputs to validation and produces validation defined",
+            "`define` consumes inputs to validation and produces validation defined",
             "typed criteria in `contract.criteria[]`",
             "`plan` consumes validation defined and maps every criterion",
             "`implement` consumes validation defined",
@@ -398,8 +398,8 @@ outside content
 
     def test_contract_surface_replaces_entry_only_framing_everywhere(self) -> None:
         forbidden = re.compile(
-            r"declared at `take`|At `take`, the contract declares|declared at entry|"
-            r"Each dimension is \*\*declared\*\* at `take`",
+            r"declared at `define`|At `define`, the contract declares|declared at entry|"
+            r"Each dimension is \*\*declared\*\* at `define`",
             flags=re.IGNORECASE,
         )
 

--- a/tests/test_define_protocol_contract_dimensions.py
+++ b/tests/test_define_protocol_contract_dimensions.py
@@ -14,7 +14,7 @@ from tooling.prose_conformance import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
-TAKE_PROTOCOL = ROOT / "protocols" / "take" / "PROTOCOL.md"
+DEFINE_PROTOCOL = ROOT / "protocols" / "define" / "PROTOCOL.md"
 CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
 EXPECTED_CONTRACT_DIMENSIONS = {
     "**Behavior**",
@@ -27,13 +27,13 @@ def protocol(name: str) -> dict:
     return {entry["name"]: entry for entry in manifest_protocols(ROOT)}[name]
 
 
-class TakeProtocolContractDimensionTests(unittest.TestCase):
-    def test_manifest_declares_take_as_scoped_contract_entry(self) -> None:
-        take = protocol("take")
+class DefineProtocolContractDimensionTests(unittest.TestCase):
+    def test_manifest_declares_define_as_scoped_contract_entry(self) -> None:
+        define = protocol("define")
 
-        self.assertTrue(take["scoped"])
-        self.assertEqual(["work-unit"], take["requires"])
-        self.assertEqual(["contract"], take["produces"])
+        self.assertTrue(define["scoped"])
+        self.assertEqual(["work-unit"], define["requires"])
+        self.assertEqual(["contract"], define["produces"])
 
     def test_contract_schema_requires_dimension_agnostic_teeth_fields(self) -> None:
         schema = artifact_schema(ROOT, "contract")
@@ -45,16 +45,16 @@ class TakeProtocolContractDimensionTests(unittest.TestCase):
         self.assertEqual(["executable", "attested"], criterion["properties"]["check_kind"]["enum"])
         self.assertNotIn("behavior_form", criterion["properties"])
 
-    def test_take_delivery_block_matches_manifest_and_schema_boundary(self) -> None:
-        take = {boundary.protocol: boundary for boundary in delivery_boundaries(ROOT)}["take"]
+    def test_define_delivery_block_matches_manifest_and_schema_boundary(self) -> None:
+        define = {boundary.protocol: boundary for boundary in delivery_boundaries(ROOT)}["define"]
 
-        self.assertTrue(take.passed)
-        self.assertEqual("contract", take.artifact)
-        self.assertTrue(take.scoped)
-        self.assertTrue(take.schema_requires_work_unit)
+        self.assertTrue(define.passed)
+        self.assertEqual("contract", define.artifact)
+        self.assertTrue(define.scoped)
+        self.assertTrue(define.schema_requires_work_unit)
 
-    def test_take_consults_contract_dimension_authorities(self) -> None:
-        body = read(TAKE_PROTOCOL)
+    def test_define_consults_contract_dimension_authorities(self) -> None:
+        body = read(DEFINE_PROTOCOL)
         rows = contract_dimension_rows(ROOT)
 
         self.assertEqual(EXPECTED_CONTRACT_DIMENSIONS, set(rows))
@@ -88,9 +88,9 @@ class TakeProtocolContractDimensionTests(unittest.TestCase):
             mutated_dimensions,
         )
 
-    def test_take_ends_at_contract_capstone_with_named_corruption_modes(self) -> None:
-        steps = markdown_section(read(TAKE_PROTOCOL), "Steps")
-        corruption_modes = markdown_section(read(TAKE_PROTOCOL), "Corruption Modes")
+    def test_define_ends_at_contract_capstone_with_named_corruption_modes(self) -> None:
+        steps = markdown_section(read(DEFINE_PROTOCOL), "Steps")
+        corruption_modes = markdown_section(read(DEFINE_PROTOCOL), "Corruption Modes")
 
         self.assertIsNone(re.search(r"^6\. \*\*", steps, flags=re.MULTILINE))
         self.assertIn("contract-after-code", corruption_modes)

--- a/tests/test_forge_capability.py
+++ b/tests/test_forge_capability.py
@@ -50,7 +50,7 @@ CONNECTOR_MODEL_DOCUMENTS = [
     ROOT / "protocols" / "decompose" / "PROTOCOL.md",
     ROOT / "protocols" / "submit" / "PROTOCOL.md",
     ROOT / "protocols" / "land" / "PROTOCOL.md",
-    ROOT / "protocols" / "take" / "references" / "workspace.md",
+    ROOT / "protocols" / "define" / "references" / "workspace.md",
 ]
 
 
@@ -365,7 +365,7 @@ class ForgeCapabilityTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             tree = Path(tmp) / "tree"
             shutil.copytree(ROOT / "skills" / "acquire", tree / "skills" / "acquire")
-            shutil.copytree(ROOT / "protocols" / "take", tree / "protocols" / "take")
+            shutil.copytree(ROOT / "protocols" / "define", tree / "protocols" / "define")
             acquire = tree / "skills" / "acquire" / "SKILL.md"
             body = acquire.read_text(encoding="utf-8")
             clause = "The comment log is read as entry context, never persisted into the artifact"

--- a/tests/test_groundwork_install.py
+++ b/tests/test_groundwork_install.py
@@ -76,8 +76,8 @@ class MethodologyFixture:
         self.write("skills/orient/SKILL.md", "---\nname: orient\n---\n# Orient\n")
         self.write("skills/reckon/SKILL.md", "---\nname: reckon\n---\n# Reckon\n")
         self.write("skills/reckon/references/example.md", "reckon reference\n")
-        self.write("protocols/take/PROTOCOL.md", "---\nname: take\n---\n# Take\n")
-        self.write("protocols/take/references/example.md", "take reference\n")
+        self.write("protocols/define/PROTOCOL.md", "---\nname: define\n---\n# Define\n")
+        self.write("protocols/define/references/example.md", "define reference\n")
         self.write("protocols/submit/PROTOCOL.md", "---\nname: submit\n---\n# Submit\n")
 
     def init_git(self) -> None:
@@ -202,10 +202,10 @@ class GroundworkInstallTests(unittest.TestCase):
         result = install.run_installer("install")
 
         assert_success(self, result)
-        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
-        take_body = (install.target(".claude", "take") / "SKILL.md").read_text(encoding="utf-8")
-        self.assert_handoff_projected_once(take_body)
-        self.assertTrue((install.target(".agents", "take") / "references" / "example.md").is_file())
+        self.assert_installed_inventory(install, {"orient", "reckon", "define", "submit"})
+        define_body = (install.target(".claude", "define") / "SKILL.md").read_text(encoding="utf-8")
+        self.assert_handoff_projected_once(define_body)
+        self.assertTrue((install.target(".agents", "define") / "references" / "example.md").is_file())
         self.assertTrue((install.target(".agents", "reckon") / "references" / "example.md").is_file())
 
     def test_install_projects_post_retirement_runtime_bundle(self) -> None:
@@ -289,7 +289,7 @@ class GroundworkInstallTests(unittest.TestCase):
         producer_protocols = [
             "survey",
             "decompose",
-            "take",
+            "define",
             "specify",
             "plan",
             "implement",
@@ -426,7 +426,7 @@ class GroundworkInstallTests(unittest.TestCase):
 
         assert_success(self, result)
         self.assertEqual(self.installed_entry_stats(install), before)
-        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
+        self.assert_installed_inventory(install, {"orient", "reckon", "define", "submit"})
 
     def test_install_restores_same_sha_managed_target_drift(self) -> None:
         fixture = self.add_fixture("same-sha-drift")
@@ -443,7 +443,7 @@ class GroundworkInstallTests(unittest.TestCase):
         assert_success(self, result)
         self.assertEqual(skill.read_text(encoding="utf-8"), expected)
         self.assertFalse((entry / "local-only.md").exists())
-        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
+        self.assert_installed_inventory(install, {"orient", "reckon", "define", "submit"})
 
     def test_install_restores_state_recorded_target_when_marker_is_missing(self) -> None:
         fixture = self.add_fixture("missing-marker-drift")
@@ -462,7 +462,7 @@ class GroundworkInstallTests(unittest.TestCase):
         self.assertTrue((entry / ".groundwork-install").is_file())
         self.assertEqual(skill.read_text(encoding="utf-8"), expected)
         self.assertFalse((entry / "local-only.md").exists())
-        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
+        self.assert_installed_inventory(install, {"orient", "reckon", "define", "submit"})
 
     def test_sync_converges_to_a_different_pinned_source_state(self) -> None:
         fixture = self.add_fixture("sync")
@@ -475,7 +475,7 @@ class GroundworkInstallTests(unittest.TestCase):
         result = install.run_installer("sync")
 
         assert_success(self, result)
-        self.assert_installed_inventory(install, {"orient", "take", "submit", "verify"})
+        self.assert_installed_inventory(install, {"orient", "define", "submit", "verify"})
         self.assertFalse(install.target(".claude", "reckon").exists())
 
     def test_sync_upgrades_state_owned_entry_when_kind_changes(self) -> None:
@@ -561,7 +561,7 @@ class GroundworkInstallTests(unittest.TestCase):
         assert_success(self, result)
         self.assertTrue((unrelated / "SKILL.md").is_file())
         self.assertFalse(install.target(".agents", "orient").exists())
-        self.assertFalse(install.target(".claude", "take").exists())
+        self.assertFalse(install.target(".claude", "define").exists())
 
     def test_uninstall_fails_and_retains_state_when_managed_entry_is_missing_marker(self) -> None:
         fixture = self.add_fixture("uninstall-missing-marker")
@@ -591,7 +591,7 @@ class GroundworkInstallTests(unittest.TestCase):
         self.assertIn("scripts/install", result.stderr)
         self.assertNotIn("unmanaged conflict at %s" % conflict, result.stderr)
         self.assertEqual((conflict / "SKILL.md").read_text(encoding="utf-8"), "# Canonical\n")
-        self.assertFalse((install.home / ".agents" / "skills" / "take").exists())
+        self.assertFalse((install.home / ".agents" / "skills" / "define").exists())
         self.assertFalse(install.state_file().exists())
 
     def test_install_redirects_runtime_owned_by_canonical_installer(self) -> None:
@@ -632,7 +632,7 @@ class GroundworkInstallTests(unittest.TestCase):
 
         assert_failure_contains(self, result, "unmanaged conflict")
         self.assertEqual((conflict / "SKILL.md").read_text(encoding="utf-8"), "# Mine\n")
-        self.assertFalse((install.home / ".agents" / "skills" / "take").exists())
+        self.assertFalse((install.home / ".agents" / "skills" / "define").exists())
 
     def test_install_rejects_marker_only_targets_as_unmanaged_conflicts(self) -> None:
         fixture = self.add_fixture("marker-only-conflict")
@@ -646,7 +646,7 @@ class GroundworkInstallTests(unittest.TestCase):
 
         assert_failure_contains(self, result, "unmanaged conflict")
         self.assertEqual((conflict / "SKILL.md").read_text(encoding="utf-8"), "# Mine\n")
-        self.assertFalse((install.home / ".agents" / "skills" / "take").exists())
+        self.assertFalse((install.home / ".agents" / "skills" / "define").exists())
         self.assertFalse(install.state_file().exists())
 
     def test_install_rejects_unmanaged_runtime_conflict_before_replacing_it(self) -> None:
@@ -726,7 +726,7 @@ class GroundworkInstallTests(unittest.TestCase):
         result = install.run_installer("install", "--from-branch")
 
         assert_success(self, result)
-        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
+        self.assert_installed_inventory(install, {"orient", "reckon", "define", "submit"})
         recorded = {
             line.split("\t")[3]
             for line in install.state_file().read_text(encoding="utf-8").splitlines()
@@ -747,7 +747,7 @@ class GroundworkInstallTests(unittest.TestCase):
         result = install.run_installer("sync", "--from-branch")
 
         assert_success(self, result)
-        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit", "added"})
+        self.assert_installed_inventory(install, {"orient", "reckon", "define", "submit", "added"})
         recorded = {
             line.split("\t")[3]
             for line in install.state_file().read_text(encoding="utf-8").splitlines()
@@ -769,7 +769,7 @@ class GroundworkInstallTests(unittest.TestCase):
         fixture.write(".gitignore", "*.swp\n")
         fixture.commit_new_ref("v2")
         fixture.write("skills/orient/local.swp", "ignored skill artifact\n")
-        fixture.write("protocols/take/local.swp", "ignored protocol artifact\n")
+        fixture.write("protocols/define/local.swp", "ignored protocol artifact\n")
         install = InstallRun(self, fixture.root)
 
         result = install.run_installer("install")
@@ -777,7 +777,7 @@ class GroundworkInstallTests(unittest.TestCase):
         assert_success(self, result)
         for root in [".claude", ".agents"]:
             self.assertFalse((install.target(root, "orient") / "local.swp").exists())
-            self.assertFalse((install.target(root, "take") / "local.swp").exists())
+            self.assertFalse((install.target(root, "define") / "local.swp").exists())
 
     def test_install_omits_ignored_top_level_files_under_skills(self) -> None:
         fixture = self.add_fixture("ignored-top-level-skill-files")
@@ -789,7 +789,7 @@ class GroundworkInstallTests(unittest.TestCase):
         result = install.run_installer("install")
 
         assert_success(self, result)
-        self.assert_installed_inventory(install, {"orient", "reckon", "take", "submit"})
+        self.assert_installed_inventory(install, {"orient", "reckon", "define", "submit"})
         for root in [".claude", ".agents"]:
             self.assertFalse((install.home / root / "skills" / "local.swp").exists())
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -115,7 +115,7 @@ class MethodologyFixture:
         self.write("skills/orient/SKILL.md", "---\nname: orient\n---\n# Orient\n")
         self.write("skills/reckon/SKILL.md", "---\nname: reckon\n---\n# Reckon\n")
         self.write("skills/reckon/references/example.md", "reckon reference\n")
-        self.write("protocols/take/PROTOCOL.md", "---\nname: take\n---\n# Take\n")
+        self.write("protocols/define/PROTOCOL.md", "---\nname: define\n---\n# Define\n")
         self.write(
             "schemas/work-unit.schema.json",
             """
@@ -155,7 +155,7 @@ class MethodologyFixture:
             name = "read-artifact"
 
             [[protocols]]
-            name = "take"
+            name = "define"
             requires = ["work-unit"]
             produces = ["contract"]
             scoped = true
@@ -332,7 +332,7 @@ class SelfInstallTests(unittest.TestCase):
             name = "contract"
 
             [[protocols]]
-            name = "take"
+            name = "define"
             requires = ["work-unit"]
             produces = ["contract"]
             scoped = true
@@ -391,7 +391,7 @@ class SelfInstallTests(unittest.TestCase):
         self.assertTrue((runtime / "manifest.toml").is_file())
         self.assertTrue((runtime / MARKER_NAME).is_file())
         self.assertTrue((runtime / "schemas" / "work-unit.schema.json").is_file())
-        self.assertTrue((runtime / "protocols" / "take" / "PROTOCOL.md").is_file())
+        self.assertTrue((runtime / "protocols" / "define" / "PROTOCOL.md").is_file())
         self.assertFalse((runtime / "mechanics").exists())
         self.assertFalse((runtime / "lib" / "tooling" / "forge_operations.py").exists())
         self.assertFalse((runtime / "bin" / "groundwork-mechanic").exists())
@@ -591,13 +591,13 @@ class SelfInstallTests(unittest.TestCase):
 
     def test_missing_manifest_declared_protocol_fails_before_target_mutation(self) -> None:
         fixture = self.add_fixture("missing-declared-protocol")
-        fixture.remove("protocols/take")
+        fixture.remove("protocols/define")
         fixture.commit("drop declared protocol")
         install = InstallRun(self, fixture.root)
 
         result = install.run_installer("install")
 
-        assert_failure_contains(self, result, "protocols/take/PROTOCOL.md")
+        assert_failure_contains(self, result, "protocols/define/PROTOCOL.md")
         for surface in [".claude", ".agents", ".groundwork"]:
             self.assertFalse((install.home / surface).exists(), f"{surface} must be untouched")
 
@@ -612,7 +612,7 @@ class SelfInstallTests(unittest.TestCase):
             name = "../../escaped/work-unit"
 
             [[protocols]]
-            name = "take"
+            name = "define"
             requires = ["work-unit"]
             produces = ["work-unit"]
             scoped = true

--- a/tests/test_interactive_session_surface.py
+++ b/tests/test_interactive_session_surface.py
@@ -90,7 +90,7 @@ class InteractiveSessionSurfaceTests(unittest.TestCase):
                         "title": "task(dual-mode): groundwork conforms to the session surface",
                         "description": "Make interactive Groundwork sessions use runa's validated session surface.",
                         "acceptance_criteria": [
-                            "Interactive sessions reach take through the runa session surface"
+                            "Interactive sessions reach define through the runa session surface"
                         ],
                         "handle": {
                             "id": "ticket:382-session-surface",
@@ -117,7 +117,7 @@ class InteractiveSessionSurfaceTests(unittest.TestCase):
                     printf '%s\\n' '{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"2024-11-05","capabilities":{{}},"clientInfo":{{"name":"groundwork-go-smoke","version":"1.0.0"}}}}}}'
                     printf '%s\\n' '{{"jsonrpc":"2.0","method":"notifications/initialized"}}'
                     printf '%s\\n' '{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"next-protocol-context","arguments":{{}}}}}}'
-                    printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"contract","arguments":{{"instance_id":"contract-1","title":"Interactive sessions use the session surface","criteria":[{{"id":"session-surface-records-output","dimension":"behavior","acceptance_criterion":"Interactive sessions reach take through the runa session surface","statement":"The scoped session records the produced contract artifact through the MCP session surface.","hollow_delivery":"The agent prints a contract but no validated artifact is persisted.","check_kind":"executable","check":"Run the interactive session smoke test."}}]}}}}}}'
+                    printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"contract","arguments":{{"instance_id":"contract-1","title":"Interactive sessions use the session surface","criteria":[{{"id":"session-surface-records-output","dimension":"behavior","acceptance_criterion":"Interactive sessions reach define through the runa session surface","statement":"The scoped session records the produced contract artifact through the MCP session surface.","hollow_delivery":"The agent prints a contract but no validated artifact is persisted.","check_kind":"executable","check":"Run the interactive session smoke test."}}]}}}}}}'
                     printf '%s\\n' '{{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{{"name":"advance","arguments":{{}}}}}}'
                     sleep 1
                 }} | "$3" --session --work-unit {WORK_UNIT_ID} > "$4"
@@ -157,7 +157,7 @@ class InteractiveSessionSurfaceTests(unittest.TestCase):
             self.assertEqual(contract["work_unit"], WORK_UNIT_ID)
             self.assertEqual(
                 contract["criteria"][0]["acceptance_criterion"],
-                "Interactive sessions reach take through the runa session surface",
+                "Interactive sessions reach define through the runa session surface",
             )
 
     def test_completion_evidence_persist_rejects_contract_mismatches(self) -> None:
@@ -304,7 +304,7 @@ class InteractiveSessionSurfaceTests(unittest.TestCase):
                     printf '%s\\n' '{{"jsonrpc":"2.0","method":"notifications/initialized"}}'
                     printf '%s\\n' '{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"next-protocol-context","arguments":{{}}}}}}'
                     case "$protocol" in
-                      take)
+                      define)
                         printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"contract","arguments":{{"instance_id":"contract-1","title":"Dimension criteria stay on the contract surface","criteria":[{{"id":"gate-form-behavior-artifacts","dimension":"behavior","acceptance_criterion":{json.dumps(criterion)},"statement":"Gate-form behavior artifacts stay schema-valid through the runtime MCP tool.","hollow_delivery":"The artifact validates only by fabricating a scenario-shaped contract.","check_kind":"executable","check":"Validate runtime artifacts through the MCP tool."}}]}}}}}}'
                         ;;
                       plan)
@@ -314,7 +314,7 @@ class InteractiveSessionSurfaceTests(unittest.TestCase):
                         printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"test-evidence","arguments":{{"instance_id":"evidence-1","evidence":[{{"criterion_id":"gate-form-behavior-artifacts","result":"pass","command":"python -m unittest tests.test_artifact_schemas","output_summary":"Gate-checked artifact fixtures validated."}}]}}}}}}'
                         ;;
                       verify)
-                        printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"completion-evidence","arguments":{{"instance_id":"completion-1","results":[{{"criterion_id":"gate-form-behavior-artifacts","result":"pass","evidence":{{"summary":"Gate-form runtime artifacts validated.","run":{{"command":"python -m unittest tests.test_artifact_schemas","result":"pass","output_summary":"Artifact fixtures validated."}}}}}}],"documentation":{{"updated":["schemas/README.md","CHANGELOG.md"],"verified_accurate":["protocols/take/PROTOCOL.md"],"follow_up_work_units":[]}}}}}}}}'
+                        printf '%s\\n' '{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"completion-evidence","arguments":{{"instance_id":"completion-1","results":[{{"criterion_id":"gate-form-behavior-artifacts","result":"pass","evidence":{{"summary":"Gate-form runtime artifacts validated.","run":{{"command":"python -m unittest tests.test_artifact_schemas","result":"pass","output_summary":"Artifact fixtures validated."}}}}}}],"documentation":{{"updated":["schemas/README.md","CHANGELOG.md"],"verified_accurate":["protocols/define/PROTOCOL.md"],"follow_up_work_units":[]}}}}}}}}'
                         ;;
                       *)
                         printf 'unexpected protocol: %s\\n' "$protocol" >&2
@@ -335,7 +335,7 @@ class InteractiveSessionSurfaceTests(unittest.TestCase):
                 [agent_path, prompt_path, config_capture_path, runa_mcp, mcp_log_path],
             )
 
-            for expected_protocol in ["take", "plan", "implement", "verify"]:
+            for expected_protocol in ["define", "plan", "implement", "verify"]:
                 with self.subTest(protocol=expected_protocol):
                     env = groundwork_env()
                     env["GROUNDWORK_GATE_PROTOCOL"] = expected_protocol

--- a/tests/test_prose_conformance.py
+++ b/tests/test_prose_conformance.py
@@ -57,8 +57,8 @@ class ProseConformanceHelperTests(unittest.TestCase):
 
         self.assertEqual(manifest_producers, [boundary.protocol for boundary in boundaries])
         self.assertEqual([], [boundary for boundary in boundaries if not boundary.passed])
-        self.assertTrue(by_protocol["take"].scoped)
-        self.assertTrue(by_protocol["take"].schema_requires_work_unit)
+        self.assertTrue(by_protocol["define"].scoped)
+        self.assertTrue(by_protocol["define"].schema_requires_work_unit)
         self.assertFalse(by_protocol["decompose"].scoped)
         self.assertFalse(by_protocol["decompose"].schema_requires_work_unit)
 
@@ -71,21 +71,21 @@ class ProseConformanceHelperTests(unittest.TestCase):
             shutil.copytree(ROOT / "schemas", tree / "schemas")
             manifest = (ROOT / "manifest.toml").read_text(encoding="utf-8")
             manifest = manifest.replace(
-                'name = "take"\nscoped = true\nrequires = ["work-unit"]',
-                'name = "take"\nrequires = ["work-unit"]',
+                'name = "define"\nscoped = true\nrequires = ["work-unit"]',
+                'name = "define"\nrequires = ["work-unit"]',
                 1,
             )
             (tree / "manifest.toml").write_text(manifest, encoding="utf-8")
 
-            take = [
+            define = [
                 boundary
                 for boundary in helper.delivery_boundaries(tree)
-                if boundary.protocol == "take"
+                if boundary.protocol == "define"
             ][0]
 
-        self.assertFalse(take.passed)
-        self.assertFalse(take.scoped)
-        self.assertTrue(take.schema_requires_work_unit)
+        self.assertFalse(define.passed)
+        self.assertFalse(define.scoped)
+        self.assertTrue(define.schema_requires_work_unit)
 
     def test_delivery_boundary_explanation_removal_flips_semantic_result(self) -> None:
         helper = prose_conformance()
@@ -98,23 +98,23 @@ class ProseConformanceHelperTests(unittest.TestCase):
                 (ROOT / "manifest.toml").read_text(encoding="utf-8"),
                 encoding="utf-8",
             )
-            take = tree / "protocols" / "take" / "PROTOCOL.md"
+            define = tree / "protocols" / "define" / "PROTOCOL.md"
             body, substitutions = re.subn(
                 r"The object below\s+is MCP tool input, not artifact body[.]\s+"
                 r"`instance_id` is a tool parameter\s+that names the artifact instance;.*?"
                 r"must not appear in\s+the artifact body[.]\s*",
                 "",
-                take.read_text(encoding="utf-8"),
+                define.read_text(encoding="utf-8"),
                 count=1,
                 flags=re.DOTALL,
             )
             self.assertEqual(1, substitutions)
-            take.write_text(body, encoding="utf-8")
+            define.write_text(body, encoding="utf-8")
 
             boundary = [
                 boundary
                 for boundary in helper.delivery_boundaries(tree)
-                if boundary.protocol == "take"
+                if boundary.protocol == "define"
             ][0]
 
         self.assertTrue(boundary.passed)
@@ -131,21 +131,21 @@ class ProseConformanceHelperTests(unittest.TestCase):
                 (ROOT / "manifest.toml").read_text(encoding="utf-8"),
                 encoding="utf-8",
             )
-            take = tree / "protocols" / "take" / "PROTOCOL.md"
+            define = tree / "protocols" / "define" / "PROTOCOL.md"
             body, substitutions = re.subn(
                 r"Runa injects `work_unit` from session context; the\s+"
                 r"agent does not supply `work_unit`[.]",
                 "The schema carries work-unit identity.",
-                take.read_text(encoding="utf-8"),
+                define.read_text(encoding="utf-8"),
                 count=1,
             )
             self.assertEqual(1, substitutions)
-            take.write_text(body, encoding="utf-8")
+            define.write_text(body, encoding="utf-8")
 
             boundary = [
                 boundary
                 for boundary in helper.delivery_boundaries(tree)
-                if boundary.protocol == "take"
+                if boundary.protocol == "define"
             ][0]
 
         self.assertTrue(boundary.passed)
@@ -193,21 +193,21 @@ class ProseConformanceHelperTests(unittest.TestCase):
                 (ROOT / "manifest.toml").read_text(encoding="utf-8"),
                 encoding="utf-8",
             )
-            take = tree / "protocols" / "take" / "PROTOCOL.md"
+            define = tree / "protocols" / "define" / "PROTOCOL.md"
             body, substitutions = re.subn(
                 r"Runa validates the remaining artifact body fields against the contract\s+"
                 r"schema, persists the artifact, and records it in the artifact store[.]",
                 "Runa validates the contract schema and records the artifact.",
-                take.read_text(encoding="utf-8"),
+                define.read_text(encoding="utf-8"),
                 count=1,
             )
             self.assertEqual(1, substitutions)
-            take.write_text(body, encoding="utf-8")
+            define.write_text(body, encoding="utf-8")
 
             boundary = [
                 boundary
                 for boundary in helper.delivery_boundaries(tree)
-                if boundary.protocol == "take"
+                if boundary.protocol == "define"
             ][0]
 
         self.assertTrue(boundary.passed)

--- a/tests/test_protocol_artifact_delivery_docs.py
+++ b/tests/test_protocol_artifact_delivery_docs.py
@@ -72,7 +72,7 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
             [
                 "survey",
                 "decompose",
-                "take",
+                "define",
                 "plan",
                 "implement",
                 "verify",

--- a/tests/test_release_ceremony.py
+++ b/tests/test_release_ceremony.py
@@ -97,7 +97,7 @@ class ReleaseFixture:
             name = "claim"
 
             [[protocols]]
-            name = "take"
+            name = "define"
             requires = ["claim"]
             accepts = []
             produces = ["claim"]
@@ -120,7 +120,7 @@ class ReleaseFixture:
             """,
         )
         self.write("schemas/claim.schema.json", '{"type":"object"}\n')
-        self.write("protocols/take/PROTOCOL.md", "# Take\n")
+        self.write("protocols/define/PROTOCOL.md", "# Define\n")
         self.write("skills/orient/SKILL.md", "# Orient\n")
         self.write("README.md", "# Groundwork\n")
         self.write("RELEASING.md", "scripts/release-cut vX.Y.Z\nADR-0012\n")
@@ -239,7 +239,7 @@ class ReleaseCeremonyTests(unittest.TestCase):
             name = "claim"
 
             [[protocols]]
-            name = "take"
+            name = "define"
             requires = ["claim"]
             accepts = []
             produces = ["claim"]

--- a/tooling/prose_conformance.py
+++ b/tooling/prose_conformance.py
@@ -417,8 +417,8 @@ class EntrySurfaceCoherence:
     acquire_reads_ticket_comments: bool
     acquire_surfaces_comments_as_entry_context: bool
     acquire_excludes_comments_from_artifact: bool
-    take_grounds_frame_in_whole_ticket: bool
-    take_uses_newest_review_directives: bool
+    define_grounds_frame_in_whole_ticket: bool
+    define_uses_newest_review_directives: bool
 
     @property
     def passed(self) -> bool:
@@ -426,14 +426,14 @@ class EntrySurfaceCoherence:
             self.acquire_reads_ticket_comments
             and self.acquire_surfaces_comments_as_entry_context
             and self.acquire_excludes_comments_from_artifact
-            and self.take_grounds_frame_in_whole_ticket
-            and self.take_uses_newest_review_directives
+            and self.define_grounds_frame_in_whole_ticket
+            and self.define_uses_newest_review_directives
         )
 
 
 def entry_surface_coherence(root: Path) -> EntrySurfaceCoherence:
     acquire = read(root / "skills" / "acquire" / "SKILL.md")
-    take = read(root / "protocols" / "take" / "PROTOCOL.md")
+    define = read(root / "protocols" / "define" / "PROTOCOL.md")
     return EntrySurfaceCoherence(
         acquire_reads_ticket_comments=(
             "`comments`" in acquire
@@ -458,16 +458,16 @@ def entry_surface_coherence(root: Path) -> EntrySurfaceCoherence:
             r"\bnever persisted\b",
             r"\bartifact\b",
         ),
-        take_grounds_frame_in_whole_ticket=(
-            has_semantic_clause(take, r"\bGround\b", r"\bwhole ticket\b")
+        define_grounds_frame_in_whole_ticket=(
+            has_semantic_clause(define, r"\bGround\b", r"\bwhole ticket\b")
             and has_semantic_clause(
-                take,
+                define,
                 r"\bcomment log\b",
                 r"\brunning record\b",
             )
         ),
-        take_uses_newest_review_directives=has_semantic_clause(
-            take,
+        define_uses_newest_review_directives=has_semantic_clause(
+            define,
             r"\bnewest\b",
             r"\breview directives\b",
             r"\bsubmitted head\b",


### PR DESCRIPTION
## Summary

Implements #529 against the plan of record (comment 4883474754) and the Fable contract of record (comment 4883373890).

- Regenerates the scoped entry protocol from `take` to `define`, preserving the `contract` artifact name/schema/tool and bumping the protocol to 4.0.0.
- Removes the auto-advance prose from the entry capstone while preserving the runtime-less fallback.
- Sweeps the live protocol, skill, documentation, tooling, and test register references to `define`, leaving ADRs and prior changelog history intact.
- Adds the `[Unreleased]` changelog entry for the breaking rename, migration points, capstone normalization, and unchanged contract artifact surface.

## Validation

- Register-first RED confirmed before production changes: renamed/updated register failed against the still-`take` tree with missing `define` manifest/path/field authorities.
- `python -m tooling.conformance` -> 21 passed, 0 failed.
- Focused affected tests -> 52 passed.
- `python -m pytest` -> 441 passed, 3 skipped, with only the two pre-recorded local `runa-mcp 0.2.0-rc.1` subtest failures in `tests/test_interactive_session_surface.py::InteractiveSessionSurfaceTests::test_completion_evidence_persist_rejects_contract_mismatches` (`completion-unknown`, `completion-missing`). This matches the plan's documented local environment skew; CI is the suite-green authority.
- `git diff --check` clean.
- No diff under `docs/architecture/decisions/` or `schemas/contract.schema.json`.

Closes #529.
