### PR TITLE
[codex] feat(acquire): freshen inherited work units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Freshening is built into acquisition** (#465). `acquire` (v2.0.0) now
+  re-grounds an inherited ticket body and dependency graph before delivery,
+  records exactly one typed freshen disposition, and admits the work-unit to
+  `define` only when the disposition is `proceed-as-freshened`. The freshen
+  record is single-homed in `schemas/freshen-record.schema.json` as a tracker
+  comment substrate, with conformance gates in `tooling/prose_conformance.py`
+  and `tests/test_freshen_conformance.py` binding the disposition set, record
+  elements, graph facets, and withhold rule to the schema and manifest.
+
 - **The comment log carries resumption state** (#481).
   `skills/work-unit-craft/SKILL.md` §"The Body Is the Spec; Comments Are a
   Log" (v1.4.0) gains the resumption obligation: a progress comment carries,

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -15,6 +15,12 @@ Mechanic parameters are shell environment variable names because invocation
 data is supplied through the child process environment; secret parameters use
 `secret = true` and must remain values, not rendered command text.
 
+`freshen-record.schema.json` is an authoring substrate for acquisition
+freshening records. It is validated by the general schema conformance sweep,
+not declared as a runtime artifact type in `manifest.toml`: the record's home
+is a tracker comment on the acquired ticket, while the delivered runtime
+artifact remains the re-materialized `work-unit`.
+
 `change-proposal.schema.json`, `change-approved.schema.json`, and
 `change-needs-revision.schema.json` are the C-4 artifact schemas for the
 submit -> review handoff from ADR-0002 and ADR-0003. `change-proposal`

--- a/schemas/freshen-record.schema.json
+++ b/schemas/freshen-record.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/freshen-record.schema.json",
+  "title": "Freshen Record",
+  "description": "Authoring-substrate schema for the tracker comment recording an acquired work-unit freshen pass. The record is a log entry on the ticket, not a runtime artifact.",
+  "type": "object",
+  "required": [
+    "work_unit",
+    "grounded_against",
+    "staleness_finding",
+    "graph_finding",
+    "disposition"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "work_unit": {
+      "type": "string",
+      "description": "Common envelope - threads to work unit.",
+      "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
+    },
+    "grounded_against": {
+      "type": "object",
+      "description": "Current substrate the freshen pass grounded against.",
+      "required": ["commit", "grounded_at", "tracker_state"],
+      "additionalProperties": false,
+      "properties": {
+        "commit": {
+          "type": "string",
+          "description": "Repository commit or immutable source identifier consulted during grounding.",
+          "minLength": 1
+        },
+        "grounded_at": {
+          "type": "string",
+          "description": "Timestamp when the grounding pass was performed.",
+          "format": "date-time"
+        },
+        "tracker_state": {
+          "type": "string",
+          "description": "Tracker state consulted for the ticket body and dependency graph.",
+          "minLength": 1
+        }
+      }
+    },
+    "staleness_finding": {
+      "type": "string",
+      "description": "Present finding naming what was stale or thin and what changed, or stating that grounding found the body current.",
+      "minLength": 1
+    },
+    "graph_finding": {
+      "type": "object",
+      "description": "Present finding for every dependency-graph facet on the acquired unit.",
+      "required": [
+        "blockers",
+        "blocked",
+        "epic_membership",
+        "siblings",
+        "milestone",
+        "labels"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "blockers": {
+          "type": "string",
+          "description": "Finding for blocking work-units and their current state.",
+          "minLength": 1
+        },
+        "blocked": {
+          "type": "string",
+          "description": "Finding for work-units blocked by this unit and their current state.",
+          "minLength": 1
+        },
+        "epic_membership": {
+          "type": "string",
+          "description": "Finding for parent epic membership or absence.",
+          "minLength": 1
+        },
+        "siblings": {
+          "type": "string",
+          "description": "Finding for sibling or duplicate work-unit state.",
+          "minLength": 1
+        },
+        "milestone": {
+          "type": "string",
+          "description": "Finding for milestone currency or absence.",
+          "minLength": 1
+        },
+        "labels": {
+          "type": "string",
+          "description": "Finding for label accuracy against current tracker state.",
+          "minLength": 1
+        }
+      }
+    },
+    "disposition": {
+      "type": "string",
+      "description": "Exactly one typed freshen disposition selected before any re-craft.",
+      "enum": [
+        "proceed-as-freshened",
+        "close",
+        "split",
+        "relink",
+        "reblock",
+        "reframe-as-spike"
+      ]
+    }
+  }
+}

--- a/skills/acquire/SKILL.md
+++ b/skills/acquire/SKILL.md
@@ -8,8 +8,8 @@ description: >-
   of decompose's create path: decompose creates the ticket it delivers;
   acquire adopts the ticket it is given, and creates no ticket.
 metadata:
-  version: "1.1.0"
-  updated: "2026-07-02"
+  version: "2.0.0"
+  updated: "2026-07-05"
 ---
 
 # Acquire
@@ -18,15 +18,18 @@ The scoped pipeline activates on a `work-unit` artifact, but the live
 planning surface is the forge tracker. Acquisition is the bridge for the
 natural developer entry — "start on ticket #N" — when that ticket already
 exists and no work-unit artifact does yet. It reads the ticket and
-materializes the work-unit artifact; `define` then proceeds unchanged on that
-artifact through its existing contract.
+materializes the work-unit artifact. Before the artifact is delivered,
+acquisition freshens the inherited frame against current substrate and chooses
+one typed disposition; only a `proceed-as-freshened` disposition lets `define`
+proceed on the artifact through its existing contract.
 
 Acquisition is **one-way**: the ticket is the planning home, the artifact is
-its execution-scoped snapshot, and `handle` is the back-link. Nothing here
-writes artifact content back to the ticket, and nothing here creates a
-ticket — acquisition *adopts* the ticket it is given. An acquired work-unit
-is indistinguishable downstream from a decomposed one: same `handle`, same
-`work-unit-<N>-<short-slug>` instance-id convention.
+its execution-scoped snapshot, and `handle` is the back-link. Freshening may
+repair the ticket body at the planning home before delivery, then re-materialize
+from that source; it never writes artifact content back into the ticket body,
+and it never creates a ticket. Acquisition *adopts* the ticket it is given. An
+acquired work-unit is indistinguishable downstream from a decomposed one: same
+`handle`, same `work-unit-<N>-<short-slug>` instance-id convention.
 
 This is a skill, not a protocol, because it runs when there is no artifact
 state for a trigger to fire on. It belongs to whatever surface hosts a
@@ -77,8 +80,78 @@ cold start.
    re-acquire. Do not hand-fill the missing fields here — that would forge an
    execution snapshot the planning home never authorized.
 
-4. **Deliver the `work-unit` artifact.** Invoke the `work-unit` MCP tool with
-   the materializer's `instance_id` and `artifact` body — the same call shape
+4. **Freshen the acquired work-unit.**
+   The materialized artifact is held until the freshen pass completes. This is
+   the single acquisition boundary shared by autonomous and interactive
+   sessions; session mode is a property of the session, not a second acquisition path
+   ([commons ADR-0015](https://github.com/tesserine/commons/blob/main/adr/0015-mode-is-a-property-of-the-session.md)).
+
+   Run the pass before `define` claims the ticket:
+
+   1. Ground the ticket body against the current tree at the current base commit:
+      verify identifiers, paths, behaviors, and acceptance criteria against
+      current substrate, using the already-surfaced comment log for staleness
+      and directive context.
+   2. Ground the dependency graph against live tracker state: verify blockers,
+      blocked units, epic membership, siblings, milestone, and labels.
+   3. Re-reckon the frame by consulting [reckon](../reckon/SKILL.md): trace the
+      inherited frame to the current need it must serve.
+   4. Choose exactly one typed disposition from the routing table below before
+      any re-craft.
+   5. When proceeding after staleness or thinness, re-craft the ticket body at
+      the planning home by consulting [work-unit-craft](../work-unit-craft/SKILL.md),
+      then re-run `skills/acquire/scripts/materialize.py` on the freshened body
+      so the delivered artifact is a faithful snapshot of a standalone,
+      currently-verifiable spec. When grounding finds the body current, proceed
+      without re-craft.
+   6. Validate the freshen record against the
+      [freshen-record schema](../../schemas/freshen-record.schema.json). The
+      record is posted to the ticket as a comment before the disposition takes
+      effect.
+
+   A defective substrate finding escalates to [resolve](../resolve/SKILL.md) as
+   a side quest: freshen repairs the unit, resolve repairs the substrate.
+
+### Freshen routing table
+
+| Disposition | Consequence | Onward route |
+|-------------|-------------|--------------|
+| proceed-as-freshened | Artifact delivery admits the unit to define. | Deliver the re-materialized work-unit artifact. |
+| close | Acquisition ends without artifact delivery. | Close the tracker ticket with the freshen record as the rationale. |
+| split | Acquisition ends without artifact delivery. | Route to `decompose`'s `refine-work-unit` discipline to split the ticket, then acquire the resulting ready unit. |
+| relink | Acquisition ends without artifact delivery. | Repair tracker links or merge the duplicate, then re-acquire or close. |
+| reblock | Acquisition ends without artifact delivery. | Record the blocking edges in the tracker and leave the unit waiting unmaterialized. |
+| reframe-as-spike | Acquisition ends without artifact delivery. | File a spike work-unit using [work-unit-craft](../work-unit-craft/SKILL.md)'s spike form. |
+
+### Graph facets
+
+| Facet | Finding required |
+|-------|------------------|
+| blockers | State of work-units blocking this unit. |
+| blocked | State of work-units this unit blocks. |
+| epic_membership | Current parent epic membership or confirmed absence. |
+| siblings | Current sibling, duplicate, or absorbed-scope state. |
+| milestone | Current milestone assignment and currency, or confirmed absence. |
+| labels | Current label accuracy. |
+
+### Freshen record contract
+
+| Element | Meaning |
+|---------|---------|
+| work_unit | The acquired work-unit identity the record threads to. |
+| grounded_against | The commit, grounding timestamp, and tracker state consulted. |
+| staleness_finding | What was stale or thin and what changed, or that the body is current. |
+| graph_finding | Present finding for every dependency-graph facet above. |
+| disposition | The single typed disposition selected by the pass. |
+
+   The freshen record is a positive log entry in the running record acquire
+   already reads. It is never written into the work-unit body; the freshened
+   unit's body carries only the re-crafted spec.
+
+5. **Deliver the `work-unit` artifact.**
+   Deliver the work-unit artifact only under a recorded `proceed-as-freshened` disposition.
+   Invoke the `work-unit` MCP tool with the materializer's `instance_id` and
+   `artifact` body — the same call shape
    `decompose` uses for a tracker-backed work-unit, with the ticket's
    `handle` carried unchanged. `work-unit` is a planning-phase artifact: the
    agent supplies the schema fields and runa does not inject `work_unit`. Do
@@ -98,10 +171,10 @@ cold start.
    records it. The cascade then computes `define` as the next station on the
    acquired artifact.
 
-5. **Hand off to `define`.** Acquisition materializes; `define` claims. Tracker
-   claiming (assigning the ticket, marking it in progress) is `define`'s
-   workspace-preparation step, not acquisition's — keep the one-way boundary
-   clean.
+6. **Hand off to `define`.** Acquisition freshens and materializes only when the
+   disposition proceeds; `define` claims. Tracker claiming (assigning the
+   ticket, marking it in progress) is `define`'s workspace-preparation step,
+   not acquisition's — keep the one-way boundary clean.
 
 ## Corruption Modes
 
@@ -115,8 +188,11 @@ cold start.
 - `content-fabrication`: hand-filling acceptance criteria or a description
   the ticket does not contain, instead of routing the gap to refinement. The
   artifact must be a faithful snapshot of the planning home.
-- `write-back`: editing the ticket from acquisition (beyond `define`'s later
-  claim). Derivation is one-way.
+- `stale-acquisition`: delivering an acquired work-unit after materialization
+  without grounding its body and dependency graph against current substrate.
+- `write-back`: editing the ticket from artifact content, or editing anything
+  beyond planning-home repair authorized by freshening or `refine-work-unit`.
+  Derivation is one-way: ticket body to artifact body.
 - `handle-drift`: re-deriving or altering the `handle` instead of carrying
   the ticket's identity through verbatim — breaks the back-link and risks a
   downstream identity collision.
@@ -127,6 +203,8 @@ cold start.
   of `refine-work-unit` — where a ticket-quality gap surfaced here is fixed.
 - `define` (protocol): proceeds on the acquired artifact through its existing
   contract; owns tracker claiming.
+- `schemas/freshen-record.schema.json`: the single home for the freshen record
+  fields, dependency-graph facets, and typed disposition set.
 - `read-ticket` (connector capability operation): emits
   `{handle, title, body, state}` and, per forge-capability `1.2.0`, the
   optional ordered `comments` log for the selected connector.

--- a/tests/fixtures/freshen-record/invalid-compound-disposition.json
+++ b/tests/fixtures/freshen-record/invalid-compound-disposition.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "1e751e9b",
+    "grounded_at": "2026-07-05T08:57:19Z",
+    "tracker_state": "issue body and dependency graph at acquisition"
+  },
+  "staleness_finding": "The unit remains current.",
+  "graph_finding": {
+    "blockers": "No blockers.",
+    "blocked": "No blocked units.",
+    "epic_membership": "No epic.",
+    "siblings": "No siblings.",
+    "milestone": "No milestone.",
+    "labels": "Labels are current."
+  },
+  "disposition": "split, and also reblocked"
+}

--- a/tests/fixtures/freshen-record/invalid-empty-finding.json
+++ b/tests/fixtures/freshen-record/invalid-empty-finding.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "1e751e9b",
+    "grounded_at": "2026-07-05T08:57:19Z",
+    "tracker_state": "issue body and dependency graph at acquisition"
+  },
+  "staleness_finding": "",
+  "graph_finding": {
+    "blockers": "No blockers.",
+    "blocked": "No blocked units.",
+    "epic_membership": "No epic.",
+    "siblings": "No siblings.",
+    "milestone": "No milestone.",
+    "labels": "Labels are current."
+  },
+  "disposition": "proceed-as-freshened"
+}

