### PR TITLE
feat(forge-capability): consume v2.0.0 neutral work-unit operations (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Forge Capability v2.0.0 consumption: neutral work-unit operation names**
+  ([tesserine/commons#106](https://github.com/tesserine/commons/issues/106)).
+  Groundwork now vendors forge-capability **v2.0.0** at
+  `schemas/forge-capability/v2/forge-capability.schema.json`, pinned to the
+  immutable commons authority
+  (`e75e211689e92a4772614bfe6e4eca4b647d4d66`), and the v1 copy is retired from
+  the active vendored path. The capability read/create operations are the
+  neutral `read-work-unit` and `create-work-unit`, and the shared output type is
+  `work-unit-snapshot`; the leaked provider-noun operations `read-ticket`,
+  `create-ticket`, and `ticket-snapshot` are gone from the capability layer.
+  Tooling (`forge_capability`, `conformance`, `workflow_contracts`), the
+  conformance and prose gates, and capability-level methodology prose — `acquire`,
+  `decompose`, `define`, `orient`, `contract`, `verification-craft`,
+  `work-unit-craft`, and the connecting-structure architecture doc — name the
+  work-unit vocabulary. Provider nouns remain only where a specific provider is
+  projected: GitHub says *issue*, SourceHut says *ticket*, and SourceHut
+  tracker-backed handles keep their `ticket:`-prefixed opaque identity. No
+  old-name alias, compatibility shim, or new pre-claim noun is introduced;
+  commons v1 remains the retained frozen authority for v1 consumers.
+
 - **Breaking vocabulary rename: entry protocol `take` becomes `define`**
   (#529). The contract-first entry stage is now registered and installed as
   `define` (protocol version 4.0.0), matching the stage's act: authoring

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ units with acceptance criteria and dependency edges.
 
 **Entry** into the scoped pipeline happens one of two ways: a work-unit newly
 created by decompose, or one the acquire skill materializes from an existing
-forge ticket (the "start on ticket #N" path). Either way define activates on a
+forge work-unit (the "start on work-unit #N" path). Either way define activates on a
 work-unit artifact.
 
 **The scoped pipeline** takes one work-unit and carries it through to a merged
@@ -63,7 +63,7 @@ stage-specific judgment:
 - **verification-craft** — [`skills/verification-craft/SKILL.md`](skills/verification-craft/SKILL.md),
   the discipline for authoring verification gates over prose and text artifacts
 - **code-review** — review judgment for submitted change proposals
-- **acquire** — entry from an existing forge ticket: materializes the work-unit artifact define activates on
+- **acquire** — entry from an existing forge work-unit: materializes the work-unit artifact define activates on
 
 Not every piece of work needs every stage. A bug with an existing work-unit enters
 at execution. A new capability enters at planning. The constraint is sequence,
@@ -163,9 +163,9 @@ marker. It deliberately contains no provider mechanics, resolver module, or
 forge-operation binary; upgrading removes stale copies of those retired runtime
 children.
 
-Forge work uses the vendored Forge Capability v1.1.0 contract at
-`schemas/forge-capability/v1/forge-capability.schema.json`. The eight canonical
-operations are connector MCP tools: `read-ticket`, `create-ticket`,
+Forge work uses the vendored Forge Capability v2.0.0 contract at
+`schemas/forge-capability/v2/forge-capability.schema.json`. The eight canonical
+operations are connector MCP tools: `read-work-unit`, `create-work-unit`,
 `claim-work-unit`, `record-progress`, `deliver-change-proposal`,
 `reflect-disposition`, `apply-approved-change`, and `close-out`. Work units and
 change proposals carry the connector-issued `{ id, display }` handle. The

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -102,13 +102,13 @@ runa injects `work_unit` into every scoped artifact and validates
 canonical ids — so the entry's capstone is the contract itself.
 
 The `work-unit` artifact define activates on arrives one of two ways:
-created by `decompose`, or materialized from an existing forge ticket by
+created by `decompose`, or materialized from an existing forge work-unit by
 the [`acquire`](../../skills/acquire/SKILL.md) skill. Acquisition is
 skill-side intake — the mirror of decompose's create path — and reaches
 runa's store through decompose's own `work-unit` output tool, the same
 way the `research` skill's output reaches the store through a protocol's
 `may_produce` tool (see *the `may_produce` bridge* below). It creates no
-ticket, derives the artifact one-way from the ticket (ticket = planning
+work-unit, derives the artifact one-way from the work-unit (work-unit = planning
 home, artifact = execution snapshot, `handle` = back-link), and uses
 decompose's tracker-backed `instance_id` convention, so acquired and
 decomposed work-units are indistinguishable downstream. The manifest
@@ -140,7 +140,7 @@ live in [`manifest.toml`](../../manifest.toml); each protocol's
 the distinction visible: ordinary planning reaches decompose through the
 `requirements` trigger, and `requirements` is accepted so the protocol
 receives the content it is decomposing — not required, because
-cold-start ticket entry substitutes the trigger with the ticket
+cold-start work-unit entry substitutes the trigger with the work-unit
 reference, reaches the same `work-unit` output surface, and has no
 planning-phase requirements artifact yet.
 
@@ -515,13 +515,13 @@ groundwork treats it as opaque: schema validity and conformance are
 checked against the vendored Forge Capability handle definition, while
 identity comparisons derive from `id` equality rather than provider
 coordinates or display text. The vendored schema at
-[`schemas/forge-capability/v1/forge-capability.schema.json`](../../schemas/forge-capability/v1/forge-capability.schema.json)
+[`schemas/forge-capability/v2/forge-capability.schema.json`](../../schemas/forge-capability/v2/forge-capability.schema.json)
 is the single home for the handle definition and the canonical
 capability operations; groundwork artifact schemas carry self-contained
 copies so runa can validate artifacts directly, and conformance fails
 when those copies drift from the vendored `#/$defs/handle` definition.
 The [decompose delivery rules](../../protocols/decompose/PROTOCOL.md)
-create the tracker ticket before first work-unit delivery and carry the
+create the tracker work-unit before first work-unit delivery and carry the
 returned connector handle exactly once.
 
 ## Where Documentation Discipline Lives

--- a/docs/architecture/decisions/0002-methodology-sovereignty.md
+++ b/docs/architecture/decisions/0002-methodology-sovereignty.md
@@ -1,6 +1,6 @@
 # ADR-0002: Methodology Sovereignty
 
-Current forge work follows the connector-owned Forge Capability v1.1.0
+Current forge work follows the connector-owned Forge Capability v2.0.0
 contract: Groundwork carries connector-issued `{ id, display }` handles in
 artifacts and invokes canonical capability operations through runa's connector
 MCP surface.

--- a/docs/architecture/decisions/0004-contract-first-scoped-pipeline.md
+++ b/docs/architecture/decisions/0004-contract-first-scoped-pipeline.md
@@ -93,43 +93,43 @@ begins"; verification/documentation share the boundary "work is complete").
 The scoped pipeline activates on a `work-unit` artifact, but the live
 planning surface is the forge tracker, and before this redesign the only
 path to a work-unit artifact was `decompose`'s create path — which refuses
-to adopt a pre-existing ticket (`create-ticket` is first-delivery-only).
-The natural developer entry, "start on ticket #N" for a ticket already on
+to adopt a pre-existing work-unit (`create-work-unit` is first-delivery-only).
+The natural developer entry, "start on work-unit #N" for a work-unit already on
 the tracker, had no path: `decompose` would not adopt it, `runa take <id>`
 was retired, and runa-native decompose is future work.
 
 The **methodology half** of that entry is decided here: the `acquire` skill.
-Given a reference to an existing forge ticket on either forge, an agent in a
-scoped session reads the ticket through the existing `read-ticket` mechanic
+Given a reference to an existing forge work-unit on either forge, an agent in a
+scoped session reads the work-unit through the existing `read-work-unit` mechanic
 and materializes a `work-unit` artifact from it, after which `take` proceeds
 unchanged. The governing constraints:
 
 - **Acquisition produces the work-unit artifact; take's contract is
   untouched** (take still requires/triggers on `work-unit`).
-- **One-way derivation**, ticket → artifact (Single Home): the ticket is the
+- **One-way derivation**, work-unit → artifact (Single Home): the work-unit is the
   planning home, the artifact its execution-scoped snapshot, `handle` the
-  back-link. Nothing in acquisition writes content back to the ticket.
+  back-link. Nothing in acquisition writes content back to the work-unit.
 - **Adopt, don't create.** Acquisition is the mirror of decompose's create
-  path — decompose creates the ticket it delivers; acquisition adopts the
-  ticket it is given — and creates no ticket. `handle` is the ticket's, and
+  path — decompose creates the work-unit it delivers; acquisition adopts the
+  work-unit it is given — and creates no work-unit. `handle` is the work-unit's, and
   the tracker-backed `work-unit-<N>-<short-slug>` instance-id convention
   matches decompose's, so acquired and decomposed work-units are
   indistinguishable downstream.
 - **No new mechanic, artifact type, or schema.** The forge read resolves
-  through `read-ticket`; delivery is through the existing `work-unit` MCP
+  through `read-work-unit`; delivery is through the existing `work-unit` MCP
   tool. Acquisition is skill-side intake reaching the store through
   decompose's declared output tool — the same shape as `research`-record's
   `may_produce` bridge — so `decompose` remains the sole manifest producer
   of `work-unit`.
-- **Gaps route to refinement, never to invention.** Where ticket content
+- **Gaps route to refinement, never to invention.** Where work-unit content
   does not map onto required schema fields (no extractable acceptance
-  criteria, empty body, non-open ticket), the materializer surfaces a named
+  criteria, empty body, non-open work-unit), the materializer surfaces a named
   work-unit-quality defect routed to `decompose`'s `refine-work-unit`
   discipline rather than fabricating content.
 - **Claiming stays take's.** Acquisition materializes; take claims the
   tracker in its workspace-prep step. The one-way boundary stays clean.
 
-The **runtime half** — a cold-start entrypoint that accepts a ticket
+The **runtime half** — a cold-start entrypoint that accepts a work-unit
 reference and opens the scoped session in which acquisition runs (so the
 operator types the equivalent of "take runa#14" against an empty store) —
 needs a runtime change and stays flagged below as
@@ -210,7 +210,7 @@ context to fire passively — with full expositions in references.
    "stopped short of submit" were accidents of the session framing removed
    in (2).
 7. **The crisp entry tool** → split by layer. The methodology half — a
-   ticket → work-unit materialization path — is decided here as the
+   work-unit → work-unit materialization path — is decided here as the
    `acquire` skill (see *Entry: two sources, one artifact*). The runtime
    half — a cold-start entrypoint that opens the session acquisition runs in
    — stays flagged below as a coordinated runtime dependency
@@ -244,7 +244,7 @@ context to fire passively — with full expositions in references.
   The methodology half of acquisition is delivered here (the `acquire`
   skill; see *Entry: two sources, one artifact*), and runs today inside a
   `decompose`-scoped session. What remains runtime-side is the cold-start
-  affordance: an entrypoint that takes a bare ticket reference against an
+  affordance: an entrypoint that takes a bare work-unit reference against an
   empty store and opens the scoped session acquisition runs in — so the
   operator types "take runa#14" with nothing materialized yet. That is the
   retired `runa take <id>` shape, filed as

--- a/docs/architecture/groundwork-skill-ontology-row-1-audit.md
+++ b/docs/architecture/groundwork-skill-ontology-row-1-audit.md
@@ -37,7 +37,7 @@ Groundwork scoped pipeline.
 
 | Asset | Kind | Domain Coupling | Form | Membership-Test Ground |
 |---|---|---|---|---|
-| acquire | skill | domain:software | skill | Gazette or another non-code methodology may need entry from an existing planning record, but this skill materializes a forge ticket as a `work-unit` snapshot with a `handle` for `define`. |
+| acquire | skill | domain:software | skill | Gazette or another non-code methodology may need entry from an existing planning record, but this skill materializes a forge work-unit as a `work-unit` snapshot with a `handle` for `define`. |
 | code-review | skill | domain:software | skill | Gazette needs independent quality judgment, but code-review's criteria are software-specific: behavior regressions, schemas, interfaces, tests, and documentation impact for code changes. |
 | contract | skill | universal | skill | Gazette or another domain still needs an executable definition of done across behavior, documentation, and quality dimensions; only the evidence form changes. |
 | debug | skill | universal | skill | Root-cause-before-fix applies to non-code failures as well as software failures; gazette grounding or publication failures still need evidence before correction. |
@@ -84,7 +84,7 @@ skills.
 
 | Domain Skill | Domain Scope | Projects From | Inherited Discipline | Domain Delta |
 |---|---|---|---|---|
-| acquire | domain:software | acquisition | Materialize an execution artifact from an authorized planning record without fabricating content. | Reads a forge ticket, preserves `handle`, derives a `work-unit` body, and hands execution to `define`. |
+| acquire | domain:software | acquisition | Materialize an execution artifact from an authorized planning record without fabricating content. | Reads a forge work-unit, preserves `handle`, derives a `work-unit` body, and hands execution to `define`. |
 | code-review | domain:software | quality-review | Judge proposed work against scope, contract, evidence, and recipient impact before approval. | Adds software-specific correctness checks: code semantics, schemas, interfaces, tests, regressions, and current documentation accuracy. |
 
 ## Lateral Harmonics

--- a/manifest.toml
+++ b/manifest.toml
@@ -85,7 +85,7 @@ name = "run-test"
 #
 # `decompose` is also the acquisition surface: it is the sole unscoped
 # producer of `work-unit`. Ordinary planning still reaches it through the
-# `requirements` trigger, while cold-start ticket entry substitutes that
+# `requirements` trigger, while cold-start work-unit entry substitutes that
 # trigger so acquisition can materialize the work-unit before requirements
 # exist.
 #

--- a/protocols/decompose/PROTOCOL.md
+++ b/protocols/decompose/PROTOCOL.md
@@ -3,7 +3,7 @@ name: decompose
 description: >-
   The work-unit protocol. Produce `work-unit` artifacts: create, refine, and
   triage work-units, decompose epics into them, and deliver each through the
-  `work-unit` MCP tool with its connector ticket handle. Close-state review
+  `work-unit` MCP tool with its connector work-unit handle. Close-state review
   happens here; the close itself is performed by `land`. The authoring craft
   lives in the `work-unit-craft` skill; this protocol consults it.
 metadata:
@@ -25,9 +25,9 @@ protocol consults that home and owns only its own moves.
 `decompose` is also Groundwork's acquisition surface: it is the sole unscoped
 producer of the `work-unit` artifact. Ordinary planning reaches this protocol
 when a `requirements` artifact satisfies its trigger, so requirements still
-precede decomposition in the planning route. Cold-start ticket entry substitutes
+precede decomposition in the planning route. Cold-start work-unit entry substitutes
 that trigger with the entry reference and serves the same work-unit output
-surface so the acquire discipline can read the ticket and materialize the
+surface so the acquire discipline can read the work-unit and materialize the
 work-unit before any planning-phase requirements artifact exists. The manifest
 therefore keeps `requirements` as the trigger, not as a `requires` precondition.
 
@@ -180,11 +180,11 @@ connector handle back to it.
 
 Deliver each `work-unit` artifact by invoking the `work-unit` MCP tool once
 per delivered artifact. Every work-unit is tracker-backed. For a newly created
-work-unit, first invoke the connector capability `create-ticket` operation and
-carry the returned `{ id, display }` handle into the artifact body. `create-ticket`
+work-unit, first invoke the connector capability `create-work-unit` operation and
+carry the returned `{ id, display }` handle into the artifact body. `create-work-unit`
 is a first-delivery-only step: refinement never calls it, and decompose does not
-adopt a pre-existing tracker ticket into a new artifact. If a tracker ticket
-already exists, this delivery path must not create a second ticket for it.
+adopt a pre-existing tracker work-unit into a new artifact. If a tracker work-unit
+already exists, this delivery path must not create a second work-unit for it.
 The object below is MCP tool input, not artifact body.
 `instance_id` is a tool parameter.
 It names the artifact instance and becomes the workspace filename.
@@ -198,10 +198,10 @@ Use a fresh `instance_id` when creating a new work-unit. Reuse the existing
 `instance_id` when refining an already-delivered work-unit artifact so artifact
 identity and inbound dependency references remain stable. First MCP delivery
 uses a stable id derived from the connector handle's `id`, and must populate
-`handle` exactly once from the identity returned by `create-ticket`.
+`handle` exactly once from the identity returned by `create-work-unit`.
 Subsequent updates reuse the `instance_id` established at first delivery and
 carry the existing `handle` through unchanged from the previously delivered
-artifact body. Do not call `create-ticket`, re-derive `handle`, or omit
+artifact body. Do not call `create-work-unit`, re-derive `handle`, or omit
 `handle` during refinement; MCP delivery persists the submitted body. In this
 section, "refining an existing work-unit" means refining an existing artifact,
 not merely refining a tracker item.
@@ -219,8 +219,8 @@ work-unit({
   out_of_scope: ["submit protocol", "land protocol"],
   dependencies: ["work-unit-122-artifact-store-cleanup"],
   handle: {
-    id: "<connector-issued ticket identity>",
-    display: "<human-readable ticket identity>"
+    id: "<connector-issued work-unit identity>",
+    display: "<human-readable work-unit identity>"
   }
 })
 ```
@@ -279,9 +279,9 @@ decompose's own — epic, graph, and delivery misuse.
   cannot answer without reading all task bodies, the graph is missing.*
 
 - `refinement-as-first-delivery`: a refinement is delivered as if it were a
-  first delivery — `create-ticket` invoked, a fresh `instance_id` minted, or
+  first delivery — `create-work-unit` invoked, a fresh `instance_id` minted, or
   `handle` re-derived for an already-delivered work-unit. The tracker gains a
-  second ticket for the same work, or the artifact store gains a duplicate
+  second work-unit for the same work, or the artifact store gains a duplicate
   whose inbound `dependencies` still point at the stale instance.
   *Recognition: before delivering, ask "does a delivered artifact for this
   work-unit already exist?" If yes, the delivery is a refinement — reuse its
@@ -294,8 +294,8 @@ decompose's own — epic, graph, and delivery misuse.
 - `reckon`: first-principles constraint verification before work-unit framing,
   refinement, and epic decomposition.
 - `acquire` (skill): the mirror of this protocol's create path — decompose
-  creates the ticket it delivers; acquire adopts the ticket it is given and
-  creates none. A ticket-quality gap acquire surfaces routes to
+  creates the work-unit it delivers; acquire adopts the work-unit it is given and
+  creates none. A work-unit-quality gap acquire surfaces routes to
   `refine-work-unit` here.
 - `define`: contract-authoring entry discipline that states what done means
   for one work-unit.

--- a/protocols/define/PROTOCOL.md
+++ b/protocols/define/PROTOCOL.md
@@ -16,7 +16,7 @@ metadata:
 Define authors the contract for a single work-unit. Selection happened
 upstream — the work-unit artifact exists and runa activates define on it,
 having arrived either from `decompose` (a newly created work-unit) or from
-the `acquire` skill (materialized from an existing forge ticket). Entry's
+the `acquire` skill (materialized from an existing forge work-unit). Entry's
 job is to stand on prepared ground and state, precisely and verifiably,
 what will be true when this work is done.
 
@@ -45,10 +45,10 @@ proves it, or records it.
    work whose `dependencies` are still open; a blocked work-unit is a
    substrate signal, not an invitation.
 
-   Ground the frame in the whole ticket.
-   The ticket body is the work-unit's spec.
+   Ground the frame in the whole work-unit.
+   The work-unit body is the work-unit's spec.
    The comment log is the running record: review state, dispositions, and directives live there.
-   `acquire` surfaces it from the `read-ticket` snapshot per forge-capability `1.2.0`.
+   `acquire` surfaces it from the `read-work-unit` snapshot per forge-capability `2.0.0`.
    The newest review directives at the submitted head govern the work.
    The body remains the spec, and directives refine delivery against it.
    Weigh each log entry by recency and standing: a directive superseded by a newer round, or by a body amendment, is record, not direction.
@@ -182,7 +182,7 @@ begins — the dose is proportional.
 - `decompose` (protocol): owns work-unit boundaries and acceptance-criteria
   quality. A work-unit that cannot be framed or contracted routes back there.
 - `acquire` (skill): the other entry source — materializes the work-unit
-  artifact from an existing forge ticket before define activates on it.
+  artifact from an existing forge work-unit before define activates on it.
 - `plan` (protocol): the next station — consumes the contract and converges
   on a decision-complete design.
 - `land` (protocol): the closing bookend — define establishes what done means;

--- a/protocols/land/PROTOCOL.md
+++ b/protocols/land/PROTOCOL.md
@@ -120,7 +120,7 @@ The protocol is not a forge operation. It must not activate from a raw
 - `schemas/change-approved.schema.json` defines the approval disposition.
 - `schemas/change-proposal.schema.json` defines the proposal detail land
   resolves before mapping it to the connector apply input.
-- `schemas/forge-capability/v1/forge-capability.schema.json` defines the
+- `schemas/forge-capability/v2/forge-capability.schema.json` defines the
   `apply-approved-change-input` connector payload land must satisfy.
 - `schemas/completion-record.schema.json` defines the record fields land
   fills from the uniform evidence surface: `criterion_summary` carries

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -28,7 +28,7 @@ is tracker-backed and carries the connector-issued `{ id, display }` handle.
 Planning-phase work-unit bodies do not carry a top-level `work_unit` field.
 
 The vendored forge capability schema at
-`schemas/forge-capability/v1/forge-capability.schema.json` is the authority for
+`schemas/forge-capability/v2/forge-capability.schema.json` is the authority for
 the connector handle definition and the eight canonical forge operations.
 Groundwork artifact schemas carry self-contained copies of the handle schema so
 runa can validate artifacts without an external registry or network fetch, and

--- a/schemas/forge-capability/v2/forge-capability.schema.json
+++ b/schemas/forge-capability/v2/forge-capability.schema.json
@@ -1,20 +1,25 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "x-tesserine-canonical": {
-    "version": "1.2.0",
-    "schema_url": "https://raw.githubusercontent.com/tesserine/commons/b229fb1a840c27ced31d582b40d766f4f441dcf6/schemas/forge-capability/v1/forge-capability.schema.json"
+    "version": "2.0.0",
+    "schema_url": "https://raw.githubusercontent.com/tesserine/commons/e75e211689e92a4772614bfe6e4eca4b647d4d66/schemas/forge-capability/v2/forge-capability.schema.json"
   },
   "title": "Forge Capability",
-  "description": "Canonical schema for the forge capability connector tool-set and operation payloads. Version 1.2.0. commons is the spec authority; FORGE-CAPABILITY.md carries the governing prose and ADR-0005 describes the system-conventions pattern under which this lives. When this schema and FORGE-CAPABILITY.md disagree, FORGE-CAPABILITY.md is authoritative.",
+  "description": "Canonical schema for the forge capability connector tool-set and operation payloads. Version 2.0.0. commons is the spec authority; FORGE-CAPABILITY.md carries the governing prose and ADR-0005 describes the system-conventions pattern under which this lives. When this schema and FORGE-CAPABILITY.md disagree, FORGE-CAPABILITY.md is authoritative.",
   "type": "object",
-  "required": ["capability", "version", "handle_schema", "tools"],
+  "required": [
+    "capability",
+    "version",
+    "handle_schema",
+    "tools"
+  ],
   "additionalProperties": false,
   "properties": {
     "capability": {
       "const": "forge"
     },
     "version": {
-      "const": "1.2.0"
+      "const": "2.0.0"
     },
     "handle_schema": {
       "const": "#/$defs/handle"
@@ -30,12 +35,12 @@
       "allOf": [
         {
           "contains": {
-            "$ref": "#/$defs/read-ticket-tool"
+            "$ref": "#/$defs/read-work-unit-tool"
           }
         },
         {
           "contains": {
-            "$ref": "#/$defs/create-ticket-tool"
+            "$ref": "#/$defs/create-work-unit-tool"
           }
         },
         {
@@ -74,7 +79,10 @@
   "$defs": {
     "handle": {
       "type": "object",
-      "required": ["id", "display"],
+      "required": [
+        "id",
+        "display"
+      ],
       "additionalProperties": false,
       "properties": {
         "id": {
@@ -92,8 +100,8 @@
     "operation-name": {
       "type": "string",
       "enum": [
-        "read-ticket",
-        "create-ticket",
+        "read-work-unit",
+        "create-work-unit",
         "claim-work-unit",
         "record-progress",
         "reflect-disposition",
@@ -114,7 +122,12 @@
     },
     "tool-base": {
       "type": "object",
-      "required": ["operation", "name", "input_schema", "output_schema"],
+      "required": [
+        "operation",
+        "name",
+        "input_schema",
+        "output_schema"
+      ],
       "additionalProperties": false,
       "properties": {
         "operation": {
@@ -134,10 +147,10 @@
     "tool": {
       "oneOf": [
         {
-          "$ref": "#/$defs/read-ticket-tool"
+          "$ref": "#/$defs/read-work-unit-tool"
         },
         {
-          "$ref": "#/$defs/create-ticket-tool"
+          "$ref": "#/$defs/create-work-unit-tool"
         },
         {
           "$ref": "#/$defs/claim-work-unit-tool"
@@ -159,7 +172,7 @@
         }
       ]
     },
-    "read-ticket-tool": {
+    "read-work-unit-tool": {
       "allOf": [
         {
           "$ref": "#/$defs/tool-base"
@@ -168,22 +181,22 @@
           "type": "object",
           "properties": {
             "operation": {
-              "const": "read-ticket"
+              "const": "read-work-unit"
             },
             "name": {
-              "const": "read-ticket"
+              "const": "read-work-unit"
             },
             "input_schema": {
-              "const": "#/$defs/read-ticket-input"
+              "const": "#/$defs/read-work-unit-input"
             },
             "output_schema": {
-              "const": "#/$defs/ticket-snapshot"
+              "const": "#/$defs/work-unit-snapshot"
             }
           }
         }
       ]
     },
-    "create-ticket-tool": {
+    "create-work-unit-tool": {
       "allOf": [
         {
           "$ref": "#/$defs/tool-base"
@@ -192,16 +205,16 @@
           "type": "object",
           "properties": {
             "operation": {
-              "const": "create-ticket"
+              "const": "create-work-unit"
             },
             "name": {
-              "const": "create-ticket"
+              "const": "create-work-unit"
             },
             "input_schema": {
-              "const": "#/$defs/create-ticket-input"
+              "const": "#/$defs/create-work-unit-input"
             },
             "output_schema": {
-              "const": "#/$defs/ticket-snapshot"
+              "const": "#/$defs/work-unit-snapshot"
             }
           }
         }
@@ -351,21 +364,26 @@
         }
       ]
     },
-    "read-ticket-input": {
+    "read-work-unit-input": {
       "type": "object",
-      "required": ["reference"],
+      "required": [
+        "reference"
+      ],
       "additionalProperties": false,
       "properties": {
         "reference": {
           "type": "string",
-          "description": "Connector-interpreted ticket reference in the active deployment; may carry provider coordinates the connector validates against its configured scope. See FORGE-CAPABILITY.md (Forge Work-Unit Identity).",
+          "description": "Connector-interpreted work-unit reference in the active deployment; may carry provider coordinates the connector validates against its configured scope. See FORGE-CAPABILITY.md (Forge Work-Unit Identity).",
           "minLength": 1
         }
       }
     },
-    "create-ticket-input": {
+    "create-work-unit-input": {
       "type": "object",
-      "required": ["title", "body"],
+      "required": [
+        "title",
+        "body"
+      ],
       "additionalProperties": false,
       "properties": {
         "title": {
@@ -380,7 +398,9 @@
     },
     "claim-work-unit-input": {
       "type": "object",
-      "required": ["handle"],
+      "required": [
+        "handle"
+      ],
       "additionalProperties": false,
       "properties": {
         "handle": {
@@ -390,7 +410,10 @@
     },
     "record-progress-input": {
       "type": "object",
-      "required": ["handle", "body"],
+      "required": [
+        "handle",
+        "body"
+      ],
       "additionalProperties": false,
       "properties": {
         "handle": {
@@ -404,7 +427,9 @@
     },
     "comment-entry": {
       "type": "object",
-      "required": ["body"],
+      "required": [
+        "body"
+      ],
       "additionalProperties": false,
       "properties": {
         "body": {
@@ -422,9 +447,13 @@
         }
       }
     },
-    "ticket-snapshot": {
+    "work-unit-snapshot": {
       "type": "object",
-      "required": ["handle", "title", "state"],
+      "required": [
+        "handle",
+        "title",
+        "state"
+      ],
       "additionalProperties": false,
       "properties": {
         "handle": {
@@ -435,7 +464,10 @@
           "minLength": 1
         },
         "body": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "state": {
           "type": "string",
@@ -443,7 +475,7 @@
         },
         "comments": {
           "type": "array",
-          "description": "Ordered comment log, oldest first. The ticket body is the work-unit's spec; the comment log is its running record — review state, dispositions, and directives.",
+          "description": "Ordered comment log, oldest first. The body is the work-unit's spec; the comment log is its running record — review state, dispositions, and directives.",
           "items": {
             "$ref": "#/$defs/comment-entry"
           }
@@ -452,7 +484,10 @@
     },
     "work-unit-effect": {
       "type": "object",
-      "required": ["handle", "receipt"],
+      "required": [
+        "handle",
+        "receipt"
+      ],
       "additionalProperties": false,
       "properties": {
         "handle": {
@@ -471,7 +506,15 @@
     },
     "deliver-change-proposal-input": {
       "type": "object",
-      "required": ["work_unit", "branch", "commit", "base", "summary", "body", "version"],
+      "required": [
+        "work_unit",
+        "branch",
+        "commit",
+        "base",
+        "summary",
+        "body",
+        "version"
+      ],
       "additionalProperties": false,
       "properties": {
         "work_unit": {
@@ -503,7 +546,12 @@
     },
     "change-proposal": {
       "type": "object",
-      "required": ["handle", "work_unit", "commit", "version"],
+      "required": [
+        "handle",
+        "work_unit",
+        "commit",
+        "version"
+      ],
       "additionalProperties": false,
       "properties": {
         "handle": {
@@ -524,7 +572,10 @@
     },
     "finding": {
       "type": "object",
-      "required": ["observation", "classification"],
+      "required": [
+        "observation",
+        "classification"
+      ],
       "additionalProperties": false,
       "properties": {
         "observation": {
@@ -533,7 +584,10 @@
         },
         "classification": {
           "type": "string",
-          "enum": ["blocking", "non-blocking"]
+          "enum": [
+            "blocking",
+            "non-blocking"
+          ]
         },
         "location": {
           "type": "string",
@@ -543,12 +597,21 @@
     },
     "disposition": {
       "type": "object",
-      "required": ["kind", "against_version", "reviewer", "reviewed_at", "findings"],
+      "required": [
+        "kind",
+        "against_version",
+        "reviewer",
+        "reviewed_at",
+        "findings"
+      ],
       "additionalProperties": false,
       "properties": {
         "kind": {
           "type": "string",
-          "enum": ["approved", "needs-revision"]
+          "enum": [
+            "approved",
+            "needs-revision"
+          ]
         },
         "against_version": {
           "type": "integer",
@@ -573,7 +636,12 @@
     },
     "reflect-disposition-input": {
       "type": "object",
-      "required": ["work_unit", "change", "disposition", "body"],
+      "required": [
+        "work_unit",
+        "change",
+        "disposition",
+        "body"
+      ],
       "additionalProperties": false,
       "properties": {
         "work_unit": {
@@ -593,7 +661,11 @@
     },
     "disposition-effect": {
       "type": "object",
-      "required": ["work_unit", "change", "receipt"],
+      "required": [
+        "work_unit",
+        "change",
+        "receipt"
+      ],
       "additionalProperties": false,
       "properties": {
         "work_unit": {
@@ -610,7 +682,13 @@
     },
     "apply-approved-change-input": {
       "type": "object",
-      "required": ["work_unit", "change", "approved_version", "approved_commit", "base"],
+      "required": [
+        "work_unit",
+        "change",
+        "approved_version",
+        "approved_commit",
+        "base"
+      ],
       "additionalProperties": false,
       "properties": {
         "work_unit": {
@@ -634,7 +712,12 @@
     },
     "apply-result": {
       "type": "object",
-      "required": ["work_unit", "change", "applied_commit", "receipt"],
+      "required": [
+        "work_unit",
+        "change",
+        "applied_commit",
+        "receipt"
+      ],
       "additionalProperties": false,
       "properties": {
         "work_unit": {
@@ -655,7 +738,12 @@
     },
     "completion": {
       "type": "object",
-      "required": ["criterion_summary", "gaps", "change_reference", "documentation_status"],
+      "required": [
+        "criterion_summary",
+        "gaps",
+        "change_reference",
+        "documentation_status"
+      ],
       "additionalProperties": false,
       "properties": {
         "criterion_summary": {
@@ -681,7 +769,11 @@
     },
     "close-out-input": {
       "type": "object",
-      "required": ["work_unit", "completion", "body"],
+      "required": [
+        "work_unit",
+        "completion",
+        "body"
+      ],
       "additionalProperties": false,
       "properties": {
         "work_unit": {
@@ -698,7 +790,10 @@
     },
     "close-out-effect": {
       "type": "object",
-      "required": ["work_unit", "receipt"],
+      "required": [
+        "work_unit",
+        "receipt"
+      ],
       "additionalProperties": false,
       "properties": {
         "work_unit": {

--- a/skills/acquire/SKILL.md
+++ b/skills/acquire/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: acquire
 description: >-
-  Entry from an existing forge ticket. Use to start scoped work from a ticket
+  Entry from an existing forge work-unit. Use to start scoped work from a work-unit
   reference that is already on the tracker (e.g. "define runa#14") when no
-  work-unit artifact exists yet — acquisition reads the ticket and
+  work-unit artifact exists yet — acquisition reads the work-unit and
   materializes the work-unit artifact that define then proceeds on. The mirror
-  of decompose's create path: decompose creates the ticket it delivers;
-  acquire adopts the ticket it is given, and creates no ticket.
+  of decompose's create path: decompose creates the work-unit it delivers;
+  acquire adopts the work-unit it is given, and creates no work-unit.
 metadata:
   version: "1.1.0"
   updated: "2026-07-02"
@@ -16,15 +16,15 @@ metadata:
 
 The scoped pipeline activates on a `work-unit` artifact, but the live
 planning surface is the forge tracker. Acquisition is the bridge for the
-natural developer entry — "start on ticket #N" — when that ticket already
-exists and no work-unit artifact does yet. It reads the ticket and
+natural developer entry — "start on work-unit #N" — when that work-unit already
+exists and no work-unit artifact does yet. It reads the work-unit and
 materializes the work-unit artifact; `define` then proceeds unchanged on that
 artifact through its existing contract.
 
-Acquisition is **one-way**: the ticket is the planning home, the artifact is
+Acquisition is **one-way**: the work-unit is the planning home, the artifact is
 its execution-scoped snapshot, and `handle` is the back-link. Nothing here
-writes artifact content back to the ticket, and nothing here creates a
-ticket — acquisition *adopts* the ticket it is given. An acquired work-unit
+writes artifact content back to the work-unit, and nothing here creates a
+work-unit — acquisition *adopts* the work-unit it is given. An acquired work-unit
 is indistinguishable downstream from a decomposed one: same `handle`, same
 `work-unit-<N>-<short-slug>` instance-id convention.
 
@@ -36,22 +36,22 @@ cold start.
 
 ## Steps
 
-1. **Read the ticket.** Invoke the connector capability `read-ticket`
+1. **Read the work-unit.** Invoke the connector capability `read-work-unit`
    operation exposed on runa's MCP surface:
 
    ```
-   read-ticket({ reference: "<tracker reference>" })
+   read-work-unit({ reference: "<tracker reference>" })
    ```
 
    The deployment-selected connector owns provider coordinates and
    credentials.
-   The `read-ticket` output includes an optional ordered `comments` log.
-   It also includes the whole ticket: `{handle, title, body, state}` plus the
+   The `read-work-unit` output includes an optional ordered `comments` log.
+   It also includes the whole work-unit: `{handle, title, body, state}` plus the
    connector-issued `{ id, display }` identity.
    The body is the work-unit's spec; the comment log is its running record — review state, dispositions, and directives.
-   Surface the log to the session as entry context so the session grounds on the whole ticket, not the spec alone.
+   Surface the log to the session as entry context so the session grounds on the whole work-unit, not the spec alone.
 
-2. **Materialize the artifact body.** Pipe the read-ticket output through
+2. **Materialize the artifact body.** Pipe the read-work-unit output through
    the materializer:
 
    ```
@@ -61,36 +61,36 @@ cold start.
    (Script path from the groundwork methodology root.)
 
    It derives the work-unit body — `title`, `description`, and
-   `acceptance_criteria` from the ticket content, `handle` carried through
+   `acceptance_criteria` from the work-unit content, `handle` carried through
    verbatim — and the `instance_id` (`work-unit-<sha256(handle.id)>`). The
    derivation never invents content (see step 3).
-   The artifact materializes from the ticket body alone.
+   The artifact materializes from the work-unit body alone.
    The comment log is read as entry context, never persisted into the artifact.
-   The ticket remains the planning home, and the artifact carries the spec.
+   The work-unit remains the planning home, and the artifact carries the spec.
 
-3. **Surface gaps; never invent.** When the ticket does not map cleanly onto
+3. **Surface gaps; never invent.** When the work-unit does not map cleanly onto
    the required schema fields — no extractable acceptance criteria, an empty
-   body, or a ticket that is not open — `materialize.py` exits non-zero with
+   body, or a work-unit that is not open — `materialize.py` exits non-zero with
    a named work-unit-quality defect. That is not an acquisition failure to
-   work around: it is a defect in the ticket at its planning home. Route it
-   to `decompose`'s `refine-work-unit` discipline (improve the ticket), then
+   work around: it is a defect in the work-unit at its planning home. Route it
+   to `decompose`'s `refine-work-unit` discipline (improve the work-unit), then
    re-acquire. Do not hand-fill the missing fields here — that would forge an
    execution snapshot the planning home never authorized.
 
 4. **Deliver the `work-unit` artifact.** Invoke the `work-unit` MCP tool with
    the materializer's `instance_id` and `artifact` body — the same call shape
-   `decompose` uses for a tracker-backed work-unit, with the ticket's
+   `decompose` uses for a tracker-backed work-unit, with the work-unit's
    `handle` carried unchanged. `work-unit` is a planning-phase artifact: the
    agent supplies the schema fields and runa does not inject `work_unit`. Do
-   not write the workspace JSON file directly; do not call `create-ticket`.
+   not write the workspace JSON file directly; do not call `create-work-unit`.
 
    ```
    work-unit({
      instance_id: "work-unit-<sha256-handle-id>",
-     title: "<from the ticket>",
-     description: "<from the ticket>",
-     acceptance_criteria: ["<from the ticket>"],
-     handle: { id: "<connector-issued ticket identity>", display: "<human-readable ticket identity>" }
+     title: "<from the work-unit>",
+     description: "<from the work-unit>",
+     acceptance_criteria: ["<from the work-unit>"],
+     handle: { id: "<connector-issued work-unit identity>", display: "<human-readable work-unit identity>" }
    })
    ```
 
@@ -99,34 +99,34 @@ cold start.
    acquired artifact.
 
 5. **Hand off to `define`.** Acquisition materializes; `define` claims. Tracker
-   claiming (assigning the ticket, marking it in progress) is `define`'s
+   claiming (assigning the work-unit, marking it in progress) is `define`'s
    workspace-preparation step, not acquisition's — keep the one-way boundary
    clean.
 
 ## Corruption Modes
 
-- `log-blindness`: handing off to `define` with the ticket's comment log
+- `log-blindness`: handing off to `define` with the work-unit's comment log
   unread and unsurfaced. The snapshot carries the running record so the
-  session grounds on the whole ticket; an entry that reads the spec alone
+  session grounds on the whole work-unit; an entry that reads the spec alone
   executes blind to its own live corrections.
-- `ticket-creation`: calling `create-ticket` during acquisition. Acquisition
-  adopts an existing ticket; creating one is `decompose`'s path, and doing
-  both makes a second ticket for the same work.
+- `work-unit-creation`: calling `create-work-unit` during acquisition. Acquisition
+  adopts an existing work-unit; creating one is `decompose`'s path, and doing
+  both makes a second work-unit for the same work.
 - `content-fabrication`: hand-filling acceptance criteria or a description
-  the ticket does not contain, instead of routing the gap to refinement. The
+  the work-unit does not contain, instead of routing the gap to refinement. The
   artifact must be a faithful snapshot of the planning home.
-- `write-back`: editing the ticket from acquisition (beyond `define`'s later
+- `write-back`: editing the work-unit from acquisition (beyond `define`'s later
   claim). Derivation is one-way.
 - `handle-drift`: re-deriving or altering the `handle` instead of carrying
-  the ticket's identity through verbatim — breaks the back-link and risks a
+  the work-unit's identity through verbatim — breaks the back-link and risks a
   downstream identity collision.
 
 ## Cross-References
 
 - `decompose` (protocol): the create path acquisition mirrors, and the home
-  of `refine-work-unit` — where a ticket-quality gap surfaced here is fixed.
+  of `refine-work-unit` — where a work-unit-quality gap surfaced here is fixed.
 - `define` (protocol): proceeds on the acquired artifact through its existing
   contract; owns tracker claiming.
-- `read-ticket` (connector capability operation): emits
-  `{handle, title, body, state}` and, per forge-capability `1.2.0`, the
+- `read-work-unit` (connector capability operation): emits
+  `{handle, title, body, state}` and, per forge-capability `2.0.0`, the
   optional ordered `comments` log for the selected connector.

--- a/skills/acquire/scripts/materialize.py
+++ b/skills/acquire/scripts/materialize.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
-"""Derive a work-unit artifact body from an existing connector ticket.
+"""Derive a work-unit artifact body from an existing connector work-unit.
 
-Input (stdin or path): the JSON a `read-ticket` connector operation emits —
+Input (stdin or path): the JSON a `read-work-unit` connector operation emits —
 ``{"handle": {...}, "title": str, "body": str|null, "state": str}``.
 
 Output (stdout, on success): ``{"instance_id": str, "artifact": {...}}`` where
 ``artifact`` is a work-unit body ready for the `work-unit` MCP tool — its
-``handle`` is the ticket's opaque connector handle, carried through verbatim
-(one-way derivation; the ticket is the planning home, the artifact its
+``handle`` is the work-unit's opaque connector handle, carried through verbatim
+(one-way derivation; the work-unit is the planning home, the artifact its
 execution-scoped snapshot).
 
-Derivation is deterministic and never invents content. Where the ticket does
+Derivation is deterministic and never invents content. Where the work-unit does
 not map cleanly onto the required schema fields — no extractable acceptance
-criteria, an empty body, or a ticket that is not open — the script exits
+criteria, an empty body, or a work-unit that is not open — the script exits
 non-zero with a named work-unit-quality defect, routing the gap to
-decompose's refinement discipline (fix the ticket at its planning home, then
+decompose's refinement discipline (fix the work-unit at its planning home, then
 re-acquire) rather than fabricating fields.
 """
 
@@ -27,7 +27,7 @@ import re
 import sys
 from pathlib import Path
 
-# Ticket states that mean the ticket is not open for work. GitHub reports
+# Work-unit states that mean the work-unit is not open for work. GitHub reports
 # "open"/"closed"; SourceHut reports a status string whose closed terminal is
 # "resolved". Compared case-insensitively so either forge's casing matches.
 CLOSED_STATES = {"closed", "resolved"}
@@ -43,7 +43,7 @@ CHECKBOX_ITEM = re.compile(r"^\s*[-*+]\s+\[[ xX]\]\s+(?P<text>\S.*?)\s*$")
 
 
 class MaterializeError(Exception):
-    """A work-unit-quality defect in the source ticket."""
+    """A work-unit-quality defect in the source work-unit."""
 
 
 def list_items(block: str) -> list[str]:
@@ -124,8 +124,8 @@ def extract_acceptance_criteria(body: str) -> list[str]:
     return checkbox_items(body)
 
 
-def materialize(ticket: dict) -> dict:
-    handle = ticket.get("handle")
+def materialize(work_unit: dict) -> dict:
+    handle = work_unit.get("handle")
     if (
         not isinstance(handle, dict)
         or set(handle) != {"id", "display"}
@@ -135,34 +135,34 @@ def materialize(ticket: dict) -> dict:
         or not handle["display"]
     ):
         raise MaterializeError(
-            "ticket payload is missing a connector handle; read-ticket must emit "
+            "work-unit payload is missing a connector handle; read-work-unit must emit "
             "handle.id and handle.display"
         )
     identity = handle["id"]
 
-    title = ticket.get("title")
+    title = work_unit.get("title")
     if not isinstance(title, str) or not title.strip():
-        raise MaterializeError(f"ticket {identity!r} has no title to derive the work-unit from")
+        raise MaterializeError(f"work-unit {identity!r} has no title to derive the work-unit from")
 
-    state = ticket.get("state")
+    state = work_unit.get("state")
     if isinstance(state, str) and state.strip().lower() in CLOSED_STATES:
         raise MaterializeError(
-            f"ticket {identity!r} is {state!r}, not open; acquire materializes open "
-            "tickets — reopen it or pick another"
+            f"work-unit {identity!r} is {state!r}, not open; acquire materializes open "
+            "work-units — reopen it or pick another"
         )
 
-    body = ticket.get("body")
+    body = work_unit.get("body")
     if not isinstance(body, str) or not body.strip():
         raise MaterializeError(
-            f"ticket {identity!r} has an empty body; it carries no description or "
+            f"work-unit {identity!r} has an empty body; it carries no description or "
             "acceptance criteria — route it to decompose's refine-work-unit "
-            "discipline to fill the ticket, then re-acquire"
+            "discipline to fill the work-unit, then re-acquire"
         )
 
     criteria = extract_acceptance_criteria(body)
     if not criteria:
         raise MaterializeError(
-            f"ticket {identity!r} has no extractable acceptance criteria "
+            f"work-unit {identity!r} has no extractable acceptance criteria "
             "(no checklist items, no Acceptance Criteria section); route it to "
             "decompose's refine-work-unit discipline rather than inventing them"
         )
@@ -177,28 +177,28 @@ def materialize(ticket: dict) -> dict:
     return {"instance_id": f"work-unit-{digest}", "artifact": artifact}
 
 
-def load_ticket(path: str | None) -> dict:
+def load_work_unit(path: str | None) -> dict:
     raw = sys.stdin.read() if path in (None, "-") else Path(path).read_text(encoding="utf-8")
     try:
-        ticket = json.loads(raw)
+        work_unit = json.loads(raw)
     except json.JSONDecodeError as error:
-        raise MaterializeError(f"read-ticket output is not valid JSON: {error}") from error
-    if not isinstance(ticket, dict):
-        raise MaterializeError("read-ticket output must be a JSON object")
-    return ticket
+        raise MaterializeError(f"read-work-unit output is not valid JSON: {error}") from error
+    if not isinstance(work_unit, dict):
+        raise MaterializeError("read-work-unit output must be a JSON object")
+    return work_unit
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Derive a work-unit artifact body from an existing forge ticket."
+        description="Derive a work-unit artifact body from an existing forge work-unit."
     )
     parser.add_argument(
-        "path", nargs="?", help="read-ticket output path, or '-'/omit for stdin"
+        "path", nargs="?", help="read-work-unit output path, or '-'/omit for stdin"
     )
     args = parser.parse_args()
 
     try:
-        result = materialize(load_ticket(args.path))
+        result = materialize(load_work_unit(args.path))
     except MaterializeError as error:
         print(f"work-unit-quality defect: {error}", file=sys.stderr)
         return 1

--- a/skills/contract/SKILL.md
+++ b/skills/contract/SKILL.md
@@ -234,9 +234,9 @@ breaks on refactor and specifies nothing.
 A well-formed scenario can still specify nothing. "Observable, not internal"
 guards one direction — assertions that reach into internals break on refactor
 and pin implementation. The opposite failure is as fatal: a Then so shallow a
-canned return satisfies it. `create-ticket returns a complete-scoped handle` is
+canned return satisfies it. `create-work-unit returns a complete-scoped handle` is
 observable, and a connector that builds the handle string while creating no
-ticket passes it. The scenario proves the shape of a return, not that the work
+work-unit passes it. The scenario proves the shape of a return, not that the work
 happened.
 
 A contract is robust when **every scenario fails on a stub** — a vacuous or
@@ -248,8 +248,8 @@ Three shapes of hollow scenario, with the repair:
 
 - **Shape, not effect.** The Then asserts the structure of a return — a
   well-formed handle, a schema-valid payload — which a stub fabricates. Assert
-  the effect a stub cannot fake instead: not "create-ticket returns a handle"
-  but "the ticket named by the handle reads back"; not "the connector validates
+  the effect a stub cannot fake instead: not "create-work-unit returns a handle"
+  but "the work-unit named by the handle reads back"; not "the connector validates
   the operation" but "the operation issues the provider request," checkable
   against a recording transport with no live side effect.
 - **No falsifying case.** Every scenario is a positive — "valid input is
@@ -275,12 +275,12 @@ one such scenario. The check is cheap, it runs before any code exists, and it
 is the line between a contract that defines done and one that describes the
 happy shape of done.
 
-Hollow: `create_ticket_returns_complete_handle` — asserts the returned handle is
+Hollow: `create_work_unit_returns_complete_handle` — asserts the returned handle is
 well-formed; a connector that fabricates the handle and never calls the forge
-passes. Robust: `create_ticket_persists_a_retrievable_ticket` — Given a
-recording transport (or a real forge on the gated path), When create-ticket
+passes. Robust: `create_work_unit_persists_a_retrievable_ticket` — Given a
+recording transport (or a real forge on the gated path), When create-work-unit
 runs, Then the transport received the create request with the mapped fields and
-the ticket named by the returned handle reads back. The fabricating stub fails
+the work-unit named by the returned handle reads back. The fabricating stub fails
 the first Then; the no-request stub fails the second.
 
 ### Documentation-deliverable behavior gates

--- a/skills/orient/SKILL.md
+++ b/skills/orient/SKILL.md
@@ -50,8 +50,8 @@ establishes what actually needs doing; `decompose` breaks it into
 work-units with acceptance criteria and dependency edges.
 
 **Entry.** A work-unit reaches the scoped pipeline one of two ways: newly
-created by `decompose`, or materialized from an existing forge ticket by the
-`acquire` skill (the "start on ticket #N" path). Either way the result is a
+created by `decompose`, or materialized from an existing forge work-unit by the
+`acquire` skill (the "start on work-unit #N" path). Either way the result is a
 work-unit artifact, indistinguishable downstream, that `define` activates on.
 
 **The scoped pipeline (per work-unit).** Seven stations carry one selected
@@ -109,9 +109,9 @@ These are not stations; they engage when their trigger fires, at any stage.
   the codebase.
 - **`code-review`** — the evaluation discipline `review` applies to a
   change proposal.
-- **`acquire`** — entry from an existing forge ticket: reads the ticket and
+- **`acquire`** — entry from an existing forge work-unit: reads the work-unit and
   materializes the work-unit artifact `define` activates on. Fires at the
-  cold-start boundary, when work begins from a ticket reference.
+  cold-start boundary, when work begins from a work-unit reference.
 
 ## Integration Principles
 

--- a/skills/verification-craft/SKILL.md
+++ b/skills/verification-craft/SKILL.md
@@ -53,7 +53,7 @@ tokens are the invariant, and a meaning-preserving rewrite still passes.
 Worked example: `test_entry_surfaces_ground_on_the_whole_ticket` in
 [`tests/test_forge_capability.py`](https://github.com/tesserine/groundwork/blob/252024f/tests/test_forge_capability.py)
 uses `tooling.prose_conformance.entry_surface_coherence` to check the
-read-ticket comment-log lifecycle across `acquire` and `define` instead of
+read-work-unit comment-log lifecycle across `acquire` and `define` instead of
 pinning one sentence about entry context.
 
 ### Structural

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,4 +1,4 @@
-"""Acquisition: materializing a work-unit artifact from an existing connector ticket."""
+"""Acquisition: materializing a work-unit artifact from an existing connector work-unit."""
 
 import json
 import os
@@ -15,17 +15,17 @@ ROOT = Path(__file__).resolve().parents[1]
 MATERIALIZE = ROOT / "skills" / "acquire" / "scripts" / "materialize.py"
 
 TICKET_BODY = (
-    "Cold-start entry from a forge ticket reference.\n\n"
+    "Cold-start entry from a forge work-unit reference.\n\n"
     "## Acceptance criteria\n\n"
-    "- [ ] Given an existing ticket, an artifact is materialized\n"
-    "- [ ] The artifact handle identifies that ticket\n"
+    "- [ ] Given an existing work-unit, an artifact is materialized\n"
+    "- [ ] The artifact handle identifies that work-unit\n"
 )
 
 
-def materialize(read_ticket_stdout: str) -> subprocess.CompletedProcess[str]:
+def materialize(read_work_unit_stdout: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(MATERIALIZE)],
-        input=read_ticket_stdout,
+        input=read_work_unit_stdout,
         capture_output=True,
         text=True,
     )
@@ -69,7 +69,7 @@ class MaterializeTicketTests(unittest.TestCase):
     def test_opaque_connector_ticket_materializes_to_schema_valid_adopted_work_unit(self) -> None:
         ticket = {
             "handle": {"id": "ticket:opaque-alpha", "display": "TRACK-ALPHA"},
-            "title": "task(entry): cold-start scoped entry from a connector ticket",
+            "title": "task(entry): cold-start scoped entry from a connector work-unit",
             "body": TICKET_BODY,
             "state": "open",
         }
@@ -82,8 +82,8 @@ class MaterializeTicketTests(unittest.TestCase):
         self.assertEqual(ticket["handle"], payload["artifact"]["handle"])
         self.assertEqual(
             [
-                "Given an existing ticket, an artifact is materialized",
-                "The artifact handle identifies that ticket",
+                "Given an existing work-unit, an artifact is materialized",
+                "The artifact handle identifies that work-unit",
             ],
             payload["artifact"]["acceptance_criteria"],
         )
@@ -144,7 +144,7 @@ class MaterializeTicketTests(unittest.TestCase):
             "handle": {"id": "ticket:wrapped-criteria", "display": "WRAPPED"},
             "title": "Wrapped criteria",
             "body": (
-                "A ticket with wrapped markdown list items.\n\n"
+                "A work-unit with wrapped markdown list items.\n\n"
                 "## Acceptance criteria\n\n"
                 "1. A single contract surface admits criteria for any dimension. Each criterion\n"
                 "   declares dimension, acceptance criterion, statement, hollow delivery, and\n"
@@ -176,7 +176,7 @@ class MaterializeTicketTests(unittest.TestCase):
             "handle": {"id": "ticket:criteria-prose", "display": "CRITERIA-PROSE"},
             "title": "Trailing prose after criteria",
             "body": (
-                "A ticket with prose after the criteria list.\n\n"
+                "A work-unit with prose after the criteria list.\n\n"
                 "## Acceptance criteria\n\n"
                 "- [ ] The contract payload uses criteria\n"
                 "- [ ] The workflow surfaces name the contract artifact\n"
@@ -257,7 +257,7 @@ def runa_bin() -> Path | None:
             capture_output=True,
             text=True,
         )
-        if "--ticket" in help_result.stdout:
+        if "--work-unit" in help_result.stdout:
             return path
     return None
 
@@ -273,7 +273,7 @@ def runa_mcp_bin(runa: Path) -> Path | None:
 
 @unittest.skipUnless(runa_bin() is not None, "runa binary not available")
 class AcquisitionEntryEndToEndTests(unittest.TestCase):
-    def test_ticket_entry_dry_run_reaches_acquisition_and_projects_take(self) -> None:
+    def test_work_unit_entry_dry_run_reaches_acquisition_and_projects_take(self) -> None:
         runa = runa_bin()
         self.assertIsNotNone(runa)
 
@@ -284,7 +284,7 @@ class AcquisitionEntryEndToEndTests(unittest.TestCase):
                 [
                     str(runa),
                     "run",
-                    "--ticket",
+                    "--work-unit",
                     "tesserine/groundwork#499",
                     "--dry-run",
                     "--json",
@@ -422,7 +422,7 @@ class AcquisitionEntryEndToEndTests(unittest.TestCase):
             self.assertEqual(ticket["handle"], body["handle"])
 
             # The cascade now computes define as the next READY station for the
-            # acquired work-unit — entry from an existing ticket reached define.
+            # acquired work-unit — entry from an existing work-unit reached define.
             state = subprocess.run(
                 [str(runa), "state", "--work-unit", instance_id],
                 cwd=project, capture_output=True, text=True,

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -510,9 +510,9 @@ name = "close-out"
             with self.subTest(artifact_schema_name=artifact_schema_name), tempfile.TemporaryDirectory() as directory:
                 root = Path(directory)
                 schemas = root / "schemas"
-                vendored = schemas / "forge-capability" / "v1"
+                vendored = schemas / "forge-capability" / "v2"
                 vendored.mkdir(parents=True)
-                shutil.copy2(SCHEMAS / "forge-capability" / "v1" / "forge-capability.schema.json", vendored)
+                shutil.copy2(SCHEMAS / "forge-capability" / "v2" / "forge-capability.schema.json", vendored)
                 shutil.copy2(SCHEMAS / "work-unit.schema.json", schemas)
                 shutil.copy2(SCHEMAS / "change-proposal.schema.json", schemas)
                 manifest = root / "manifest.toml"
@@ -628,7 +628,7 @@ name = "define"
         results = run_conformance([SCHEMAS])
 
         self.assertGreater(len(results), 0)
-        self.assertIn(SCHEMAS / "forge-capability" / "v1" / "forge-capability.schema.json", [result.path for result in results])
+        self.assertIn(SCHEMAS / "forge-capability" / "v2" / "forge-capability.schema.json", [result.path for result in results])
         self.assertTrue(all(result.category == "C-4 schema-definition" for result in results))
         self.assertTrue(all(result.passed for result in results))
 

--- a/tests/test_forge_capability.py
+++ b/tests/test_forge_capability.py
@@ -16,10 +16,10 @@ from tooling.workflow_contracts import workflow_registry_from_manifest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMAS = ROOT / "schemas"
-VENDORED_SCHEMA = SCHEMAS / "forge-capability" / "v1" / "forge-capability.schema.json"
+VENDORED_SCHEMA = SCHEMAS / "forge-capability" / "v2" / "forge-capability.schema.json"
 EXPECTED_OPERATIONS = {
-    "read-ticket",
-    "create-ticket",
+    "read-work-unit",
+    "create-work-unit",
     "claim-work-unit",
     "record-progress",
     "deliver-change-proposal",
@@ -75,7 +75,7 @@ def contains_key(node: object, key: str) -> bool:
 
 
 def connector_model_violations(root: Path) -> list[str]:
-    schema = load_json(root / "schemas" / "forge-capability" / "v1" / "forge-capability.schema.json")
+    schema = load_json(root / "schemas" / "forge-capability" / "v2" / "forge-capability.schema.json")
     work_unit_schema = load_json(root / "schemas" / "work-unit.schema.json")
     handle_schema = schema["$defs"]["handle"]
     connecting_structure = (root / "docs" / "architecture" / "connecting-structure.md").read_text(
@@ -335,19 +335,19 @@ class ForgeCapabilityTests(unittest.TestCase):
 
         self.assertIn("connecting-structure omits handle shape { id, display }", violations)
 
-    def test_read_ticket_output_schema_declares_connector_handle(self) -> None:
+    def test_read_work_unit_output_schema_declares_connector_handle(self) -> None:
         schema = vendored_schema()
-        ticket_snapshot_ref = schema["$defs"]["read-ticket-tool"]["allOf"][1]["properties"]["output_schema"]["const"]
-        ticket_snapshot = schema_def(schema, ticket_snapshot_ref)
+        work_unit_snapshot_ref = schema["$defs"]["read-work-unit-tool"]["allOf"][1]["properties"]["output_schema"]["const"]
+        work_unit_snapshot = schema_def(schema, work_unit_snapshot_ref)
 
         handle = connector_handle()
         snapshot = {
             "handle": handle,
-            "title": "Opaque ticket",
-            "body": "## Acceptance criteria\n- [ ] Materialize opaque ticket",
+            "title": "Opaque work unit",
+            "body": "## Acceptance criteria\n- [ ] Materialize opaque work unit",
             "state": "open",
         }
-        Draft202012Validator(schema).evolve(schema=ticket_snapshot).validate(snapshot)
+        Draft202012Validator(schema).evolve(schema=work_unit_snapshot).validate(snapshot)
         snapshot["comments"] = [
             {"body": "Freshen record."},
             {
@@ -356,7 +356,7 @@ class ForgeCapabilityTests(unittest.TestCase):
                 "created_at": "2026-07-02T10:53:26Z",
             },
         ]
-        Draft202012Validator(schema).evolve(schema=ticket_snapshot).validate(snapshot)
+        Draft202012Validator(schema).evolve(schema=work_unit_snapshot).validate(snapshot)
 
     def test_entry_surfaces_ground_on_the_whole_ticket(self) -> None:
         self.assertTrue(entry_surface_coherence(ROOT).passed)

--- a/tests/test_prose_conformance.py
+++ b/tests/test_prose_conformance.py
@@ -269,7 +269,7 @@ class ProseConformanceHelperTests(unittest.TestCase):
     def test_json_schema_ref_resolution_reads_current_schema(self) -> None:
         helper = prose_conformance()
         schema = json.loads(
-            (ROOT / "schemas" / "forge-capability" / "v1" / "forge-capability.schema.json").read_text(
+            (ROOT / "schemas" / "forge-capability" / "v2" / "forge-capability.schema.json").read_text(
                 encoding="utf-8"
             )
         )

--- a/tests/test_protocol_artifact_delivery_docs.py
+++ b/tests/test_protocol_artifact_delivery_docs.py
@@ -122,7 +122,7 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
                 }[protocol["name"]]
                 self.assertTrue(boundary.explains_post_extraction_validation_scope)
 
-    def test_decompose_delivery_docs_preserve_ticket_backed_work_unit_identity_rules(self) -> None:
+    def test_decompose_delivery_docs_preserve_work_unit_backed_identity_rules(self) -> None:
         schema = artifact_schema(ROOT, "work-unit")
         handle = schema["properties"]["handle"]
         body = normalized_protocol("decompose")
@@ -130,15 +130,15 @@ class ProtocolArtifactDeliveryDocsTests(unittest.TestCase):
         self.assertEqual({"$ref": "#/$defs/handle"}, handle)
         for expected in [
             "Every work-unit is tracker-backed",
-            "first invoke the connector capability `create-ticket` operation",
-            "`create-ticket` is a first-delivery-only step",
+            "first invoke the connector capability `create-work-unit` operation",
+            "`create-work-unit` is a first-delivery-only step",
             "refinement never calls it",
-            "decompose does not adopt a pre-existing tracker ticket into a new artifact",
-            "must not create a second ticket",
+            "decompose does not adopt a pre-existing tracker work-unit into a new artifact",
+            "must not create a second work-unit",
             "uses a stable id derived from the connector handle's `id`",
-            "populate `handle` exactly once from the identity returned by `create-ticket`",
+            "populate `handle` exactly once from the identity returned by `create-work-unit`",
             "carry the existing `handle` through unchanged",
-            "Do not call `create-ticket`, re-derive `handle`, or omit `handle` during refinement",
+            "Do not call `create-work-unit`, re-derive `handle`, or omit `handle` during refinement",
             "no top-level `work_unit` field",
             "no forge identity outside the connector handle",
             "Dependency references must use canonical delivered work-unit `instance_id` values",

--- a/tooling/conformance.py
+++ b/tooling/conformance.py
@@ -393,21 +393,21 @@ def _manifest_retired_forge_model_errors(
 
 def _manifest_capability_contract_errors(root: Path) -> list[tuple[str, str]]:
     errors: list[tuple[str, str]] = []
-    schema_path = root / "schemas" / "forge-capability" / "v1" / "forge-capability.schema.json"
+    schema_path = root / "schemas" / "forge-capability" / "v2" / "forge-capability.schema.json"
     if not schema_path.exists() and root.resolve() != ROOT:
         return []
     try:
         schema = load_forge_capability_schema(root)
     except (OSError, json.JSONDecodeError) as error:
-        return [("schemas/forge-capability/v1/forge-capability.schema.json", f"cannot load vendored forge capability schema: {error}")]
+        return [("schemas/forge-capability/v2/forge-capability.schema.json", f"cannot load vendored forge capability schema: {error}")]
 
     metadata = schema.get("x-tesserine-canonical")
     if metadata != {"version": CAPABILITY_VERSION, "schema_url": CAPABILITY_PROVENANCE_URL}:
-        errors.append(("schemas/forge-capability/v1/forge-capability.schema.json", f"vendored forge capability provenance is not immutable v{CAPABILITY_VERSION}"))
+        errors.append(("schemas/forge-capability/v2/forge-capability.schema.json", f"vendored forge capability provenance is not immutable v{CAPABILITY_VERSION}"))
     if schema.get("properties", {}).get("handle_schema", {}).get("const") != "#/$defs/handle":
-        errors.append(("schemas/forge-capability/v1/forge-capability.schema.json", "forge capability handle_schema must point at #/$defs/handle"))
+        errors.append(("schemas/forge-capability/v2/forge-capability.schema.json", "forge capability handle_schema must point at #/$defs/handle"))
     if len(forge_operation_names(schema)) != 8:
-        errors.append(("schemas/forge-capability/v1/forge-capability.schema.json", "forge capability must declare exactly eight operations"))
+        errors.append(("schemas/forge-capability/v2/forge-capability.schema.json", "forge capability must declare exactly eight operations"))
     errors.extend(_manifest_artifact_handle_contract_errors(root, schema))
     return errors
 
@@ -416,7 +416,7 @@ def _manifest_artifact_handle_contract_errors(root: Path, capability_schema: dic
     errors: list[tuple[str, str]] = []
     expected_handle = capability_schema.get("$defs", {}).get("handle")
     if not isinstance(expected_handle, dict):
-        return [("schemas/forge-capability/v1/forge-capability.schema.json", "forge capability #/$defs/handle must be an object")]
+        return [("schemas/forge-capability/v2/forge-capability.schema.json", "forge capability #/$defs/handle must be an object")]
 
     for schema_name in ("work-unit.schema.json", "change-proposal.schema.json"):
         relative = Path("schemas") / schema_name

--- a/tooling/forge_capability.py
+++ b/tooling/forge_capability.py
@@ -7,17 +7,17 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
-CAPABILITY_SCHEMA = ROOT / "schemas" / "forge-capability" / "v1" / "forge-capability.schema.json"
-CAPABILITY_VERSION = "1.2.0"
+CAPABILITY_SCHEMA = ROOT / "schemas" / "forge-capability" / "v2" / "forge-capability.schema.json"
+CAPABILITY_VERSION = "2.0.0"
 CAPABILITY_PROVENANCE_URL = (
     "https://raw.githubusercontent.com/tesserine/commons/"
-    "b229fb1a840c27ced31d582b40d766f4f441dcf6/"
-    "schemas/forge-capability/v1/forge-capability.schema.json"
+    "e75e211689e92a4772614bfe6e4eca4b647d4d66/"
+    "schemas/forge-capability/v2/forge-capability.schema.json"
 )
 
 
 def load_schema(root: Path | str = ROOT) -> dict[str, Any]:
-    path = Path(root) / "schemas" / "forge-capability" / "v1" / "forge-capability.schema.json"
+    path = Path(root) / "schemas" / "forge-capability" / "v2" / "forge-capability.schema.json"
     return json.loads(path.read_text(encoding="utf-8"))
 
 

--- a/tooling/prose_conformance.py
+++ b/tooling/prose_conformance.py
@@ -414,19 +414,19 @@ def public_docs_interactive_adapter_bypass_violations(root: Path) -> dict[str, l
 
 @dataclass(frozen=True)
 class EntrySurfaceCoherence:
-    acquire_reads_ticket_comments: bool
+    acquire_reads_work_unit_comments: bool
     acquire_surfaces_comments_as_entry_context: bool
     acquire_excludes_comments_from_artifact: bool
-    define_grounds_frame_in_whole_ticket: bool
+    define_grounds_frame_in_whole_work_unit: bool
     define_uses_newest_review_directives: bool
 
     @property
     def passed(self) -> bool:
         return (
-            self.acquire_reads_ticket_comments
+            self.acquire_reads_work_unit_comments
             and self.acquire_surfaces_comments_as_entry_context
             and self.acquire_excludes_comments_from_artifact
-            and self.define_grounds_frame_in_whole_ticket
+            and self.define_grounds_frame_in_whole_work_unit
             and self.define_uses_newest_review_directives
         )
 
@@ -435,11 +435,11 @@ def entry_surface_coherence(root: Path) -> EntrySurfaceCoherence:
     acquire = read(root / "skills" / "acquire" / "SKILL.md")
     define = read(root / "protocols" / "define" / "PROTOCOL.md")
     return EntrySurfaceCoherence(
-        acquire_reads_ticket_comments=(
+        acquire_reads_work_unit_comments=(
             "`comments`" in acquire
             and has_semantic_clause(
                 acquire,
-                r"\bread-ticket\b",
+                r"\bread-work-unit\b",
                 r"`?comments`?",
                 r"\blog\b",
             )
@@ -449,7 +449,7 @@ def entry_surface_coherence(root: Path) -> EntrySurfaceCoherence:
             r"\bSurface\b",
             r"\blog\b",
             r"\bentry context\b",
-            r"\bwhole ticket\b",
+            r"\bwhole work-unit\b",
         ),
         acquire_excludes_comments_from_artifact=has_semantic_clause(
             acquire,
@@ -458,8 +458,8 @@ def entry_surface_coherence(root: Path) -> EntrySurfaceCoherence:
             r"\bnever persisted\b",
             r"\bartifact\b",
         ),
-        define_grounds_frame_in_whole_ticket=(
-            has_semantic_clause(define, r"\bGround\b", r"\bwhole ticket\b")
+        define_grounds_frame_in_whole_work_unit=(
+            has_semantic_clause(define, r"\bGround\b", r"\bwhole work-unit\b")
             and has_semantic_clause(
                 define,
                 r"\bcomment log\b",

--- a/tooling/workflow_contracts.py
+++ b/tooling/workflow_contracts.py
@@ -76,7 +76,7 @@ def workflow_registry_from_manifest(
         if isinstance(entry, dict) and isinstance(entry.get("name"), str)
     }
     mechanic_names.update(_mechanic_names_from_directory(root_path / "mechanics"))
-    if (root_path / "schemas" / "forge-capability" / "v1" / "forge-capability.schema.json").exists() or root_path.resolve() == ROOT:
+    if (root_path / "schemas" / "forge-capability" / "v2" / "forge-capability.schema.json").exists() or root_path.resolve() == ROOT:
         mechanic_names.update(forge_operation_names())
 
     return WorkflowRegistry(


### PR DESCRIPTION
Groundwork half of tesserine/commons#106 — the last of the three coordinated PRs (commons v2 `e75e211` and runa v2 `26ca07b` already landed).

## What changed
- **Vendor forge-capability v2.0.0** at `schemas/forge-capability/v2/forge-capability.schema.json`, `x-tesserine-canonical` pinned to the immutable commons authority `e75e211689e92a4772614bfe6e4eca4b647d4d66`. v1 retired from the active vendored path (groundwork is a current consumer, not a retained-version archive; commons v1 stays the frozen v1 authority).
- **Tooling** — `forge_capability` (path/version/provenance constants), `conformance`, and `workflow_contracts` consult the v2 vendored schema. Operation discovery still derives from the schema (no hand-maintained op-name list).
- **Gates/tests** — forge-capability, conformance, and prose-conformance tests derive from v2, assert `work-unit-snapshot`, and fail on old capability op names at the capability layer.
- **Capability-level prose** — `acquire`, `decompose`, `define`, `orient`, `contract`, `verification-craft`, `connecting-structure`, README, schemas/README, CHANGELOG name the work-unit vocabulary. The runa entry flag in the (skipped) e2e test tracks runa v2's `--work-unit`.
- **Provider boundary preserved** — `work-unit-craft` keeps "GitHub says issue, SourceHut says ticket"; ADR-0002 keeps the SourceHut tracker-ticket projection; SourceHut handle fixtures keep their `ticket:`-prefixed opaque identity.
- No old-name alias, compatibility shim, or new pre-claim noun; the pre-claim model collapses to `work-unit`.

## Verification
- `python3 -m pytest` — 438 passed, 7 skipped, 1218 subtests passed.
- `python3 -m tooling.conformance` — 21 passed, 0 failed.
- `python3 -m tooling.protocol_prose` — pass.
- Live old-name grep classified: no capability-level `read-ticket`/`create-ticket`/`ticket-snapshot`; every residual `ticket` is a provider projection, an opaque `ticket:` handle id, or a stale-mechanic fixture.

Contract: `behavior-groundwork-v2-consumption` and the cross-cutting documentation/code-quality criteria on the #106 accepted contract.