### PR TITLE
docs(work-unit-craft): comment log carries resumption state (#481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **The comment log carries resumption state** (#481).
+  `skills/work-unit-craft/SKILL.md` §"The Body Is the Spec; Comments Are a
+  Log" (v1.4.0) gains the resumption obligation: a progress comment carries,
+  in positive form, where the work stands and the immediate next move, as the
+  cross-role coordination contract any role — a resuming instance, a delegated
+  agent, the operator — reconstructs working state from. The obligation is
+  bounded as state, not direction: the body stays the standalone spec and the
+  `stale-comment-direction` guard is untouched. Pinned by
+  `tests/test_work_unit_craft_skill.py`.
+
 - **Verification-craft surface for vocabulary-proxy gates** (#523).
   `skills/verification-craft/SKILL.md` gives contributors the durable rule
   from the #477/#522 arc: a prose/text-artifact gate consults the invariant,

--- a/skills/work-unit-craft/SKILL.md
+++ b/skills/work-unit-craft/SKILL.md
@@ -9,8 +9,8 @@ description: >-
   and the corruption modes that make records mis-steer the agents who
   read them.
 metadata:
-  version: "1.3.1"
-  updated: "2026-07-03"
+  version: "1.4.0"
+  updated: "2026-07-05"
   origin: >-
     Adapted from pentaxis93/with-claude
     _shared/methodology/issue-craft.md (internal), renamed and
@@ -187,6 +187,27 @@ verification results, dependency signals, and a record that a decision was
 body. If a comment's direction is later superseded, either it is harmless
 history (a finding that still holds) or it must be explicitly marked
 superseded so it cannot be read as live.
+
+**The resumption obligation.** A progress comment carries, in positive
+form, *where the work stands and the immediate next move* — not merely that
+progress happened, but the working state a successor resumes from. The
+comment log is the one surface that survives a context loss which takes the
+working clone with it, so it is where working state is reconstructed: any
+role picking the unit up — a resuming instance of the same worker, a
+delegated agent, the operator — recovers where the work stands and what
+comes next from the log alone, without re-asking what the prior worker
+already knew. This is the cross-role coordination contract the log carries,
+and it makes capture a byproduct of coordinating rather than a separate act
+skipped under load.
+
+This is **state, not direction.** The comment *reports* working state — "the
+plan is reviewed sound; next is the PR at the committed head" — it does not
+carry live direction that competes with the body's spec. The body remains
+the single standalone source of the unit's contract (above); the
+`stale-comment-direction` guard is untouched, because a report of where the
+work stands is not a redefinition of what the work is. A resumption comment
+that drifted into re-specifying the contract would be that guard's failure,
+not this obligation's fulfillment.
 
 ## Corruption Modes
 

--- a/tests/test_work_unit_craft_skill.py
+++ b/tests/test_work_unit_craft_skill.py
@@ -110,6 +110,27 @@ class WorkUnitCraftSkillTests(unittest.TestCase):
             with self.subTest(heading=heading):
                 self.assertIn(expected_text, normalized(section(body, heading)))
 
+    def test_comment_log_carries_the_resumption_obligation(self) -> None:
+        # The skill is the single home of its own comment-log rule, so this
+        # gate is coherence over the section's own prose (no external
+        # authority to consult), anchored on the obligation's defining terms
+        # and the stale-comment-direction symbol it defers to — not a
+        # synonym sweep.
+        comment_log = normalized(
+            section(read_work_unit_craft(), "The Body Is the Spec; Comments Are a Log")
+        )
+
+        # The obligation carries where-it-stands and the next move.
+        self.assertIn("where the work stands", comment_log)
+        self.assertRegex(comment_log, r"\bimmediate next move\b")
+        # It serves the cross-role recipients, reconstructed from the log.
+        self.assertIn("resuming instance", comment_log)
+        self.assertIn("delegated agent", comment_log)
+        self.assertIn("operator", comment_log)
+        # Bounded as state, not direction — the guard is named and stays intact.
+        self.assertIn("state, not direction", comment_log)
+        self.assertIn("stale-comment-direction", comment_log)
+
     def test_primary_workflow_authors_contract_inputs_for_every_dimension(self) -> None:
         body = read_work_unit_craft()
         contract_inputs = section_between(body, "Author Contract Inputs", "The Sovereignty Test")


### PR DESCRIPTION
Extends `skills/work-unit-craft/SKILL.md` §"The Body Is the Spec; Comments Are a Log" with the **resumption obligation** (#481): a progress comment carries, in positive form, *where the work stands and the immediate next move*, framed as the cross-role coordination contract any role — a resuming instance, a delegated agent, the operator — reconstructs working state from.

**Bounded as state, not direction.** The body remains the standalone spec; the `stale-comment-direction` guard is untouched.

**Acceptance criteria:**
- AC1 — the section states the resumption obligation (where-it-stands + next move, positive form).
- AC2 — names the cross-role recipients and reconstruction from the log.
- AC3 — bounded as state, not direction; the `stale-comment-direction` guard remains intact.
- AC4 — coherent with the craft contract; contradicts no corruption mode.

**Enforcing drift check:** a coherence pin in `tests/test_work_unit_craft_skill.py` (the skill is the single home of its rule → coherence over its own prose, not a synonym sweep).

work-unit-craft `1.3.1 → 1.4.0`. CHANGELOG updated. Suite green: `unittest discover` 444 tests OK (7 known runa-binary skips); `tooling.conformance` 21 passed.

Closes #481.