--- a/tests/fixtures/freshen-record/invalid-missing-disposition.json
+++ b/tests/fixtures/freshen-record/invalid-missing-disposition.json
@@ -1,0 +1,17 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "1e751e9b",
+    "grounded_at": "2026-07-05T08:57:19Z",
+    "tracker_state": "issue body and dependency graph at acquisition"
+  },
+  "staleness_finding": "The unit remains current.",
+  "graph_finding": {
+    "blockers": "No blockers.",
+    "blocked": "No blocked units.",
+    "epic_membership": "No epic.",
+    "siblings": "No siblings.",
+    "milestone": "No milestone.",
+    "labels": "Labels are current."
+  }
+}

--- a/tests/fixtures/freshen-record/invalid-out-of-set-disposition.json
+++ b/tests/fixtures/freshen-record/invalid-out-of-set-disposition.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "1e751e9b",
+    "grounded_at": "2026-07-05T08:57:19Z",
+    "tracker_state": "issue body and dependency graph at acquisition"
+  },
+  "staleness_finding": "The unit remains current.",
+  "graph_finding": {
+    "blockers": "No blockers.",
+    "blocked": "No blocked units.",
+    "epic_membership": "No epic.",
+    "siblings": "No siblings.",
+    "milestone": "No milestone.",
+    "labels": "Labels are current."
+  },
+  "disposition": "proceed-with-caveats"
+}

