### PR TITLE
[codex] Add tidy-up canonical clean skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Tidy-up leaves run worktrees canonical-clean** (#518).
+  `skills/tidy-up/SKILL.md` introduces the post-run repository hygiene
+  discipline at v1.0.0 and ships `skills/tidy-up/scripts/tidy_up.py` as the
+  single executable mechanics home for `land`, `abandon`, `halt`, and
+  `verify`. The skill names the four canonical-clean checks, preserves landed
+  work and ignored files, and reports named residuals loudly on partial
+  cleanup. `land` 3.3.0->3.4.0 invokes tidy-up as Step 6 after
+  completion-record delivery; `contract` 2.7.1->2.8.0 routes abandoned and
+  regenerated runs through tidy-up before fresh derivation; `orient`
+  4.1.1->4.2.0 records the run-lifecycle rule including halt. README and the
+  ontology audit expose the new skill. Pinned by
+  `tests/test_tidy_up_skill.py` and `tests/test_tidy_up_mechanics.py`.
+
 - **The comment log carries resumption state** (#481).
   `skills/work-unit-craft/SKILL.md` §"The Body Is the Spec; Comments Are a
   Log" (v1.4.0) gains the resumption obligation: a progress comment carries,

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ stage-specific judgment:
   the discipline for authoring verification gates over prose and text artifacts
 - **code-review** — review judgment for submitted change proposals
 - **acquire** — entry from an existing forge ticket: materializes the work-unit artifact define activates on
+- **tidy-up** — [`skills/tidy-up/SKILL.md`](skills/tidy-up/SKILL.md),
+  the canonical clean post-run worktree discipline for land, abandonment or regeneration, and halt
 
 Not every piece of work needs every stage. A bug with an existing work-unit enters
 at execution. A new capability enters at planning. The constraint is sequence,

--- a/docs/architecture/groundwork-skill-ontology-row-1-audit.md
+++ b/docs/architecture/groundwork-skill-ontology-row-1-audit.md
@@ -15,7 +15,7 @@ before the ADR distills the seam.
 
 ## Method
 
-The audit reads the 19 live row-1 assets: 10 skills under `skills/` and 9
+The audit reads the 20 live row-1 assets: 11 skills under `skills/` and 9
 protocols under `protocols/`. Each asset is placed on the two axes from the
 foundation note:
 
@@ -45,6 +45,7 @@ Groundwork scoped pipeline.
 | reckon | skill | universal | skill | First-principles grounding and traceable reasoning are domain-neutral; gazette's editorial choices also need constraints before inherited frames. |
 | research | skill | universal | skill | Systematic external-evidence gathering projects directly to non-code work, including gazette's source and historical evidence questions. |
 | resolve | skill | universal | skill | Structural friction resolution applies whenever tooling, configuration, convention, or process blocks work in another domain. |
+| tidy-up | skill | domain:software | skill | Another domain may need run-termination hygiene, but this skill's actions are git worktree mechanics for software contribution checkouts. |
 | verification-craft | skill | universal | skill | Another domain still needs verification gates that consult authorities, model coherence, or substrate structure instead of matching vocabulary as a proxy; only the artifact surfaces change. |
 | work-unit-craft | skill | universal | skill | Another domain still needs delegation-record craft: outcome-first records, body-as-spec authority, and criteria that transfer intent across contexts. The artifact name may change. |
 | decompose | protocol | domain:software | protocol | The cognitive craft projects, but this shell produces `work-unit` artifacts and tracker-backed handles, not gazette's non-code artifact crossings. |
@@ -78,7 +79,7 @@ obligations in the protocol boundary.
 
 ## Projection Seams
 
-The current row has two domain-specific skills. Both point at universal
+The current row has three domain-specific skills. All point at universal
 parents that row 1 predicts but has not yet extracted as standalone source
 skills.
 
@@ -86,6 +87,7 @@ skills.
 |---|---|---|---|---|
 | acquire | domain:software | acquisition | Materialize an execution artifact from an authorized planning record without fabricating content. | Reads a forge ticket, preserves `handle`, derives a `work-unit` body, and hands execution to `define`. |
 | code-review | domain:software | quality-review | Judge proposed work against scope, contract, evidence, and recipient impact before approval. | Adds software-specific correctness checks: code semantics, schemas, interfaces, tests, regressions, and current documentation accuracy. |
+| tidy-up | domain:software | termination-hygiene | Leave the shared substrate canonical at run termination so the next actor does not inherit process residue. | Implements the invariant with git worktree checks, branch handling, ignored-file boundaries, and halt preservation commits. |
 
 ## Lateral Harmonics
 
@@ -103,6 +105,7 @@ skills.
 |---|---|---|
 | Universal parent of `code-review` and gazette `factcheck` | Independent quality judgment over a proposal or artifact, using scope, evidence, recipient impact, and domain-specific correctness as projections. | `quality-review` skill |
 | Universal parent of `acquire` | Faithfully materialize an execution-scoped artifact from an existing authoritative planning record, surfacing gaps instead of inventing content. | `acquisition` skill |
+| Universal parent of `tidy-up` | Every domain's run termination leaves the shared substrate canonical, preserving intentional outcomes while removing process residue. | `termination-hygiene` skill |
 | Universal shell authoring discipline | Explain how a typed protocol wraps one cognitive skill, owns only the artifact crossing, and leaves composition below the shell. | `protocol-shell-craft` skill |
 | Shared artifact-delivery wrapper | State the MCP tool input boundary, `instance_id` extraction, scoped `work_unit` injection, and artifact-body validation once for producer protocols. | `artifact-delivery` reference or skill |
 | Universal governance close | Close a unit only from an approved disposition, bind the approved version, record performed validation, and surface any gaps. | `governance-closure` skill |

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -94,8 +94,11 @@ The protocol is not a forge operation. It must not activate from a raw
 
 6. **Tidy up.** Invoke the tidy-up skill (`skills/tidy-up/SKILL.md`) to
    return the repository to the canonical clean post-run state after the
-   completion-record is delivered. The next reader grounds against the
-   substrate the run actually left, not process residue from the run.
+   completion-record is delivered. Pass the resolved `change-proposal.branch`
+   as tidy-up's `--run-branch`; cleanup must not infer the run branch from
+   `HEAD`, because this step may begin after the checkout already rests on the
+   canonical branch. The next reader grounds against the substrate the run
+   actually left, not process residue from the run.
 
 ## Failure Policy
 

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -5,8 +5,8 @@ description: >-
   out the work unit, and deliver the completion-record. The closing bookend
   of the scoped pipeline.
 metadata:
-  version: "3.3.0"
-  updated: "2026-07-02"
+  version: "3.4.0"
+  updated: "2026-07-05"
 ---
 
 # Land
@@ -92,6 +92,11 @@ The protocol is not a forge operation. It must not activate from a raw
    the same derivation, with `completion-evidence.results[]` as the single
    evidence surface.
 
+6. **Tidy up.** Invoke the tidy-up skill (`skills/tidy-up/SKILL.md`) to
+   return the repository to the canonical clean post-run state after the
+   completion-record is delivered. The next reader grounds against the
+   substrate the run actually left, not process residue from the run.
+
 ## Failure Policy
 
 - If approval does not resolve to exactly one proposal by
@@ -131,3 +136,5 @@ The protocol is not a forge operation. It must not activate from a raw
   recording validation-performed.
 - `define` (protocol): the opening bookend — the contract established there
   is what this record closes.
+- `tidy-up` (skill, `skills/tidy-up/SKILL.md`): returns the repository to
+  canonical-clean after land completes its record.

--- a/skills/contract/SKILL.md
+++ b/skills/contract/SKILL.md
@@ -11,8 +11,8 @@ description: >-
   or completion claims must stay traceable to a defined contract instead of
   drifting toward implementation convenience.
 metadata:
-  version: "2.7.1"
-  updated: "2026-07-03"
+  version: "2.8.0"
+  updated: "2026-07-05"
 ---
 
 # Contract
@@ -88,6 +88,11 @@ the behavioral failing-test classification. `When an existing test fails
 after a change` decides where the defect lives: bug introduced, behavior
 moved, or behavior obsolete. The disposition default decides what survives
 after the defect is known to be a contract defect.
+
+A regenerated or abandoned unit's run ends through the tidy-up skill
+(`skills/tidy-up/SKILL.md`) before the fresh derivation begins, so the next
+attempt grounds on canonical-clean substrate rather than residue from the
+discarded branch.
 
 ## The dimensions
 

--- a/skills/orient/SKILL.md
+++ b/skills/orient/SKILL.md
@@ -6,8 +6,8 @@ description: >-
   documentation-writing guidance. Activates the full skill system as one
   connected methodology and carries the always-on documentation discipline.
 metadata:
-  version: "4.1.1"
-  updated: "2026-07-02"
+  version: "4.2.0"
+  updated: "2026-07-05"
 ---
 
 # Orient
@@ -74,6 +74,10 @@ at entry, threaded unbroken to the close.
 7. **`land`** — apply the approved version, reflect the disposition, close
    out, record completion.
 
+Every run termination — land, abandonment or regeneration, and halt — closes
+the worktree through the tidy-up skill (`skills/tidy-up/SKILL.md`) so the
+next session grounds on canonical-clean substrate rather than run residue.
+
 Under runa, the runtime drives these stations per work-unit; an agent's job
 inside any station is that station's discipline, ending at its capstone
 artifact. Depth scales with the change at every station — a trivial
@@ -112,6 +116,10 @@ These are not stations; they engage when their trigger fires, at any stage.
 - **`acquire`** — entry from an existing forge ticket: reads the ticket and
   materializes the work-unit artifact `define` activates on. Fires at the
   cold-start boundary, when work begins from a ticket reference.
+- **`tidy-up`** — run termination hygiene: land, abandonment/regeneration, and
+  halt return the repository to canonical-clean through
+  `skills/tidy-up/SKILL.md` so residue does not become the next session's
+  ground.
 
 ## Integration Principles
 

--- a/skills/tidy-up/SKILL.md
+++ b/skills/tidy-up/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: tidy-up
+description: >-
+  Return a repository to its canonical clean post-run state when a run ends
+  through land, abandonment or regeneration, or halt.
+metadata:
+  version: "1.0.0"
+  updated: "2026-07-05"
+---
+
+# Tidy-Up
+
+Tidy-up is the closing worktree discipline for a Groundwork run. Define opens
+the run on clean ground and a feature branch; tidy-up closes the run by making
+the repository truthful for the next reader. It removes process residue only.
+It never removes landed work or a halt disposition the operator still needs to
+inspect.
+
+The executable mechanics live in one place:
+
+```
+python3 skills/tidy-up/scripts/tidy_up.py <kind>
+```
+
+Resolve the script path from the methodology root and run it with the current
+working directory inside the repository being tidied. `<kind>` is one of
+`land`, `abandon`, `halt`, or `verify`. The script is the mechanics home; this
+skill names the outcomes and the per-kind action sequence.
+
+## The Canonical Clean State
+
+The canonical clean state is the close-side complement to define's workspace
+preparation. It consults
+[`workspace.md` Outcome 1 "Clean ground"](../../protocols/define/references/workspace.md)
+as the opening clean-worktree invariant and
+[`workspace.md` Outcome 3 "Feature branch"](../../protocols/define/references/workspace.md)
+as the run branch departure point that tidy-up returns from.
+
+1. **Working tree porcelain-clean.** `git status --porcelain` reports no
+   staged, unstaged, or untracked-unignored residue.
+2. **HEAD rests on the canonical branch.** The checkout is not detached and
+   does not remain on a leftover run branch; it rests on the repository's
+   canonical branch, derived from `origin/HEAD` with `main` as fallback.
+3. **No run-scoped residue outside ignored paths.** Run scratch files, build
+   artifacts, and linked worktree residue introduced by the run are removed
+   unless the repository declares them ignorable.
+4. **Landed work is untouched.** A run that landed a change still contains
+   that landed content byte-for-byte; tidy-up removes process scaffolding,
+   not intended deliverables.
+
+If any check cannot be reached, the script prints the named residual state to
+stderr and exits nonzero. Do not proceed silently past a failed check; route
+the obstacle through the `resolve` skill.
+
+## Termination Kinds
+
+### Land
+
+Land starts after the approved change has been applied, reflected, closed out,
+and recorded. The landed content is already on the canonical branch. Tidy-up
+checks out the canonical branch, fetches and fast-forwards it to its remote
+state, discards only process scaffolding from the worktree, removes
+untracked-unignored residue while preserving ignored files, deletes the run
+branch, prunes run-introduced worktrees, and verifies canonical-clean.
+
+Run:
+
+```
+python3 skills/tidy-up/scripts/tidy_up.py land
+```
+
+### Abandonment and Regeneration
+
+Abandonment and regeneration start from a run whose work must not remain in the
+checkout. Tidy-up discards uncommitted residue, removes untracked-unignored
+residue while preserving ignored files, returns to the canonical branch,
+fast-forwards it to its remote state, deletes the run branch carrying
+unlanded work, prunes run-introduced worktrees, and verifies canonical-clean
+before a fresh derivation begins.
+
+Run:
+
+```
+python3 skills/tidy-up/scripts/tidy_up.py abandon
+```
+
+### Halt
+
+Halt starts from a run whose disposition still needs to be visible. Tidy-up
+preserves all tracked and untracked-unignored work-in-progress as a
+halt-marked commit on the run branch, creating a named halt branch first when
+the run halted on a detached HEAD. It then returns the checkout to the
+canonical branch, fast-forwards it to its remote state, preserves the run
+branch as the inspectable halt disposition, prunes worktrees, and verifies
+canonical-clean.
+
+Run:
+
+```
+python3 skills/tidy-up/scripts/tidy_up.py halt
+```
+
+## Verification
+
+Use verify mode when no cleanup action should run and only the postcondition
+should be checked:
+
+```
+python3 skills/tidy-up/scripts/tidy_up.py verify
+```
+
+Verification runs the four canonical-clean checks above. A dirty worktree,
+detached HEAD, non-canonical checkout, or worktree-prune failure is reported as
+a named canonical-clean residual on stderr with a nonzero exit.
+
+## Corruption Modes
+
+- **Clean-by-discard.** Reaching a clean status by removing landed work or an
+  intended halt disposition. Canonical-clean preserves intended deliverables.
+- **Partial-success silence.** Reporting tidy-up complete after a failed reset,
+  checkout, clean, branch deletion, or verification. Every failure is loud.
+- **Mechanics duplication.** Copying git cleanup commands into land,
+  contract, orient, or another termination surface. The script is the single
+  mechanics home; other surfaces invoke this skill by reference.
+- **Ignored-boundary breach.** Removing ignored files with an overbroad clean
+  operation. Tidy-up removes untracked-unignored residue, not repository-
+  declared ignored state.
+
+## Cross-References
+
+- `land` (protocol): invokes tidy-up after completion-record delivery.
+- `contract` (skill): routes regenerated and abandoned runs through tidy-up
+  before a fresh derivation begins.
+- `orient` (skill): states the run-lifecycle rule, including halt.
+- [`workspace.md`](../../protocols/define/references/workspace.md): owns the
+  opening clean-ground and feature-branch outcomes tidy-up closes.

--- a/skills/tidy-up/SKILL.md
+++ b/skills/tidy-up/SKILL.md
@@ -19,13 +19,16 @@ inspect.
 The executable mechanics live in one place:
 
 ```
-python3 skills/tidy-up/scripts/tidy_up.py <kind>
+python3 skills/tidy-up/scripts/tidy_up.py <kind> [--run-branch BRANCH]
 ```
 
 Resolve the script path from the methodology root and run it with the current
 working directory inside the repository being tidied. `<kind>` is one of
-`land`, `abandon`, `halt`, or `verify`. The script is the mechanics home; this
-skill names the outcomes and the per-kind action sequence.
+`land`, `abandon`, `halt`, or `verify`. `land` and `abandon` require the
+caller to supply `--run-branch` from the run artifact it is closing; the script
+does not infer it from `HEAD`, because cleanup may begin after the checkout has
+already returned to canonical. The script is the mechanics home; this skill
+names the outcomes and the per-kind action sequence.
 
 ## The Canonical Clean State
 
@@ -58,15 +61,16 @@ the obstacle through the `resolve` skill.
 
 Land starts after the approved change has been applied, reflected, closed out,
 and recorded. The landed content is already on the canonical branch. Tidy-up
-checks out the canonical branch, fetches and fast-forwards it to its remote
-state, discards only process scaffolding from the worktree, removes
-untracked-unignored residue while preserving ignored files, deletes the run
-branch, prunes run-introduced worktrees, and verifies canonical-clean.
+receives the run branch from the resolved `change-proposal.branch`, discards
+only process scaffolding from the worktree, removes untracked-unignored residue
+while preserving ignored files, checks out the canonical branch, fetches and
+fast-forwards it to its remote state, deletes the supplied run branch, prunes
+run-introduced worktrees, and verifies canonical-clean.
 
 Run:
 
 ```
-python3 skills/tidy-up/scripts/tidy_up.py land
+python3 skills/tidy-up/scripts/tidy_up.py land --run-branch <change-proposal.branch>
 ```
 
 ### Abandonment and Regeneration
@@ -74,14 +78,14 @@ python3 skills/tidy-up/scripts/tidy_up.py land
 Abandonment and regeneration start from a run whose work must not remain in the
 checkout. Tidy-up discards uncommitted residue, removes untracked-unignored
 residue while preserving ignored files, returns to the canonical branch,
-fast-forwards it to its remote state, deletes the run branch carrying
+fast-forwards it to its remote state, deletes the supplied run branch carrying
 unlanded work, prunes run-introduced worktrees, and verifies canonical-clean
 before a fresh derivation begins.
 
 Run:
 
 ```
-python3 skills/tidy-up/scripts/tidy_up.py abandon
+python3 skills/tidy-up/scripts/tidy_up.py abandon --run-branch <run-branch>
 ```
 
 ### Halt
@@ -110,8 +114,9 @@ python3 skills/tidy-up/scripts/tidy_up.py verify
 ```
 
 Verification runs the four canonical-clean checks above. A dirty worktree,
-detached HEAD, non-canonical checkout, or worktree-prune failure is reported as
-a named canonical-clean residual on stderr with a nonzero exit.
+detached HEAD, non-canonical checkout, prunable linked-worktree residue, or
+worktree-prune failure is reported as a named canonical-clean residual on
+stderr with a nonzero exit.
 
 ## Corruption Modes
 

--- a/skills/tidy-up/SKILL.md
+++ b/skills/tidy-up/SKILL.md
@@ -64,8 +64,8 @@ and recorded. The landed content is already on the canonical branch. Tidy-up
 receives the run branch from the resolved `change-proposal.branch`, discards
 only process scaffolding from the worktree, removes untracked-unignored residue
 while preserving ignored files, checks out the canonical branch, fetches and
-fast-forwards it to its remote state, deletes the supplied run branch, prunes
-run-introduced worktrees, and verifies canonical-clean.
+fast-forwards it to its remote state, prunes run-introduced worktrees, deletes
+the supplied run branch, and verifies canonical-clean.
 
 Run:
 
@@ -78,8 +78,8 @@ python3 skills/tidy-up/scripts/tidy_up.py land --run-branch <change-proposal.bra
 Abandonment and regeneration start from a run whose work must not remain in the
 checkout. Tidy-up discards uncommitted residue, removes untracked-unignored
 residue while preserving ignored files, returns to the canonical branch,
-fast-forwards it to its remote state, deletes the supplied run branch carrying
-unlanded work, prunes run-introduced worktrees, and verifies canonical-clean
+fast-forwards it to its remote state, prunes run-introduced worktrees, deletes
+the supplied run branch carrying unlanded work, and verifies canonical-clean
 before a fresh derivation begins.
 
 Run:

--- a/skills/tidy-up/scripts/tidy_up.py
+++ b/skills/tidy-up/scripts/tidy_up.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Return a run worktree to Groundwork's canonical clean state."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+
+
+class TidyUpError(Exception):
+    """A named canonical-clean residual or cleanup obstacle."""
+
+
+def git(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        command = "git " + " ".join(args)
+        detail = (result.stderr or result.stdout).strip()
+        raise TidyUpError(f"{command} failed: {detail}")
+    return result
+
+
+def branch_exists(branch: str) -> bool:
+    return git("show-ref", "--verify", "--quiet", f"refs/heads/{branch}", check=False).returncode == 0
+
+
+def remote_branch_exists(branch: str) -> bool:
+    return (
+        git("show-ref", "--verify", "--quiet", f"refs/remotes/origin/{branch}", check=False).returncode
+        == 0
+    )
+
+
+def canonical_branch() -> str:
+    origin_head = git("symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD", check=False)
+    if origin_head.returncode == 0:
+        name = origin_head.stdout.strip()
+        if name.startswith("origin/") and len(name) > len("origin/"):
+            return name.removeprefix("origin/")
+    return "main"
+
+
+def current_branch() -> str | None:
+    result = git("symbolic-ref", "--quiet", "--short", "HEAD", check=False)
+    if result.returncode == 0:
+        return result.stdout.strip()
+    return None
+
+
+def ensure_repository() -> None:
+    result = git("rev-parse", "--is-inside-work-tree", check=False)
+    if result.returncode != 0 or result.stdout.strip() != "true":
+        raise TidyUpError("not inside a git worktree")
+
+
+def fetch_origin() -> None:
+    if git("remote", "get-url", "origin", check=False).returncode == 0:
+        git("fetch", "origin", "--prune")
+
+
+def checkout_canonical(canonical: str) -> None:
+    if not branch_exists(canonical):
+        if remote_branch_exists(canonical):
+            git("checkout", "-B", canonical, f"origin/{canonical}")
+        else:
+            raise TidyUpError(f"canonical branch {canonical!r} does not exist")
+    else:
+        git("checkout", canonical)
+    if remote_branch_exists(canonical):
+        git("merge", "--ff-only", f"origin/{canonical}")
+
+
+def hard_reset_and_clean() -> None:
+    git("reset", "--hard")
+    git("clean", "-fd")
+
+
+def delete_branch(branch: str | None) -> None:
+    if branch and branch_exists(branch):
+        git("branch", "-D", branch)
+
+
+def prune_worktrees() -> None:
+    git("worktree", "prune")
+
+
+def status_porcelain() -> str:
+    return git("status", "--porcelain").stdout.strip()
+
+
+def verify_canonical_clean() -> None:
+    canonical = canonical_branch()
+    residuals: list[str] = []
+
+    status = status_porcelain()
+    if status:
+        residuals.append(f"working tree is not porcelain-clean: {status}")
+
+    branch = current_branch()
+    if branch is None:
+        residuals.append("HEAD is detached")
+    elif branch != canonical:
+        residuals.append(f"HEAD is on {branch!r}, expected canonical branch {canonical!r}")
+
+    clean_check = git("ls-files", "--others", "--exclude-standard", check=False)
+    if clean_check.returncode != 0:
+        residuals.append(f"could not inspect untracked residue: {clean_check.stderr.strip()}")
+    elif clean_check.stdout.strip():
+        residuals.append(f"run-scoped residue remains outside ignored paths: {clean_check.stdout.strip()}")
+
+    prune = git("worktree", "prune", "--dry-run", check=False)
+    if prune.returncode != 0:
+        residuals.append(f"could not inspect linked worktree residue: {prune.stderr.strip()}")
+
+    if residuals:
+        raise TidyUpError("; ".join(residuals))
+
+
+def run_branch_before_cleanup(canonical: str) -> str | None:
+    branch = current_branch()
+    if branch == canonical:
+        return None
+    return branch
+
+
+def tidy_land() -> None:
+    canonical = canonical_branch()
+    run_branch = run_branch_before_cleanup(canonical)
+    fetch_origin()
+    checkout_canonical(canonical)
+    hard_reset_and_clean()
+    delete_branch(run_branch)
+    prune_worktrees()
+    verify_canonical_clean()
+
+
+def tidy_abandon() -> None:
+    canonical = canonical_branch()
+    run_branch = run_branch_before_cleanup(canonical)
+    hard_reset_and_clean()
+    fetch_origin()
+    checkout_canonical(canonical)
+    delete_branch(run_branch)
+    prune_worktrees()
+    verify_canonical_clean()
+
+
+def ensure_halt_branch(canonical: str) -> str:
+    branch = current_branch()
+    if branch and branch != canonical:
+        return branch
+
+    stamp = time.strftime("%Y%m%d%H%M%S")
+    branch = f"halt/{stamp}"
+    suffix = 1
+    candidate = branch
+    while branch_exists(candidate):
+        suffix += 1
+        candidate = f"{branch}-{suffix}"
+    git("checkout", "-b", candidate)
+    return candidate
+
+
+def preserve_halt_commit(branch: str) -> None:
+    git("add", "-A")
+    staged = git("diff", "--cached", "--name-only").stdout.strip()
+    if not staged:
+        return
+    git(
+        "-c",
+        "user.name=Groundwork Tidy Up",
+        "-c",
+        "user.email=groundwork-tidy-up@example.invalid",
+        "commit",
+        "-m",
+        f"halt: preserve work-in-progress on {branch}",
+    )
+
+
+def tidy_halt() -> None:
+    canonical = canonical_branch()
+    halt_branch = ensure_halt_branch(canonical)
+    preserve_halt_commit(halt_branch)
+    fetch_origin()
+    checkout_canonical(canonical)
+    git("reset", "--hard")
+    git("clean", "-fd")
+    prune_worktrees()
+    verify_canonical_clean()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("kind", choices=["land", "abandon", "halt", "verify"])
+    args = parser.parse_args()
+
+    try:
+        ensure_repository()
+        if args.kind == "land":
+            tidy_land()
+        elif args.kind == "abandon":
+            tidy_abandon()
+        elif args.kind == "halt":
+            tidy_halt()
+        else:
+            verify_canonical_clean()
+    except TidyUpError as error:
+        print(f"canonical-clean residual: {error}", file=sys.stderr)
+        return 1
+
+    print("canonical-clean verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/tidy-up/scripts/tidy_up.py
+++ b/skills/tidy-up/scripts/tidy_up.py
@@ -81,8 +81,8 @@ def hard_reset_and_clean() -> None:
     git("clean", "-fd")
 
 
-def delete_branch(branch: str | None) -> None:
-    if branch and branch_exists(branch):
+def delete_branch(branch: str) -> None:
+    if branch_exists(branch):
         git("branch", "-D", branch)
 
 
@@ -115,34 +115,38 @@ def verify_canonical_clean() -> None:
         residuals.append(f"run-scoped residue remains outside ignored paths: {clean_check.stdout.strip()}")
 
     prune = git("worktree", "prune", "--dry-run", check=False)
+    prune_output = "\n".join(part for part in [prune.stdout.strip(), prune.stderr.strip()] if part)
     if prune.returncode != 0:
         residuals.append(f"could not inspect linked worktree residue: {prune.stderr.strip()}")
+    elif prune_output:
+        residuals.append(f"linked worktree residue remains: {prune_output}")
 
     if residuals:
         raise TidyUpError("; ".join(residuals))
 
 
-def run_branch_before_cleanup(canonical: str) -> str | None:
-    branch = current_branch()
-    if branch == canonical:
-        return None
-    return branch
+def required_run_branch(kind: str, run_branch: str | None, canonical: str) -> str:
+    if run_branch is None:
+        raise TidyUpError(f"{kind} cleanup requires --run-branch")
+    if run_branch == canonical:
+        raise TidyUpError("run branch must not be the canonical branch")
+    return run_branch
 
 
-def tidy_land() -> None:
+def tidy_land(run_branch: str | None) -> None:
     canonical = canonical_branch()
-    run_branch = run_branch_before_cleanup(canonical)
+    run_branch = required_run_branch("land", run_branch, canonical)
+    hard_reset_and_clean()
     fetch_origin()
     checkout_canonical(canonical)
-    hard_reset_and_clean()
     delete_branch(run_branch)
     prune_worktrees()
     verify_canonical_clean()
 
 
-def tidy_abandon() -> None:
+def tidy_abandon(run_branch: str | None) -> None:
     canonical = canonical_branch()
-    run_branch = run_branch_before_cleanup(canonical)
+    run_branch = required_run_branch("abandon", run_branch, canonical)
     hard_reset_and_clean()
     fetch_origin()
     checkout_canonical(canonical)
@@ -198,14 +202,18 @@ def tidy_halt() -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("kind", choices=["land", "abandon", "halt", "verify"])
+    parser.add_argument(
+        "--run-branch",
+        help="run branch to delete; required for land and abandon",
+    )
     args = parser.parse_args()
 
     try:
         ensure_repository()
         if args.kind == "land":
-            tidy_land()
+            tidy_land(args.run_branch)
         elif args.kind == "abandon":
-            tidy_abandon()
+            tidy_abandon(args.run_branch)
         elif args.kind == "halt":
             tidy_halt()
         else:

--- a/skills/tidy-up/scripts/tidy_up.py
+++ b/skills/tidy-up/scripts/tidy_up.py
@@ -139,8 +139,8 @@ def tidy_land(run_branch: str | None) -> None:
     hard_reset_and_clean()
     fetch_origin()
     checkout_canonical(canonical)
-    delete_branch(run_branch)
     prune_worktrees()
+    delete_branch(run_branch)
     verify_canonical_clean()
 
 
@@ -150,8 +150,8 @@ def tidy_abandon(run_branch: str | None) -> None:
     hard_reset_and_clean()
     fetch_origin()
     checkout_canonical(canonical)
-    delete_branch(run_branch)
     prune_worktrees()
+    delete_branch(run_branch)
     verify_canonical_clean()
 
 

--- a/tests/test_tidy_up_mechanics.py
+++ b/tests/test_tidy_up_mechanics.py
@@ -1,0 +1,171 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TIDY_UP = ROOT / "skills" / "tidy-up" / "scripts" / "tidy_up.py"
+
+
+def git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+    return result
+
+
+def run_tidy(repo: Path, kind: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TIDY_UP), kind],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def branch(repo: Path) -> str:
+    return git(repo, "branch", "--show-current").stdout.strip()
+
+
+def porcelain(repo: Path) -> str:
+    return git(repo, "status", "--porcelain").stdout.strip()
+
+
+class GitFixture:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.origin = root / "origin.git"
+        self.seed = root / "seed"
+        self.repo = root / "repo"
+        self.run_branch = "issue-518/tidy-up"
+        self.ignored = self.repo / "ignored.log"
+
+        git(root, "init", "--bare", str(self.origin))
+        self.seed.mkdir()
+        git(self.seed, "init", "-b", "main")
+        self.configure_identity(self.seed)
+        (self.seed / ".gitignore").write_text("ignored.log\n", encoding="utf-8")
+        (self.seed / "tracked.txt").write_text("base\n", encoding="utf-8")
+        git(self.seed, "add", ".")
+        git(self.seed, "commit", "-m", "initial")
+        git(self.seed, "remote", "add", "origin", str(self.origin))
+        git(self.seed, "push", "-u", "origin", "main")
+        git(self.origin, "symbolic-ref", "HEAD", "refs/heads/main")
+        git(root, "clone", str(self.origin), str(self.repo))
+        self.configure_identity(self.repo)
+        git(self.repo, "remote", "set-head", "origin", "-a")
+
+    @staticmethod
+    def configure_identity(repo: Path) -> None:
+        git(repo, "config", "user.name", "Groundwork Test")
+        git(repo, "config", "user.email", "groundwork-test@example.invalid")
+
+    def checkout_run_branch(self) -> None:
+        git(self.repo, "checkout", "-b", self.run_branch)
+
+    def seed_common_residue(self) -> None:
+        (self.repo / "tracked.txt").write_text("dirty tracked edit\n", encoding="utf-8")
+        (self.repo / "build.tmp").write_text("run build artifact\n", encoding="utf-8")
+        self.ignored.write_text("ignored survivor\n", encoding="utf-8")
+
+    def create_landed_state(self) -> str:
+        self.checkout_run_branch()
+        landed = self.repo / "landed.txt"
+        landed.write_text("landed content\n", encoding="utf-8")
+        git(self.repo, "add", "landed.txt")
+        git(self.repo, "commit", "-m", "landed change")
+        git(self.repo, "checkout", "main")
+        git(self.repo, "merge", "--ff-only", self.run_branch)
+        git(self.repo, "push", "origin", "main")
+        git(self.repo, "checkout", self.run_branch)
+        self.seed_common_residue()
+        return git(self.repo, "show", "HEAD:landed.txt").stdout
+
+
+class TidyUpMechanicsTests(unittest.TestCase):
+    def test_land_reaches_canonical_clean_preserving_landed_work_and_ignored_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = GitFixture(Path(tmp))
+            landed_before = fixture.create_landed_state()
+
+            result = run_tidy(fixture.repo, "land")
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual("", porcelain(fixture.repo))
+            self.assertEqual("main", branch(fixture.repo))
+            self.assertEqual(landed_before, git(fixture.repo, "show", "HEAD:landed.txt").stdout)
+            self.assertFalse((fixture.repo / "build.tmp").exists())
+            self.assertTrue(fixture.ignored.exists())
+            self.assertNotEqual(
+                0,
+                git(fixture.repo, "show-ref", "--verify", f"refs/heads/{fixture.run_branch}", check=False).returncode,
+            )
+
+    def test_abandon_reaches_canonical_clean_and_removes_run_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = GitFixture(Path(tmp))
+            fixture.checkout_run_branch()
+            (fixture.repo / "unlanded.txt").write_text("unlanded\n", encoding="utf-8")
+            git(fixture.repo, "add", "unlanded.txt")
+            git(fixture.repo, "commit", "-m", "unlanded work")
+            fixture.seed_common_residue()
+
+            result = run_tidy(fixture.repo, "abandon")
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual("", porcelain(fixture.repo))
+            self.assertEqual("main", branch(fixture.repo))
+            self.assertFalse((fixture.repo / "build.tmp").exists())
+            self.assertTrue(fixture.ignored.exists())
+            self.assertNotIn("unlanded.txt", git(fixture.repo, "ls-tree", "--name-only", "HEAD").stdout)
+            self.assertNotEqual(
+                0,
+                git(fixture.repo, "show-ref", "--verify", f"refs/heads/{fixture.run_branch}", check=False).returncode,
+            )
+
+    def test_halt_preserves_wip_commit_on_run_branch_and_returns_to_canonical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = GitFixture(Path(tmp))
+            fixture.checkout_run_branch()
+            fixture.seed_common_residue()
+
+            result = run_tidy(fixture.repo, "halt")
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual("", porcelain(fixture.repo))
+            self.assertEqual("main", branch(fixture.repo))
+            self.assertTrue(fixture.ignored.exists())
+            self.assertEqual(
+                "dirty tracked edit\n",
+                git(fixture.repo, "show", f"{fixture.run_branch}:tracked.txt").stdout,
+            )
+            self.assertEqual(
+                "run build artifact\n",
+                git(fixture.repo, "show", f"{fixture.run_branch}:build.tmp").stdout,
+            )
+            self.assertIn(
+                "halt: preserve work-in-progress",
+                git(fixture.repo, "log", "-1", "--pretty=%s", fixture.run_branch).stdout,
+            )
+
+    def test_verify_fails_loudly_with_named_residual_on_dirty_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = GitFixture(Path(tmp))
+            (fixture.repo / "dirty.tmp").write_text("dirty\n", encoding="utf-8")
+
+            result = run_tidy(fixture.repo, "verify")
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("canonical-clean residual", result.stderr)
+            self.assertIn("working tree is not porcelain-clean", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tidy_up_mechanics.py
+++ b/tests/test_tidy_up_mechanics.py
@@ -93,9 +93,12 @@ class GitFixture:
         self.seed_common_residue()
         return git(self.repo, "show", "HEAD:landed.txt").stdout
 
-    def create_stale_linked_worktree_entry(self) -> Path:
+    def create_stale_linked_worktree_entry(self, branch: str | None = None) -> Path:
         stale = self.root / "stale-linked-worktree"
-        git(self.repo, "worktree", "add", str(stale))
+        command = ["worktree", "add", str(stale)]
+        if branch is not None:
+            command.append(branch)
+        git(self.repo, *command)
         shutil.rmtree(stale)
         return stale
 
@@ -155,6 +158,21 @@ class TidyUpMechanicsTests(unittest.TestCase):
                 git(fixture.repo, "show-ref", "--verify", f"refs/heads/{fixture.run_branch}", check=False).returncode,
             )
 
+    def test_land_prunes_stale_worktree_metadata_before_deleting_run_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = GitFixture(Path(tmp))
+            fixture.create_landed_state(checkout_run_branch=False)
+            fixture.create_stale_linked_worktree_entry(fixture.run_branch)
+
+            result = run_tidy(fixture.repo, "land", fixture.run_branch)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual("main", branch(fixture.repo))
+            self.assertNotEqual(
+                0,
+                git(fixture.repo, "show-ref", "--verify", f"refs/heads/{fixture.run_branch}", check=False).returncode,
+            )
+
     def test_abandon_deletes_supplied_run_branch_when_invoked_from_canonical(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             fixture = GitFixture(Path(tmp))
@@ -163,6 +181,26 @@ class TidyUpMechanicsTests(unittest.TestCase):
             git(fixture.repo, "add", "unlanded.txt")
             git(fixture.repo, "commit", "-m", "unlanded work")
             git(fixture.repo, "checkout", "main")
+
+            result = run_tidy(fixture.repo, "abandon", fixture.run_branch)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual("main", branch(fixture.repo))
+            self.assertNotIn("unlanded.txt", git(fixture.repo, "ls-tree", "--name-only", "HEAD").stdout)
+            self.assertNotEqual(
+                0,
+                git(fixture.repo, "show-ref", "--verify", f"refs/heads/{fixture.run_branch}", check=False).returncode,
+            )
+
+    def test_abandon_prunes_stale_worktree_metadata_before_deleting_run_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = GitFixture(Path(tmp))
+            fixture.checkout_run_branch()
+            (fixture.repo / "unlanded.txt").write_text("unlanded\n", encoding="utf-8")
+            git(fixture.repo, "add", "unlanded.txt")
+            git(fixture.repo, "commit", "-m", "unlanded work")
+            git(fixture.repo, "checkout", "main")
+            fixture.create_stale_linked_worktree_entry(fixture.run_branch)
 
             result = run_tidy(fixture.repo, "abandon", fixture.run_branch)
 

--- a/tests/test_tidy_up_mechanics.py
+++ b/tests/test_tidy_up_mechanics.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -21,9 +22,12 @@ def git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProces
     return result
 
 
-def run_tidy(repo: Path, kind: str) -> subprocess.CompletedProcess[str]:
+def run_tidy(repo: Path, kind: str, run_branch: str | None = None) -> subprocess.CompletedProcess[str]:
+    command = [sys.executable, str(TIDY_UP), kind]
+    if run_branch is not None:
+        command.extend(["--run-branch", run_branch])
     return subprocess.run(
-        [sys.executable, str(TIDY_UP), kind],
+        command,
         cwd=repo,
         capture_output=True,
         text=True,
@@ -75,7 +79,7 @@ class GitFixture:
         (self.repo / "build.tmp").write_text("run build artifact\n", encoding="utf-8")
         self.ignored.write_text("ignored survivor\n", encoding="utf-8")
 
-    def create_landed_state(self) -> str:
+    def create_landed_state(self, *, checkout_run_branch: bool = True) -> str:
         self.checkout_run_branch()
         landed = self.repo / "landed.txt"
         landed.write_text("landed content\n", encoding="utf-8")
@@ -84,9 +88,16 @@ class GitFixture:
         git(self.repo, "checkout", "main")
         git(self.repo, "merge", "--ff-only", self.run_branch)
         git(self.repo, "push", "origin", "main")
-        git(self.repo, "checkout", self.run_branch)
+        if checkout_run_branch:
+            git(self.repo, "checkout", self.run_branch)
         self.seed_common_residue()
         return git(self.repo, "show", "HEAD:landed.txt").stdout
+
+    def create_stale_linked_worktree_entry(self) -> Path:
+        stale = self.root / "stale-linked-worktree"
+        git(self.repo, "worktree", "add", str(stale))
+        shutil.rmtree(stale)
+        return stale
 
 
 class TidyUpMechanicsTests(unittest.TestCase):
@@ -95,7 +106,7 @@ class TidyUpMechanicsTests(unittest.TestCase):
             fixture = GitFixture(Path(tmp))
             landed_before = fixture.create_landed_state()
 
-            result = run_tidy(fixture.repo, "land")
+            result = run_tidy(fixture.repo, "land", fixture.run_branch)
 
             self.assertEqual(0, result.returncode, result.stderr)
             self.assertEqual("", porcelain(fixture.repo))
@@ -117,13 +128,46 @@ class TidyUpMechanicsTests(unittest.TestCase):
             git(fixture.repo, "commit", "-m", "unlanded work")
             fixture.seed_common_residue()
 
-            result = run_tidy(fixture.repo, "abandon")
+            result = run_tidy(fixture.repo, "abandon", fixture.run_branch)
 
             self.assertEqual(0, result.returncode, result.stderr)
             self.assertEqual("", porcelain(fixture.repo))
             self.assertEqual("main", branch(fixture.repo))
             self.assertFalse((fixture.repo / "build.tmp").exists())
             self.assertTrue(fixture.ignored.exists())
+            self.assertNotIn("unlanded.txt", git(fixture.repo, "ls-tree", "--name-only", "HEAD").stdout)
+            self.assertNotEqual(
+                0,
+                git(fixture.repo, "show-ref", "--verify", f"refs/heads/{fixture.run_branch}", check=False).returncode,
+            )
+
+    def test_land_deletes_supplied_run_branch_when_invoked_from_canonical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = GitFixture(Path(tmp))
+            fixture.create_landed_state(checkout_run_branch=False)
+
+            result = run_tidy(fixture.repo, "land", fixture.run_branch)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual("main", branch(fixture.repo))
+            self.assertNotEqual(
+                0,
+                git(fixture.repo, "show-ref", "--verify", f"refs/heads/{fixture.run_branch}", check=False).returncode,
+            )
+
+    def test_abandon_deletes_supplied_run_branch_when_invoked_from_canonical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = GitFixture(Path(tmp))
+            fixture.checkout_run_branch()
+            (fixture.repo / "unlanded.txt").write_text("unlanded\n", encoding="utf-8")
+            git(fixture.repo, "add", "unlanded.txt")
+            git(fixture.repo, "commit", "-m", "unlanded work")
+            git(fixture.repo, "checkout", "main")
+
+            result = run_tidy(fixture.repo, "abandon", fixture.run_branch)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual("main", branch(fixture.repo))
             self.assertNotIn("unlanded.txt", git(fixture.repo, "ls-tree", "--name-only", "HEAD").stdout)
             self.assertNotEqual(
                 0,
@@ -165,6 +209,18 @@ class TidyUpMechanicsTests(unittest.TestCase):
             self.assertNotEqual(0, result.returncode)
             self.assertIn("canonical-clean residual", result.stderr)
             self.assertIn("working tree is not porcelain-clean", result.stderr)
+
+    def test_verify_fails_loudly_with_named_residual_on_stale_linked_worktree_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = GitFixture(Path(tmp))
+            stale = fixture.create_stale_linked_worktree_entry()
+
+            result = run_tidy(fixture.repo, "verify")
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("canonical-clean residual", result.stderr)
+            self.assertIn("linked worktree residue remains", result.stderr)
+            self.assertIn(stale.name, result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_tidy_up_skill.py
+++ b/tests/test_tidy_up_skill.py
@@ -1,0 +1,143 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TIDY_UP = ROOT / "skills" / "tidy-up" / "SKILL.md"
+TIDY_UP_SCRIPT = ROOT / "skills" / "tidy-up" / "scripts" / "tidy_up.py"
+LAND = ROOT / "protocols" / "land" / "PROTOCOL.md"
+CONTRACT = ROOT / "skills" / "contract" / "SKILL.md"
+ORIENT = ROOT / "skills" / "orient" / "SKILL.md"
+README = ROOT / "README.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def section(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^## {re.escape(heading)}\n(?P<section>.*?)(?=^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing section: {heading}")
+    return match.group("section")
+
+
+def subsection(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^### {re.escape(heading)}\n(?P<section>.*?)(?=^### |^## |\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match is None:
+        raise AssertionError(f"missing subsection: {heading}")
+    return match.group("section")
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+class TidyUpSkillTests(unittest.TestCase):
+    def test_skill_declares_four_distinct_canonical_clean_checks(self) -> None:
+        clean_state = section(read(TIDY_UP), "The Canonical Clean State")
+        checks = re.findall(r"(?m)^\d+[.] \*\*(?P<name>[^*]+)\*\*", clean_state)
+
+        self.assertEqual(
+            [
+                "Working tree porcelain-clean.",
+                "HEAD rests on the canonical branch.",
+                "No run-scoped residue outside ignored paths.",
+                "Landed work is untouched.",
+            ],
+            checks,
+        )
+        for expected in [
+            "git status --porcelain",
+            "origin/HEAD",
+            "untracked-unignored residue",
+            "byte-for-byte",
+            "workspace.md",
+            "Outcome 1",
+            "Outcome 3",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, clean_state)
+
+    def test_each_termination_kind_has_distinct_action_prose_and_invocation(self) -> None:
+        termination = section(read(TIDY_UP), "Termination Kinds")
+        expectations = {
+            "Land": ["approved change has been applied", "deletes the run branch", "land"],
+            "Abandonment and Regeneration": [
+                "work must not remain",
+                "deletes the run branch carrying unlanded work",
+                "abandon",
+            ],
+            "Halt": ["disposition still needs to be visible", "halt-marked commit", "halt"],
+        }
+
+        for heading, expected_terms in expectations.items():
+            with self.subTest(heading=heading):
+                body = subsection(termination, heading)
+                prose = normalized(body)
+                for term in expected_terms:
+                    self.assertIn(term, prose)
+                self.assertIn(
+                    f"python3 skills/tidy-up/scripts/tidy_up.py {expected_terms[-1]}",
+                    body,
+                )
+
+        self.assertTrue(TIDY_UP_SCRIPT.is_file())
+
+    def test_land_steps_section_invokes_tidy_up(self) -> None:
+        body = read(LAND)
+        steps = body.split("## Steps", 1)[1].split("## Failure Policy", 1)[0]
+        cross_refs = body.split("## Cross-References", 1)[1]
+
+        self.assertIn("6. **Tidy up.**", steps)
+        self.assertIn("skills/tidy-up/SKILL.md", steps)
+        self.assertIn("completion-record", steps)
+        self.assertIn("skills/tidy-up/SKILL.md", cross_refs)
+
+    def test_non_land_surfaces_reference_one_skill_without_command_blocks(self) -> None:
+        disposition = section(read(CONTRACT), "The disposition default")
+        orient_shape = section(read(ORIENT), "The Shape of the Work")
+        orient_disciplines = section(read(ORIENT), "Cross-Cutting Disciplines")
+
+        for name, body in [
+            ("contract disposition default", disposition),
+            ("orient shape", orient_shape),
+            ("orient disciplines", orient_disciplines),
+        ]:
+            with self.subTest(surface=name):
+                self.assertIn("skills/tidy-up/SKILL.md", body)
+                self.assertNotIn("```", body)
+
+    def test_discovery_surfaces_reach_tidy_up(self) -> None:
+        readme = read(README)
+        changelog = read(ROOT / "CHANGELOG.md")
+
+        self.assertIn("skills/tidy-up/SKILL.md", readme)
+        self.assertIn("tests/test_tidy_up_skill.py", changelog)
+        self.assertIn("tests/test_tidy_up_mechanics.py", changelog)
+
+    def test_skill_prose_names_loud_failure_and_single_mechanics_home(self) -> None:
+        body = normalized(read(TIDY_UP))
+
+        for expected in [
+            "canonical-clean residual",
+            "exits nonzero",
+            "script is the mechanics home",
+            "Mechanics duplication",
+            "Ignored-boundary breach",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tidy_up_skill.py
+++ b/tests/test_tidy_up_skill.py
@@ -71,10 +71,10 @@ class TidyUpSkillTests(unittest.TestCase):
     def test_each_termination_kind_has_distinct_action_prose_and_invocation(self) -> None:
         termination = section(read(TIDY_UP), "Termination Kinds")
         expectations = {
-            "Land": ["approved change has been applied", "deletes the run branch", "land"],
+            "Land": ["approved change has been applied", "deletes the supplied run branch", "land"],
             "Abandonment and Regeneration": [
                 "work must not remain",
-                "deletes the run branch carrying unlanded work",
+                "deletes the supplied run branch carrying unlanded work",
                 "abandon",
             ],
             "Halt": ["disposition still needs to be visible", "halt-marked commit", "halt"],
@@ -101,6 +101,8 @@ class TidyUpSkillTests(unittest.TestCase):
         self.assertIn("6. **Tidy up.**", steps)
         self.assertIn("skills/tidy-up/SKILL.md", steps)
         self.assertIn("completion-record", steps)
+        self.assertIn("change-proposal.branch", steps)
+        self.assertIn("--run-branch", steps)
         self.assertIn("skills/tidy-up/SKILL.md", cross_refs)
 
     def test_non_land_surfaces_reference_one_skill_without_command_blocks(self) -> None:


### PR DESCRIPTION
## Summary

Implements #518 by adding the `tidy-up` skill and a single shipped Python mechanics home at `skills/tidy-up/scripts/tidy_up.py` for `land`, `abandon`, `halt`, and `verify`.

- Wires land Step 6 to invoke tidy-up after completion-record delivery.
- Wires abandonment/regeneration through the contract skill disposition default and halt through orient's run-lifecycle rule.
- Adds README, CHANGELOG, and ontology audit coverage for the new skill.
- Adds the two plan-required test files: `tests/test_tidy_up_skill.py` and `tests/test_tidy_up_mechanics.py`.

## Validation

- `python -m unittest tests.test_tidy_up_skill tests.test_tidy_up_mechanics`
- `python -m unittest tests.test_groundwork_skill_ontology_row1_audit tests.test_reference_links tests.test_contract_skill_lifecycle`
- `python -m tooling.conformance`
- `python -m unittest tests.test_groundwork_install tests.test_install`
- `python -m unittest tests.test_prose_conformance tests.test_protocol_prose_conformance tests.test_architecture_prose_conformance tests.test_protocol_artifact_delivery_docs tests.test_define_protocol_contract_dimensions tests.test_verify_protocol_gate_coverage`
- `python -m unittest discover -s tests` ran 454 tests: 452 passed, 3 skipped, with the two pre-existing runtime-less `runa-mcp 0.2.0-rc.1` failures in `test_completion_evidence_persist_rejects_contract_mismatches` (`completion-unknown`, `completion-missing`).