--- a/tests/fixtures/freshen-record/valid-close.json
+++ b/tests/fixtures/freshen-record/valid-close.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "1e751e9b",
+    "grounded_at": "2026-07-05T08:57:19Z",
+    "tracker_state": "issue body, comment log, labels, milestone, and linked issue state at acquisition"
+  },
+  "staleness_finding": "The current substrate shows the unit should be closed instead of implemented as authored.",
+  "graph_finding": {
+    "blockers": "No blocking work-units remain open.",
+    "blocked": "No downstream blocked work-units require relinking before entry.",
+    "epic_membership": "No parent epic membership changed.",
+    "siblings": "A sibling absorbed the remaining scope.",
+    "milestone": "No milestone is assigned.",
+    "labels": "The enhancement label remains accurate."
+  },
+  "disposition": "close"
+}

--- a/tests/fixtures/freshen-record/valid-proceed-as-freshened.json
+++ b/tests/fixtures/freshen-record/valid-proceed-as-freshened.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "1e751e9b",
+    "grounded_at": "2026-07-05T08:57:19Z",
+    "tracker_state": "issue body, comment log, labels, milestone, and linked issue state at acquisition"
+  },
+  "staleness_finding": "The ticket body was re-grounded against current substrate and re-crafted where stale; the acceptance criteria are currently verifiable.",
+  "graph_finding": {
+    "blockers": "No blocking work-units remain open.",
+    "blocked": "No downstream blocked work-units require relinking before entry.",
+    "epic_membership": "No parent epic membership changed.",
+    "siblings": "No sibling or duplicate absorbed this scope.",
+    "milestone": "No milestone is assigned.",
+    "labels": "The enhancement label remains accurate."
+  },
+  "disposition": "proceed-as-freshened"
+}

--- a/tests/fixtures/freshen-record/valid-reblock.json
+++ b/tests/fixtures/freshen-record/valid-reblock.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "1e751e9b",
+    "grounded_at": "2026-07-05T08:57:19Z",
+    "tracker_state": "issue body, comment log, labels, milestone, and linked issue state at acquisition"
+  },
+  "staleness_finding": "The work remains valid, but current substrate reveals a blocker that must close first.",
+  "graph_finding": {
+    "blockers": "One blocking work-unit is open.",
+    "blocked": "No downstream blocked work-units require relinking before entry.",
+    "epic_membership": "No parent epic membership changed.",
+    "siblings": "No sibling or duplicate absorbed this scope.",
+    "milestone": "No milestone is assigned.",
+    "labels": "The enhancement label remains accurate."
+  },
+  "disposition": "reblock"
+}

--- a/tests/fixtures/freshen-record/valid-reframe-as-spike.json
+++ b/tests/fixtures/freshen-record/valid-reframe-as-spike.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "1e751e9b",
+    "grounded_at": "2026-07-05T08:57:19Z",
+    "tracker_state": "issue body, comment log, labels, milestone, and linked issue state at acquisition"
+  },
+  "staleness_finding": "The current frame depends on an unresolved design question and must become a spike.",
+  "graph_finding": {
+    "blockers": "No blocking work-units remain open.",
+    "blocked": "No downstream blocked work-units require relinking before entry.",
+    "epic_membership": "No parent epic membership changed.",
+    "siblings": "No sibling or duplicate absorbed this scope.",
+    "milestone": "No milestone is assigned.",
+    "labels": "The enhancement label remains accurate."
+  },
+  "disposition": "reframe-as-spike"
+}

--- a/tests/fixtures/freshen-record/valid-relink.json
+++ b/tests/fixtures/freshen-record/valid-relink.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "1e751e9b",
+    "grounded_at": "2026-07-05T08:57:19Z",
+    "tracker_state": "issue body, comment log, labels, milestone, and linked issue state at acquisition"
+  },
+  "staleness_finding": "The body remains useful, but current tracker links show it must be relinked before entry.",
+  "graph_finding": {
+    "blockers": "A former blocker closed and should be removed.",
+    "blocked": "Blocked units remain linked to the current deliverable.",
+    "epic_membership": "The unit belongs under a different parent epic.",
+    "siblings": "A duplicate candidate requires merge resolution.",
+    "milestone": "The milestone remains current.",
+    "labels": "The enhancement label remains accurate."
+  },
+  "disposition": "relink"
+}

--- a/tests/fixtures/freshen-record/valid-split.json
+++ b/tests/fixtures/freshen-record/valid-split.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "1e751e9b",
+    "grounded_at": "2026-07-05T08:57:19Z",
+    "tracker_state": "issue body, comment log, labels, milestone, and linked issue state at acquisition"
+  },
+  "staleness_finding": "The current need exceeds one session-sized unit and must be split before implementation.",
+  "graph_finding": {
+    "blockers": "No blocking work-units remain open.",
+    "blocked": "Downstream work depends on only part of this scope.",
+    "epic_membership": "The parent epic remains current.",
+    "siblings": "Sibling units divide adjacent scope.",
+    "milestone": "The milestone remains current.",
+    "labels": "The enhancement label remains accurate."
+  },
+  "disposition": "split"
+}

--- a/tests/test_freshen_conformance.py
+++ b/tests/test_freshen_conformance.py
@@ -1,0 +1,142 @@
+import copy
+import json
+import re
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from tooling.conformance import run_conformance
+from tooling.prose_conformance import (
+    FRESHEN_ADR_0015_URL,
+    freshen_dispositions,
+    freshen_graph_facets,
+    freshen_record_elements,
+    freshen_record_schema,
+    freshen_surface_coherence,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "freshen-record"
+SCHEMA = ROOT / "schemas" / "freshen-record.schema.json"
+ACQUIRE = ROOT / "skills" / "acquire" / "SKILL.md"
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validator(schema: dict | None = None) -> Draft202012Validator:
+    return Draft202012Validator(schema if schema is not None else freshen_record_schema(ROOT))
+
+
+def schema_errors(record: dict, schema: dict | None = None) -> list[str]:
+    return [error.message for error in validator(schema).iter_errors(record)]
+
+
+def valid_record(disposition: str = "proceed-as-freshened") -> dict:
+    record = load_json(FIXTURES / "valid-proceed-as-freshened.json")
+    record["disposition"] = disposition
+    return record
+
+
+class FreshenRecordSchemaTests(unittest.TestCase):
+    def test_conformance_discovers_freshen_record_schema(self) -> None:
+        results = run_conformance([SCHEMA])
+
+        self.assertEqual([SCHEMA.resolve()], [result.path for result in results])
+        self.assertTrue(all(result.passed for result in results), results)
+
+    def test_valid_fixture_exists_for_each_disposition(self) -> None:
+        schema = freshen_record_schema(ROOT)
+        for disposition in freshen_dispositions(schema):
+            with self.subTest(disposition=disposition):
+                fixture = FIXTURES / f"valid-{disposition}.json"
+                self.assertTrue(fixture.is_file())
+                self.assertEqual([], schema_errors(load_json(fixture), schema))
+
+    def test_invalid_disposition_shapes_fail(self) -> None:
+        for name in [
+            "invalid-missing-disposition.json",
+            "invalid-out-of-set-disposition.json",
+            "invalid-compound-disposition.json",
+        ]:
+            with self.subTest(fixture=name):
+                self.assertNotEqual([], schema_errors(load_json(FIXTURES / name)))
+
+    def test_required_record_elements_fail_when_missing(self) -> None:
+        schema = freshen_record_schema(ROOT)
+        for element in freshen_record_elements(schema):
+            with self.subTest(element=element):
+                record = valid_record()
+                del record[element]
+                self.assertNotEqual([], schema_errors(record, schema))
+
+    def test_graph_finding_requires_each_schema_facet(self) -> None:
+        schema = freshen_record_schema(ROOT)
+        for facet in freshen_graph_facets(schema):
+            with self.subTest(facet=facet):
+                record = valid_record()
+                del record["graph_finding"][facet]
+                self.assertNotEqual([], schema_errors(record, schema))
+
+    def test_nonfinding_strings_fail(self) -> None:
+        self.assertNotEqual([], schema_errors(load_json(FIXTURES / "invalid-empty-finding.json")))
+
+    def test_schema_required_mutation_turns_surface_projection_red(self) -> None:
+        schema = freshen_record_schema(ROOT)
+
+        record_schema = copy.deepcopy(schema)
+        record_schema["required"].remove("staleness_finding")
+        self.assertFalse(freshen_surface_coherence(ROOT, schema=record_schema).record_contract_matches_schema_required)
+
+        graph_schema = copy.deepcopy(schema)
+        graph_schema["properties"]["graph_finding"]["required"].remove("labels")
+        self.assertFalse(freshen_surface_coherence(ROOT, schema=graph_schema).graph_facets_match_schema_required)
+
+
+class FreshenAcquireSurfaceTests(unittest.TestCase):
+    def test_acquire_surface_is_gate_bound_to_freshen_schema_and_manifest(self) -> None:
+        coherence = freshen_surface_coherence(ROOT)
+
+        self.assertTrue(coherence.passed, coherence)
+
+    def test_withhold_conditioning_deletion_turns_gate_red(self) -> None:
+        surface = ACQUIRE.read_text(encoding="utf-8")
+        mutated, count = re.subn(
+            r"Deliver the work-unit artifact only under a recorded `proceed-as-freshened` disposition[.]",
+            "Deliver the work-unit artifact after the freshen pass.",
+            surface,
+            count=1,
+        )
+
+        self.assertEqual(1, count)
+        self.assertFalse(freshen_surface_coherence(ROOT, acquire_text=mutated).delivery_conditioned_on_proceed)
+
+    def test_routing_table_row_deletion_turns_projection_red(self) -> None:
+        surface = ACQUIRE.read_text(encoding="utf-8")
+        mutated, count = re.subn(
+            r"\| reblock \|.*\n",
+            "",
+            surface,
+            count=1,
+        )
+
+        self.assertEqual(1, count)
+        coherence = freshen_surface_coherence(ROOT, acquire_text=mutated)
+        self.assertFalse(coherence.routing_table_matches_disposition_enum)
+        self.assertFalse(coherence.routing_table_routes_every_disposition)
+
+    def test_adr_0015_url_is_the_canonical_commons_register_path(self) -> None:
+        self.assertEqual(
+            "https://github.com/tesserine/commons/blob/main/adr/0015-mode-is-a-property-of-the-session.md",
+            FRESHEN_ADR_0015_URL,
+        )
+        self.assertIn(FRESHEN_ADR_0015_URL, ACQUIRE.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/prose_conformance.py
+++ b/tooling/prose_conformance.py
@@ -476,6 +476,267 @@ def entry_surface_coherence(root: Path) -> EntrySurfaceCoherence:
     )
 
 
+FRESHEN_ADR_0015_URL = (
+    "https://github.com/tesserine/commons/blob/main/adr/"
+    "0015-mode-is-a-property-of-the-session.md"
+)
+
+
+def freshen_record_schema(root: Path) -> dict:
+    return json.loads(read(root / "schemas" / "freshen-record.schema.json"))
+
+
+def freshen_dispositions(schema: dict) -> list[str]:
+    disposition = schema_def(schema, "#/properties/disposition/enum")
+    if not isinstance(disposition, list):
+        raise AssertionError("freshen disposition enum must be a list")
+    return [str(value) for value in disposition]
+
+
+def freshen_graph_facets(schema: dict) -> list[str]:
+    facets = schema_def(schema, "#/properties/graph_finding/required")
+    if not isinstance(facets, list):
+        raise AssertionError("freshen graph facets must be schema-required list")
+    return [str(value) for value in facets]
+
+
+def freshen_record_elements(schema: dict) -> list[str]:
+    required = schema_def(schema, "#/required")
+    if not isinstance(required, list):
+        raise AssertionError("freshen record required fields must be a list")
+    return [str(value) for value in required]
+
+
+def protocol_triggering_on_artifact(root: Path, artifact: str) -> str:
+    matches = [
+        protocol["name"]
+        for protocol in manifest_protocols(root)
+        if protocol.get("trigger") == {"type": "on_artifact", "name": artifact}
+    ]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one protocol triggered by {artifact}, got {matches}")
+    return matches[0]
+
+
+@dataclass(frozen=True)
+class FreshenSurfaceCoherence:
+    freshen_step_is_step_four_once: bool
+    materialized_artifact_held_until_freshened: bool
+    routing_table_matches_disposition_enum: bool
+    routing_table_routes_every_disposition: bool
+    only_proceed_reaches_admitted_destination: bool
+    delivery_conditioned_on_proceed: bool
+    admitted_destination_trigger_is_work_unit: bool
+    record_contract_matches_schema_required: bool
+    graph_facets_match_schema_required: bool
+    record_is_ticket_comment_not_body: bool
+    proceed_recrafts_before_delivery: bool
+    grounds_body_and_graph_against_current_substrate: bool
+    shared_boundary_mode_parity_declared: bool
+    no_mode_specific_freshening_section: bool
+    defective_substrate_escalates_to_resolve: bool
+
+    @property
+    def passed(self) -> bool:
+        return all(
+            [
+                self.freshen_step_is_step_four_once,
+                self.materialized_artifact_held_until_freshened,
+                self.routing_table_matches_disposition_enum,
+                self.routing_table_routes_every_disposition,
+                self.only_proceed_reaches_admitted_destination,
+                self.delivery_conditioned_on_proceed,
+                self.admitted_destination_trigger_is_work_unit,
+                self.record_contract_matches_schema_required,
+                self.graph_facets_match_schema_required,
+                self.record_is_ticket_comment_not_body,
+                self.proceed_recrafts_before_delivery,
+                self.grounds_body_and_graph_against_current_substrate,
+                self.shared_boundary_mode_parity_declared,
+                self.no_mode_specific_freshening_section,
+                self.defective_substrate_escalates_to_resolve,
+            ]
+        )
+
+
+def _freshen_step_numbers(acquire: str) -> list[int]:
+    return [
+        int(match.group("number"))
+        for match in re.finditer(
+            r"^(?P<number>\d+)\. \*\*Freshen\b",
+            acquire,
+            flags=re.MULTILINE,
+        )
+    ]
+
+
+def _section_table_values(
+    text: str,
+    heading: str,
+    header: str,
+    *,
+    level: int = 3,
+) -> list[str]:
+    return [row[header] for row in markdown_table_rows(markdown_section(text, heading, level=level))]
+
+
+def freshen_surface_coherence(
+    root: Path,
+    *,
+    acquire_text: str | None = None,
+    schema: dict | None = None,
+) -> FreshenSurfaceCoherence:
+    acquire = acquire_text if acquire_text is not None else read(root / "skills" / "acquire" / "SKILL.md")
+    freshen_schema = schema if schema is not None else freshen_record_schema(root)
+    dispositions = freshen_dispositions(freshen_schema)
+    record_elements = freshen_record_elements(freshen_schema)
+    graph_facets = freshen_graph_facets(freshen_schema)
+    admitted_destination = protocol_triggering_on_artifact(root, "work-unit")
+
+    try:
+        freshen_step = numbered_step(acquire, 4)
+    except AssertionError:
+        freshen_step = ""
+    try:
+        delivery_step = numbered_step(acquire, 5)
+    except AssertionError:
+        delivery_step = ""
+
+    try:
+        routing_rows = markdown_table_rows(markdown_section(freshen_step, "Freshen routing table", level=3))
+    except AssertionError:
+        routing_rows = []
+    route_dispositions = [row.get("Disposition", "") for row in routing_rows]
+    route_by_disposition = {row.get("Disposition", ""): row for row in routing_rows}
+
+    try:
+        record_rows = markdown_table_rows(markdown_section(freshen_step, "Freshen record contract", level=3))
+    except AssertionError:
+        record_rows = []
+    record_rendered = [row.get("Element", "") for row in record_rows]
+
+    try:
+        facet_rendered = _section_table_values(
+            freshen_step,
+            "Graph facets",
+            "Facet",
+            level=3,
+        )
+    except AssertionError:
+        facet_rendered = []
+
+    non_proceed_rows = [
+        row
+        for row in routing_rows
+        if row.get("Disposition") != "proceed-as-freshened"
+    ]
+    proceed_row = route_by_disposition.get("proceed-as-freshened", {})
+    mode_specific_headings = re.findall(
+        r"^#{2,6} .*freshen.*(?:autonomous|interactive)|"
+        r"^#{2,6} .*(?:autonomous|interactive).*freshen",
+        acquire,
+        flags=re.IGNORECASE | re.MULTILINE,
+    )
+
+    return FreshenSurfaceCoherence(
+        freshen_step_is_step_four_once=_freshen_step_numbers(acquire) == [4],
+        materialized_artifact_held_until_freshened=has_semantic_clause(
+            freshen_step,
+            r"\bmaterialized artifact\b",
+            r"\bheld\b",
+            r"\bfreshen pass completes\b",
+        ),
+        routing_table_matches_disposition_enum=route_dispositions == dispositions,
+        routing_table_routes_every_disposition=(
+            len(routing_rows) == len(dispositions)
+            and all(row.get("Consequence", "").strip() for row in routing_rows)
+            and all(row.get("Onward route", "").strip() for row in routing_rows)
+        ),
+        only_proceed_reaches_admitted_destination=(
+            bool(proceed_row)
+            and admitted_destination in proceed_row.get("Consequence", "")
+            and all(
+                admitted_destination not in row.get("Consequence", "")
+                for row in non_proceed_rows
+            )
+            and all(
+                admitted_destination not in row.get("Onward route", "")
+                for row in non_proceed_rows
+            )
+        ),
+        delivery_conditioned_on_proceed=has_semantic_clause(
+            delivery_step,
+            r"\bdeliver\b",
+            r"\bonly\b",
+            r"`?proceed-as-freshened`?",
+        ),
+        admitted_destination_trigger_is_work_unit=(admitted_destination == "define"),
+        record_contract_matches_schema_required=record_rendered == record_elements,
+        graph_facets_match_schema_required=facet_rendered == graph_facets,
+        record_is_ticket_comment_not_body=(
+            has_semantic_clause(
+                freshen_step,
+                r"\brecord\b",
+                r"\bposted\b",
+                r"\bticket\b",
+                r"\bcomment\b",
+            )
+            and has_semantic_clause(
+                freshen_step,
+                r"\bfreshened unit'?s body\b",
+                r"\bonly\b",
+                r"\bspec\b",
+            )
+        ),
+        proceed_recrafts_before_delivery=(
+            has_semantic_clause(
+                freshen_step,
+                r"\bre-craft\b",
+                r"\bticket body\b",
+                r"\bplanning home\b",
+                r"\bwork-unit-craft\b",
+            )
+            and has_semantic_clause(
+                freshen_step,
+                r"\bre-run\b",
+                r"\bmaterialize.py\b",
+                r"\bstandalone\b",
+                r"\bcurrently-verifiable\b",
+            )
+        ),
+        grounds_body_and_graph_against_current_substrate=(
+            has_semantic_clause(
+                freshen_step,
+                r"\bticket body\b",
+                r"\bcurrent tree\b",
+                r"\bcurrent base commit\b",
+            )
+            and has_semantic_clause(
+                freshen_step,
+                r"\bdependency graph\b",
+                r"\blive tracker state\b",
+            )
+        ),
+        shared_boundary_mode_parity_declared=(
+            FRESHEN_ADR_0015_URL in freshen_step
+            and has_semantic_clause(
+                freshen_step,
+                r"\bsingle acquisition boundary\b",
+                r"\bautonomous\b",
+                r"\binteractive\b",
+            )
+        ),
+        no_mode_specific_freshening_section=not mode_specific_headings,
+        defective_substrate_escalates_to_resolve=has_semantic_clause(
+            freshen_step,
+            r"\bdefective substrate\b",
+            r"\bresolve\b",
+            r"\bfreshen repairs the unit\b",
+            r"\bresolve repairs the substrate\b",
+        ),
+    )
+
+
 @dataclass(frozen=True)
 class SessionSurfaceHandoffCommitments:
     has_single_marker_pair: bool


### PR DESCRIPTION
## Summary

- Builds freshening into the acquire skill before work-unit delivery.
- Adds `schemas/freshen-record.schema.json` as the single home for freshen dispositions, record fields, and graph facets.
- Adds prose/schema conformance gates and fixtures so the acquire surface stays bound to the schema and manifest.
- Documents the schema substrate and records the user-visible change in the changelog.

Closes #465.

## Verification

- `python -m unittest tests.test_freshen_conformance`
- `python -m unittest tests.test_acquisition tests.test_forge_capability` (3 skipped)
- `python -m unittest tests.test_prose_conformance tests.test_reference_links`
- `python -m unittest tests.test_dependency_graph_notation`
- `python -m tooling.conformance`
- `git diff --check`

Full `python -m unittest discover -s tests` was run and now fails only the two ambient `runa-mcp 0.2.0-rc.1` completion-evidence mismatch cases noted in the #465 plan: `completion-unknown` and `completion-missing` are accepted by the local `runa-mcp` instead of rejected.
