### PR TITLE
feat(acquire): freshening as a groundwork built-in (#465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Freshening as a groundwork built-in** (#465).
+  `skills/acquire/SKILL.md` (2.0.0) inserts a mandatory Freshen step between
+  materialization and delivery: an acquired work-unit is re-grounded against
+  current substrate — its body **and its dependency graph** — before `define`
+  activates, and the acquisition yields exactly one typed disposition. Only
+  `proceed-as-freshened` delivers the `work-unit` artifact; since `define`'s
+  sole trigger is that artifact, every other disposition structurally withholds
+  the unit from the scoped pipeline. The disposition set, the freshen record's
+  four required elements, and the six dependency-graph facets are single-homed
+  in the new `schemas/freshen-record.schema.json` (auto-gated by the conformance
+  sweep); the record lands as a comment on the work-unit, not in its body. Body
+  re-craft under a proceed disposition routes to `decompose`'s `refine-work-unit`
+  rather than reimplementing re-craft (Principle #13), so freshening's own
+  contribution is the staleness trigger and the dependency-graph re-verification.
+  `tests/test_freshen_conformance.py` gates the discipline — schema fixtures plus
+  a coherence gate that consults the schema and manifest authorities (never a
+  phrase list), with mutation probes proving the checks bite.
+
 - **Runa runtime state commit policy** (#238).
   [ADR-0009](docs/architecture/decisions/0009-runa-runtime-state-commit-policy.md)
   declares, for the four entries runa creates under `.runa/`, which a consuming

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -34,6 +34,18 @@ Groundwork artifact schemas carry self-contained copies of the handle schema so
 runa can validate artifacts without an external registry or network fetch, and
 conformance checks that those copies do not drift from the vendored contract.
 
+`freshen-record.schema.json` is an authoring substrate for the freshen record
+produced when an acquired work-unit is re-grounded at the acquisition boundary
+(`skills/acquire/SKILL.md`). It is the single home of the freshen disposition
+set (the `disposition` enum), the record's four required elements, and the six
+dependency-graph facets (the `graph_finding` required keys). It is deliberately
+not a `manifest.toml` artifact type: the record's home is a tracker comment, not
+a workspace artifact, so declaring an artifact type would mint a second
+workspace home and an MCP tool for something that must not accrete in the
+workspace. Placement in `schemas/` alone registers it with the conformance
+sweep; the acquire surface renders the set, elements, and facets as projections
+gate-bound to this schema.
+
 The scoped contract spine is dimension-agnostic. `contract.schema.json`
 declares criteria for any dimension; each criterion names its dimension,
 the acceptance criterion it refines, the statement that defines done, the

--- a/schemas/freshen-record.schema.json
+++ b/schemas/freshen-record.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/freshen-record.schema.json",
+  "title": "Freshen Record",
+  "description": "Validates the freshen record produced when an acquired work-unit is re-grounded against current substrate at the acquisition boundary. The record is a log entry (a tracker comment), not a workspace artifact type. This schema is the single home of the freshen disposition set, the record's required elements, and the dependency-graph facet list.",
+  "type": "object",
+  "required": ["work_unit", "grounded_against", "staleness_finding", "graph_finding", "disposition"],
+  "additionalProperties": false,
+  "properties": {
+    "work_unit": {
+      "type": "string",
+      "description": "Common envelope - identifies the acquired work-unit the record grounds.",
+      "pattern": "^[a-z][a-z0-9]*([-.][a-z0-9]+)*$"
+    },
+    "grounded_against": {
+      "type": "object",
+      "description": "The substrate state the acquisition was grounded against - reality, not the work-unit's own prior text.",
+      "required": ["commit", "grounded_at", "tracker_state"],
+      "additionalProperties": false,
+      "properties": {
+        "commit": {
+          "type": "string",
+          "description": "The substrate commit the body was re-grounded against.",
+          "minLength": 1
+        },
+        "grounded_at": {
+          "type": "string",
+          "description": "When the grounding was performed.",
+          "format": "date-time",
+          "minLength": 1
+        },
+        "tracker_state": {
+          "type": "string",
+          "description": "The live tracker state the dependency graph was re-verified against.",
+          "minLength": 1
+        }
+      }
+    },
+    "staleness_finding": {
+      "type": "string",
+      "description": "What was stale or thin in the body and what changed, or that grounding found the body current. A present, positive finding - never a hedge.",
+      "minLength": 1
+    },
+    "graph_finding": {
+      "type": "object",
+      "description": "The dependency-graph finding, one per facet, each re-verified against live tracker state. This object's required key set is the single home of the graph-facet list.",
+      "required": ["blockers", "blocked", "epic_membership", "siblings", "milestone", "labels"],
+      "additionalProperties": false,
+      "properties": {
+        "blockers": {
+          "type": "string",
+          "description": "Finding for the unit's stated blockers, re-verified against current tracker state.",
+          "minLength": 1
+        },
+        "blocked": {
+          "type": "string",
+          "description": "Finding for the units this one blocks, re-verified against current tracker state.",
+          "minLength": 1
+        },
+        "epic_membership": {
+          "type": "string",
+          "description": "Finding for the unit's epic membership, re-verified against current tracker state.",
+          "minLength": 1
+        },
+        "siblings": {
+          "type": "string",
+          "description": "Finding for the unit's siblings, re-verified against current tracker state.",
+          "minLength": 1
+        },
+        "milestone": {
+          "type": "string",
+          "description": "Finding for the unit's milestone, re-verified against current tracker state.",
+          "minLength": 1
+        },
+        "labels": {
+          "type": "string",
+          "description": "Finding for the unit's labels, re-verified against current tracker state.",
+          "minLength": 1
+        }
+      }
+    },
+    "disposition": {
+      "type": "string",
+      "description": "The one typed disposition the freshen pass chose. This enum is the single home of the freshen disposition set. Exactly one member: zero fails `required`, two cannot be expressed in a scalar, out-of-set fails the enum.",
+      "enum": [
+        "proceed-as-freshened",
+        "close",
+        "split",
+        "relink",
+        "reblock",
+        "reframe-as-spike"
+      ]
+    }
+  }
+}

--- a/skills/acquire/SKILL.md
+++ b/skills/acquire/SKILL.md
@@ -3,13 +3,14 @@ name: acquire
 description: >-
   Entry from an existing forge work-unit. Use to start scoped work from a work-unit
   reference that is already on the tracker (e.g. "define runa#14") when no
-  work-unit artifact exists yet — acquisition reads the work-unit and
-  materializes the work-unit artifact that define then proceeds on. The mirror
-  of decompose's create path: decompose creates the work-unit it delivers;
-  acquire adopts the work-unit it is given, and creates no work-unit.
+  work-unit artifact exists yet — acquisition reads the work-unit, freshens it
+  against current substrate, and materializes the work-unit artifact that define
+  then proceeds on. The mirror of decompose's create path: decompose creates the
+  work-unit it delivers; acquire adopts the work-unit it is given, and creates no
+  work-unit.
 metadata:
-  version: "1.1.0"
-  updated: "2026-07-02"
+  version: "2.0.0"
+  updated: "2026-07-05"
 ---
 
 # Acquire
@@ -77,8 +78,33 @@ cold start.
    re-acquire. Do not hand-fill the missing fields here — that would forge an
    execution snapshot the planning home never authorized.
 
-4. **Deliver the `work-unit` artifact.** Invoke the `work-unit` MCP tool with
-   the materializer's `instance_id` and `artifact` body — the same call shape
+4. **Freshen the acquired work-unit.** A well-formed work-unit can still be
+   *stale*: it was authored in another context at another time, and its body
+   and its stated dependency edges are a claim about a past moment, not current
+   ground — reality wins over the work-unit record, the need wins over the
+   record. This is groundwork's one inherited-frame entry, so re-grounding is
+   owed here, before `define` builds on the frame. Run the freshen pass over
+   the acquired work-unit and choose exactly one disposition; the pass, the
+   disposition set, and the freshen record it produces are detailed under
+   [Freshening](#freshening) below. The pass has three moves in order: ground
+   the body against current substrate, ground the dependency graph against live
+   tracker state, then re-craft or dispose. Where grounding finds staleness or
+   thinness, the body is re-crafted through `refine-work-unit` at its planning
+   home rather than reimplemented here — freshening adds the staleness trigger
+   and the dependency-graph re-verification, not a second re-craft engine. When
+   grounding shows the substrate the unit rests on is itself defective, the
+   finding escalates to `resolve` as a side quest rather than being absorbed
+   into the unit — freshen repairs the unit, resolve repairs the substrate.
+   Freshening fires at this single acquisition boundary in both session modes —
+   mode is a property of the session (commons ADR-0015), not a fork in the
+   pass.
+
+5. **Deliver the `work-unit` artifact.** Only a `proceed-as-freshened`
+   disposition may deliver the work-unit artifact; every other disposition ends
+   acquisition without delivery, so `define` — whose sole trigger is the
+   `work-unit` artifact — never fires on an unfreshened or withheld frame.
+   Under `proceed-as-freshened`, invoke the `work-unit` MCP tool with the
+   materializer's `instance_id` and `artifact` body — the same call shape
    `decompose` uses for a tracker-backed work-unit, with the work-unit's
    `handle` carried unchanged. `work-unit` is a planning-phase artifact: the
    agent supplies the schema fields and runa does not inject `work_unit`. Do
@@ -98,10 +124,64 @@ cold start.
    records it. The cascade then computes `define` as the next station on the
    acquired artifact.
 
-5. **Hand off to `define`.** Acquisition materializes; `define` claims. Tracker
+6. **Hand off to `define`.** Acquisition materializes; `define` claims. Tracker
    claiming (assigning the work-unit, marking it in progress) is `define`'s
    workspace-preparation step, not acquisition's — keep the one-way boundary
    clean.
+
+## Freshening
+
+Freshening re-grounds an acquired work-unit against current substrate at the
+acquisition boundary and yields exactly one typed disposition. The discipline
+is groundwork's native re-derivation of the `freshen-work-unit` station skill:
+the transferable invariants are the pass shape, the typed disposition, and the
+freshen record. It composes existing assets at their homes — `reckon` supplies
+the re-grounding reasoning, `refine-work-unit` the body re-craft, the `spike`
+work-unit the reframe home, `resolve` the defective-substrate escalation — and
+builds on the comment log this skill already surfaces, adding no second
+log-surfacing.
+
+**The pass.** Ground the body against the current substrate the work-unit's
+acceptance criteria cite; ground the dependency graph against live tracker
+state; then choose one disposition and record it. The disposition is chosen
+*before* any re-craft.
+
+**The disposition set and where each unit goes.** The `disposition` value is
+one member of the set declared in `schemas/freshen-record.schema.json` — the
+single home of the set. Only `proceed-as-freshened` admits the unit to
+`define`; every other disposition withholds it, the way the
+committed-but-unspecced gate withholds an unspecced unit.
+
+| Disposition | Admits to `define`? | Onward route |
+| --- | --- | --- |
+| `proceed-as-freshened` | yes | delivered to `define` through step 5 |
+| `close` | no | closed at the tracker; the need is gone or already met |
+| `split` | no | routed to `decompose`'s `refine-work-unit`, then re-acquired |
+| `relink` | no | re-linked or merged at the tracker, then re-acquired or closed |
+| `reblock` | no | blocking edges recorded at the tracker; the unit waits, unmaterialized |
+| `reframe-as-spike` | no | filed as a `spike` work-unit per `work-unit-craft` |
+
+**The freshen record.** Every acquisition from an existing work-unit attaches a
+freshen record — validated against `schemas/freshen-record.schema.json` and
+posted as a comment on the work-unit, a log entry in the running record, not
+written into the work-unit body. It carries four required elements: the
+`grounded_against` substrate state (commit, when, and the tracker state the
+graph was verified against), the `staleness_finding` (what was stale or thin
+and what changed, or that grounding found the body current), the `graph_finding`
+(below), and the `disposition`.
+
+**The graph finding covers the whole graph, not only the body.** The
+`graph_finding` re-verifies each stated edge against current tracker state, one
+finding per facet: `blockers`, `blocked`, `epic_membership`, `siblings`,
+`milestone`, `labels`. A finding that addresses only body staleness does not
+satisfy the record — the schema's `graph_finding` object requires all six
+facets.
+
+**Proceed re-craft.** Under `proceed-as-freshened`, where grounding found
+staleness or thinness the body is re-crafted through `refine-work-unit` at the
+planning home — which re-applies `work-unit-craft`'s contract-input pass — and
+re-materialized, so the body `define` receives is a standalone spec verifiable
+against current substrate, not a stale body wearing a freshened annotation.
 
 ## Corruption Modes
 
@@ -109,14 +189,20 @@ cold start.
   unread and unsurfaced. The snapshot carries the running record so the
   session grounds on the whole work-unit; an entry that reads the spec alone
   executes blind to its own live corrections.
+- `freshen-skipped`: handing off to `define` without running the freshen pass
+  and recording a disposition. An acquired frame is inherited, not reckoned;
+  skipping the pass carries a stale body and stale edges into the pipeline with
+  perfect fidelity.
 - `work-unit-creation`: calling `create-work-unit` during acquisition. Acquisition
   adopts an existing work-unit; creating one is `decompose`'s path, and doing
   both makes a second work-unit for the same work.
 - `content-fabrication`: hand-filling acceptance criteria or a description
   the work-unit does not contain, instead of routing the gap to refinement. The
   artifact must be a faithful snapshot of the planning home.
-- `write-back`: editing the work-unit from acquisition (beyond `define`'s later
-  claim). Derivation is one-way.
+- `write-back`: editing the work-unit artifact from acquisition (beyond a freshen
+  re-craft at the planning home and `define`'s later claim). Derivation is
+  one-way: freshening repairs the work-unit at its planning home through
+  `refine-work-unit`, never the materialized artifact.
 - `handle-drift`: re-deriving or altering the `handle` instead of carrying
   the work-unit's identity through verbatim — breaks the back-link and risks a
   downstream identity collision.
@@ -124,9 +210,16 @@ cold start.
 ## Cross-References
 
 - `decompose` (protocol): the create path acquisition mirrors, and the home
-  of `refine-work-unit` — where a work-unit-quality gap surfaced here is fixed.
+  of `refine-work-unit` — where a work-unit-quality gap surfaced here is fixed,
+  and where a freshen `proceed-as-freshened` re-craft is performed.
 - `define` (protocol): proceeds on the acquired artifact through its existing
-  contract; owns tracker claiming.
+  contract; owns tracker claiming. Its sole trigger is the `work-unit` artifact,
+  so withholding delivery under a non-proceed disposition structurally withholds
+  the unit from the scoped pipeline.
+- `resolve` (skill): the defective-substrate escalation when freshening finds
+  the substrate the unit rests on is itself defective.
 - `read-work-unit` (connector capability operation): emits
   `{handle, title, body, state}` and, per forge-capability `2.0.0`, the
   optional ordered `comments` log for the selected connector.
+- `schemas/freshen-record.schema.json`: the single home of the freshen
+  disposition set, the record's required elements, and the graph-facet list.

--- a/tests/fixtures/freshen-record/invalid-compound-disposition.json
+++ b/tests/fixtures/freshen-record/invalid-compound-disposition.json
@@ -1,0 +1,21 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "13a9ac14",
+    "grounded_at": "2026-07-05T16:40:00Z",
+    "tracker_state": "commons#106 closed; #459 open compose-with; enhancement label; no epic; no milestone"
+  },
+  "staleness_finding": "Body carried retired ticket vocabulary and a resolved blocker line; swept to neutral work-unit vocabulary and removed the resolved blocker.",
+  "graph_finding": {
+    "blockers": "commons#106 was the sole blocker; verified closed/completed - resolved.",
+    "blocked": "No units are blocked by this one; verified against the tracker.",
+    "epic_membership": "Not a child of any epic; verified.",
+    "siblings": "No sibling absorbed the freshen scope; verified.",
+    "milestone": "No milestone; verified.",
+    "labels": "One enhancement label; discriminating; verified."
+  },
+  "disposition": [
+    "split",
+    "reblock"
+  ]
+}

--- a/tests/fixtures/freshen-record/invalid-empty-staleness.json
+++ b/tests/fixtures/freshen-record/invalid-empty-staleness.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "13a9ac14",
+    "grounded_at": "2026-07-05T16:40:00Z",
+    "tracker_state": "commons#106 closed; #459 open compose-with; enhancement label; no epic; no milestone"
+  },
+  "staleness_finding": "",
+  "graph_finding": {
+    "blockers": "commons#106 was the sole blocker; verified closed/completed - resolved.",
+    "blocked": "No units are blocked by this one; verified against the tracker.",
+    "epic_membership": "Not a child of any epic; verified.",
+    "siblings": "No sibling absorbed the freshen scope; verified.",
+    "milestone": "No milestone; verified.",
+    "labels": "One enhancement label; discriminating; verified."
+  },
+  "disposition": "proceed-as-freshened"
+}

--- a/tests/fixtures/freshen-record/invalid-missing-facet.json
+++ b/tests/fixtures/freshen-record/invalid-missing-facet.json
@@ -1,0 +1,17 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "13a9ac14",
+    "grounded_at": "2026-07-05T16:40:00Z",
+    "tracker_state": "commons#106 closed; #459 open compose-with; enhancement label; no epic; no milestone"
+  },
+  "staleness_finding": "Body carried retired ticket vocabulary and a resolved blocker line; swept to neutral work-unit vocabulary and removed the resolved blocker.",
+  "graph_finding": {
+    "blockers": "commons#106 was the sole blocker; verified closed/completed - resolved.",
+    "blocked": "No units are blocked by this one; verified against the tracker.",
+    "epic_membership": "Not a child of any epic; verified.",
+    "siblings": "No sibling absorbed the freshen scope; verified.",
+    "labels": "One enhancement label; discriminating; verified."
+  },
+  "disposition": "proceed-as-freshened"
+}

--- a/tests/fixtures/freshen-record/invalid-missing-graph-finding.json
+++ b/tests/fixtures/freshen-record/invalid-missing-graph-finding.json
@@ -1,0 +1,10 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "13a9ac14",
+    "grounded_at": "2026-07-05T16:40:00Z",
+    "tracker_state": "commons#106 closed; #459 open compose-with; enhancement label; no epic; no milestone"
+  },
+  "staleness_finding": "Body carried retired ticket vocabulary and a resolved blocker line; swept to neutral work-unit vocabulary and removed the resolved blocker.",
+  "disposition": "proceed-as-freshened"
+}

--- a/tests/fixtures/freshen-record/invalid-missing-grounded-against.json
+++ b/tests/fixtures/freshen-record/invalid-missing-grounded-against.json
@@ -1,0 +1,13 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "staleness_finding": "Body carried retired ticket vocabulary and a resolved blocker line; swept to neutral work-unit vocabulary and removed the resolved blocker.",
+  "graph_finding": {
+    "blockers": "commons#106 was the sole blocker; verified closed/completed - resolved.",
+    "blocked": "No units are blocked by this one; verified against the tracker.",
+    "epic_membership": "Not a child of any epic; verified.",
+    "siblings": "No sibling absorbed the freshen scope; verified.",
+    "milestone": "No milestone; verified.",
+    "labels": "One enhancement label; discriminating; verified."
+  },
+  "disposition": "proceed-as-freshened"
+}

--- a/tests/fixtures/freshen-record/invalid-out-of-set-disposition.json
+++ b/tests/fixtures/freshen-record/invalid-out-of-set-disposition.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "13a9ac14",
+    "grounded_at": "2026-07-05T16:40:00Z",
+    "tracker_state": "commons#106 closed; #459 open compose-with; enhancement label; no epic; no milestone"
+  },
+  "staleness_finding": "Body carried retired ticket vocabulary and a resolved blocker line; swept to neutral work-unit vocabulary and removed the resolved blocker.",
+  "graph_finding": {
+    "blockers": "commons#106 was the sole blocker; verified closed/completed - resolved.",
+    "blocked": "No units are blocked by this one; verified against the tracker.",
+    "epic_membership": "Not a child of any epic; verified.",
+    "siblings": "No sibling absorbed the freshen scope; verified.",
+    "milestone": "No milestone; verified.",
+    "labels": "One enhancement label; discriminating; verified."
+  },
+  "disposition": "proceed-with-caveats"
+}

--- a/tests/fixtures/freshen-record/valid-close.json
+++ b/tests/fixtures/freshen-record/valid-close.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "13a9ac14",
+    "grounded_at": "2026-07-05T16:40:00Z",
+    "tracker_state": "commons#106 closed; #459 open compose-with; enhancement label; no epic; no milestone"
+  },
+  "staleness_finding": "Grounding found the work-unit was completed by a since-landed change; nothing remains.",
+  "graph_finding": {
+    "blockers": "commons#106 was the sole blocker; verified closed/completed - resolved.",
+    "blocked": "No units are blocked by this one; verified against the tracker.",
+    "epic_membership": "Not a child of any epic; verified.",
+    "siblings": "No sibling absorbed the freshen scope; verified.",
+    "milestone": "No milestone; verified.",
+    "labels": "One enhancement label; discriminating; verified."
+  },
+  "disposition": "close"
+}

--- a/tests/fixtures/freshen-record/valid-proceed.json
+++ b/tests/fixtures/freshen-record/valid-proceed.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "13a9ac14",
+    "grounded_at": "2026-07-05T16:40:00Z",
+    "tracker_state": "commons#106 closed; #459 open compose-with; enhancement label; no epic; no milestone"
+  },
+  "staleness_finding": "Body carried retired ticket vocabulary and a resolved blocker line; swept to neutral work-unit vocabulary and removed the resolved blocker.",
+  "graph_finding": {
+    "blockers": "commons#106 was the sole blocker; verified closed/completed - resolved.",
+    "blocked": "No units are blocked by this one; verified against the tracker.",
+    "epic_membership": "Not a child of any epic; verified.",
+    "siblings": "No sibling absorbed the freshen scope; verified.",
+    "milestone": "No milestone; verified.",
+    "labels": "One enhancement label; discriminating; verified."
+  },
+  "disposition": "proceed-as-freshened"
+}

--- a/tests/fixtures/freshen-record/valid-reframe-as-spike.json
+++ b/tests/fixtures/freshen-record/valid-reframe-as-spike.json
@@ -1,0 +1,18 @@
+{
+  "work_unit": "work-unit-465-freshen-built-in",
+  "grounded_against": {
+    "commit": "13a9ac14",
+    "grounded_at": "2026-07-05T16:40:00Z",
+    "tracker_state": "commons#106 closed; #459 open compose-with; enhancement label; no epic; no milestone"
+  },
+  "staleness_finding": "The unit's answer depends on an unresolved unknown; reframed as a spike.",
+  "graph_finding": {
+    "blockers": "commons#106 was the sole blocker; verified closed/completed - resolved.",
+    "blocked": "No units are blocked by this one; verified against the tracker.",
+    "epic_membership": "Not a child of any epic; verified.",
+    "siblings": "No sibling absorbed the freshen scope; verified.",
+    "milestone": "No milestone; verified.",
+    "labels": "One enhancement label; discriminating; verified."
+  },
+  "disposition": "reframe-as-spike"
+}

--- a/tests/test_freshen_conformance.py
+++ b/tests/test_freshen_conformance.py
@@ -1,0 +1,212 @@
+"""Conformance gates for the freshen-on-acquire built-in (groundwork#465).
+
+Two layers of teeth, both discovered by `unittest` (CI's `conformance.yml`
+runs `python -m unittest discover -s tests`):
+
+* the freshen-record schema is validated against real fixtures — valid records
+  pass, and each hollow record (a missing element, a missing facet, an
+  out-of-set or compound disposition) fails; and
+* the acquire surface is checked against the authorities that own its
+  invariants (the schema's disposition set / facets / required elements, and
+  the manifest-derived admitted destination), never against a phrase list.
+
+The mutation probes copy the tree, hollow one thing, and assert the gate turns
+red — the anti-theater evidence that the checks bite on every run, including a
+schema mutation that proves the surface gate consults the schema rather than a
+hard-coded list.
+"""
+
+import json
+import re
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schemas" / "freshen-record.schema.json"
+FIXTURES = ROOT / "tests" / "fixtures" / "freshen-record"
+
+EXPECTED_DISPOSITION_SET = {
+    "proceed-as-freshened",
+    "close",
+    "split",
+    "relink",
+    "reblock",
+    "reframe-as-spike",
+}
+EXPECTED_GRAPH_FACETS = {
+    "blockers",
+    "blocked",
+    "epic_membership",
+    "siblings",
+    "milestone",
+    "labels",
+}
+
+
+def load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def prose_conformance():
+    try:
+        from tooling import prose_conformance as module
+    except ImportError as error:  # pragma: no cover - RED before helper exists.
+        raise AssertionError("tooling.prose_conformance helper is missing") from error
+    return module
+
+
+def _copy_tree(tmp: str) -> Path:
+    """A tree carrying every substrate the freshen gate reads: the acquire
+    skill, the schemas, and the manifest."""
+    tree = Path(tmp) / "tree"
+    shutil.copytree(ROOT / "skills", tree / "skills")
+    shutil.copytree(ROOT / "schemas", tree / "schemas")
+    (tree / "manifest.toml").write_text(
+        (ROOT / "manifest.toml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    return tree
+
+
+class FreshenRecordSchemaTests(unittest.TestCase):
+    def test_schema_is_a_valid_draft_2020_12_schema(self) -> None:
+        Draft202012Validator.check_schema(load_schema())
+
+    def test_disposition_enum_is_the_declared_set(self) -> None:
+        enum = load_schema()["properties"]["disposition"]["enum"]
+        self.assertEqual(len(enum), len(set(enum)), "disposition enum has duplicates")
+        self.assertEqual(set(enum), EXPECTED_DISPOSITION_SET)
+
+    def test_graph_finding_requires_all_six_facets(self) -> None:
+        graph = load_schema()["properties"]["graph_finding"]
+        self.assertEqual(set(graph["required"]), EXPECTED_GRAPH_FACETS)
+        self.assertFalse(
+            graph.get("additionalProperties", True),
+            "graph_finding must be a closed object",
+        )
+
+    def test_record_requires_its_four_elements(self) -> None:
+        required = set(load_schema()["required"])
+        self.assertEqual(
+            required,
+            {"work_unit", "grounded_against", "staleness_finding", "graph_finding", "disposition"},
+        )
+
+    def test_valid_records_pass(self) -> None:
+        validator = Draft202012Validator(load_schema())
+        for name in ("valid-proceed.json", "valid-close.json", "valid-reframe-as-spike.json"):
+            with self.subTest(fixture=name):
+                validator.validate(load_fixture(name))
+
+    def test_hollow_records_fail(self) -> None:
+        validator = Draft202012Validator(load_schema())
+        for name in (
+            "invalid-missing-graph-finding.json",
+            "invalid-missing-grounded-against.json",
+            "invalid-missing-facet.json",
+            "invalid-out-of-set-disposition.json",
+            "invalid-compound-disposition.json",
+            "invalid-empty-staleness.json",
+        ):
+            with self.subTest(fixture=name):
+                self.assertFalse(
+                    validator.is_valid(load_fixture(name)),
+                    f"hollow record {name} unexpectedly validated",
+                )
+
+
+class FreshenOnAcquireCoherenceTests(unittest.TestCase):
+    def test_admitted_destination_is_manifest_derived(self) -> None:
+        helper = prose_conformance()
+        self.assertEqual(helper.acquisition_admitted_destination(ROOT), "define")
+
+    def test_surface_coherence_passes(self) -> None:
+        helper = prose_conformance()
+        result = helper.freshen_on_acquire_coherence(ROOT)
+        failing = [name for name, value in vars(result).items() if not value]
+        self.assertTrue(result.passed, f"failing facets: {failing}")
+
+    def test_probe_removed_disposition_row_turns_red(self) -> None:
+        helper = prose_conformance()
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = _copy_tree(tmp)
+            acquire = tree / "skills" / "acquire" / "SKILL.md"
+            body, count = re.subn(
+                r"^\| `close` \|.*\|\n",
+                "",
+                acquire.read_text(encoding="utf-8"),
+                flags=re.MULTILINE,
+            )
+            self.assertEqual(count, 1, "probe did not find the close disposition row")
+            acquire.write_text(body, encoding="utf-8")
+            result = helper.freshen_on_acquire_coherence(tree)
+        self.assertFalse(result.disposition_set_matches_schema)
+        self.assertFalse(result.passed)
+
+    def test_probe_removed_withhold_clause_turns_red(self) -> None:
+        helper = prose_conformance()
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = _copy_tree(tmp)
+            acquire = tree / "skills" / "acquire" / "SKILL.md"
+            body, count = re.subn(
+                r"Only a `proceed-as-freshened`\s+disposition may deliver the work-unit artifact;\s*",
+                "",
+                acquire.read_text(encoding="utf-8"),
+            )
+            self.assertEqual(count, 1, "probe did not find the withhold clause")
+            acquire.write_text(body, encoding="utf-8")
+            result = helper.freshen_on_acquire_coherence(tree)
+        self.assertFalse(result.withhold_conditioning_present)
+        self.assertFalse(result.passed)
+
+    def test_probe_removed_graph_facet_token_turns_red(self) -> None:
+        helper = prose_conformance()
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = _copy_tree(tmp)
+            acquire = tree / "skills" / "acquire" / "SKILL.md"
+            body = acquire.read_text(encoding="utf-8").replace("`milestone`", "milestone")
+            acquire.write_text(body, encoding="utf-8")
+            result = helper.freshen_on_acquire_coherence(tree)
+        self.assertFalse(result.graph_finding_covers_schema_facets)
+        self.assertFalse(result.passed)
+
+    def test_probe_removed_record_element_token_turns_red(self) -> None:
+        helper = prose_conformance()
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = _copy_tree(tmp)
+            acquire = tree / "skills" / "acquire" / "SKILL.md"
+            body = acquire.read_text(encoding="utf-8").replace(
+                "`staleness_finding`", "staleness_finding"
+            )
+            acquire.write_text(body, encoding="utf-8")
+            result = helper.freshen_on_acquire_coherence(tree)
+        self.assertFalse(result.record_contract_covers_required_elements)
+        self.assertFalse(result.passed)
+
+    def test_probe_schema_enum_widened_turns_red(self) -> None:
+        """The surface gate consults the schema enum, not a hard-coded list: a
+        disposition added to the schema the surface does not render turns the
+        gate red."""
+        helper = prose_conformance()
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = _copy_tree(tmp)
+            schema_path = tree / "schemas" / "freshen-record.schema.json"
+            schema = json.loads(schema_path.read_text(encoding="utf-8"))
+            schema["properties"]["disposition"]["enum"].append("proceed-with-caveats")
+            schema_path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+            result = helper.freshen_on_acquire_coherence(tree)
+        self.assertFalse(result.disposition_set_matches_schema)
+        self.assertFalse(result.passed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/prose_conformance.py
+++ b/tooling/prose_conformance.py
@@ -549,3 +549,205 @@ def session_surface_handoff_commitments(
             forbidden_pattern_hits(body, PUBLIC_DOCS_BYPASS_PATTERNS)
         ),
     )
+
+
+# --- Freshen-on-acquire coherence (groundwork#465) ----------------------------
+#
+# These helpers gate the freshen-on-acquire built-in's methodology surface
+# (skills/acquire/SKILL.md) against the authorities that own its invariants:
+# the freshen-record schema (the disposition set, the required record elements,
+# the six graph facets), and the manifest (the protocol whose trigger admits an
+# acquired work-unit). No assertion enumerates forbidden prose; the surface's
+# own renderings are checked against their schema/manifest homes, and positive
+# coherence clauses are checked where the surface is the single home of its own
+# rule.
+
+FRESHEN_ACQUISITION_TRIGGER_ARTIFACT = "work-unit"
+
+
+def freshen_record_disposition_set(root: Path) -> list[str]:
+    schema = artifact_schema(root, "freshen-record")
+    return list(schema_def(schema, "#/properties/disposition/enum"))
+
+
+def freshen_record_graph_facets(root: Path) -> list[str]:
+    schema = artifact_schema(root, "freshen-record")
+    return list(schema_def(schema, "#/properties/graph_finding/required"))
+
+
+def freshen_record_required_elements(root: Path) -> list[str]:
+    schema = artifact_schema(root, "freshen-record")
+    return [name for name in schema.get("required", []) if name != "work_unit"]
+
+
+def acquisition_admitted_destination(root: Path) -> str | None:
+    """The protocol that admits an acquired work-unit into the scoped pipeline:
+    the one whose trigger fires on_artifact work-unit. Derived from the
+    manifest, never hard-coded, so manifest drift that re-homes the trigger is
+    caught by every gate built on this."""
+    for protocol in manifest_protocols(root):
+        trigger = protocol.get("trigger") or {}
+        if (
+            trigger.get("type") == "on_artifact"
+            and trigger.get("name") == FRESHEN_ACQUISITION_TRIGGER_ARTIFACT
+        ):
+            name = protocol.get("name")
+            return name if isinstance(name, str) else None
+    return None
+
+
+def _cell(value: str) -> str:
+    return value.strip().strip("`").strip().lower()
+
+
+def _column(rows: list[dict[str, str]], header_substring: str) -> list[str]:
+    if not rows:
+        return []
+    header = next(
+        (key for key in rows[0] if header_substring.lower() in key.lower()),
+        None,
+    )
+    if header is None:
+        return []
+    return [row[header] for row in rows]
+
+
+@dataclass(frozen=True)
+class FreshenOnAcquireCoherence:
+    freshen_step_present: bool
+    freshen_precedes_delivery: bool
+    disposition_set_matches_schema: bool
+    only_proceed_admits_to_pipeline: bool
+    record_contract_covers_required_elements: bool
+    graph_finding_covers_schema_facets: bool
+    withhold_conditioning_present: bool
+    record_is_log_entry_not_body: bool
+    composes_refine_work_unit: bool
+    resolve_escalation_present: bool
+    mode_parity_single_boundary: bool
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.freshen_step_present
+            and self.freshen_precedes_delivery
+            and self.disposition_set_matches_schema
+            and self.only_proceed_admits_to_pipeline
+            and self.record_contract_covers_required_elements
+            and self.graph_finding_covers_schema_facets
+            and self.withhold_conditioning_present
+            and self.record_is_log_entry_not_body
+            and self.composes_refine_work_unit
+            and self.resolve_escalation_present
+            and self.mode_parity_single_boundary
+        )
+
+
+def _step_title_index(steps: str, title_pattern: str) -> int | None:
+    match = re.search(
+        rf"^\d+\. \*\*[^*]*{title_pattern}[^*]*\*\*",
+        steps,
+        flags=re.MULTILINE | re.IGNORECASE,
+    )
+    return match.start() if match else None
+
+
+def freshen_on_acquire_coherence(root: Path) -> FreshenOnAcquireCoherence:
+    acquire = read(root / "skills" / "acquire" / "SKILL.md")
+    disposition_set = set(freshen_record_disposition_set(root))
+    facets = freshen_record_graph_facets(root)
+    required_elements = freshen_record_required_elements(root)
+    destination = acquisition_admitted_destination(root)
+
+    steps = markdown_section(acquire, "Steps")
+    freshen_index = _step_title_index(steps, r"Freshen")
+    deliver_index = _step_title_index(steps, r"Deliver")
+    freshen_step_present = freshen_index is not None
+    freshen_precedes_delivery = (
+        freshen_index is not None
+        and deliver_index is not None
+        and freshen_index < deliver_index
+    )
+
+    try:
+        freshening = markdown_section(acquire, "Freshening")
+        rows = markdown_table_rows(freshening)
+    except AssertionError:
+        rows = []
+
+    disposition_cells = {_cell(value) for value in _column(rows, "disposition")}
+    disposition_set_matches_schema = bool(rows) and disposition_cells == disposition_set
+
+    only_proceed_admits = False
+    if rows and destination is not None:
+        admit_column = _column(rows, destination)
+        disposition_column = _column(rows, "disposition")
+        if admit_column and len(admit_column) == len(disposition_column):
+            proceed_admits: list[bool] = []
+            nonproceed_admits: list[bool] = []
+            for disposition_value, admit_value in zip(disposition_column, admit_column):
+                admits = _cell(admit_value) in {"yes", "y", "true"}
+                if _cell(disposition_value) == "proceed-as-freshened":
+                    proceed_admits.append(admits)
+                else:
+                    nonproceed_admits.append(admits)
+            only_proceed_admits = (
+                len(proceed_admits) == 1
+                and all(proceed_admits)
+                and not any(nonproceed_admits)
+            )
+
+    record_contract_covers_required_elements = all(
+        f"`{element}`" in acquire for element in required_elements
+    )
+    graph_finding_covers_schema_facets = all(
+        f"`{facet}`" in acquire for facet in facets
+    )
+
+    withhold_conditioning_present = has_semantic_clause(
+        acquire,
+        r"\bonly\b",
+        r"\bproceed-as-freshened\b",
+        r"\bdeliver",
+    )
+    record_is_log_entry_not_body = has_semantic_clause(
+        acquire,
+        r"\bfreshen record\b",
+        r"\bcomment\b",
+        r"\bnot\b",
+        r"\bbody\b",
+    )
+    composes_refine_work_unit = has_semantic_clause(
+        acquire,
+        r"\brefine-work-unit\b",
+        r"\bre-craft",
+    )
+    resolve_escalation_present = has_semantic_clause(
+        acquire,
+        r"\bresolve\b",
+        r"\bsubstrate\b",
+        r"\bescalat",
+    )
+    mode_parity_single_boundary = (
+        has_semantic_clause(
+            acquire,
+            r"\bADR-0015\b",
+            r"\bmode is a property of the session\b",
+        )
+        and len(re.findall(r"^\d+\. \*\*[^*]*Freshen[^*]*\*\*", steps, flags=re.MULTILINE))
+        == 1
+    )
+
+    return FreshenOnAcquireCoherence(
+        freshen_step_present=freshen_step_present,
+        freshen_precedes_delivery=freshen_precedes_delivery,
+        disposition_set_matches_schema=disposition_set_matches_schema,
+        only_proceed_admits_to_pipeline=only_proceed_admits,
+        record_contract_covers_required_elements=record_contract_covers_required_elements,
+        graph_finding_covers_schema_facets=graph_finding_covers_schema_facets,
+        withhold_conditioning_present=withhold_conditioning_present,
+        record_is_log_entry_not_body=record_is_log_entry_not_body,
+        composes_refine_work_unit=composes_refine_work_unit,
+        resolve_escalation_present=resolve_escalation_present,
+        mode_parity_single_boundary=mode_parity_single_boundary,
+    )


### PR DESCRIPTION
## Summary

Freshening as a groundwork built-in (closes #465). Inserts a mandatory **Freshen** step into `skills/acquire/SKILL.md` (bumped to **2.0.0**) between materialization and delivery: an acquired work-unit is re-grounded against current substrate — its body **and its dependency graph** — before `define` activates, yielding exactly one typed disposition.

Station-direct implementation, re-derived on the neutral work-unit surface (#536): the graded-relay contract/plan of record was superseded when commons#106's neutral re-vendor landed under this unit, so the sound structural spine was regenerated from the re-freshened body.

## How each acceptance criterion is met

- **One typed disposition** — `schemas/freshen-record.schema.json` `disposition` is a scalar enum of six (`proceed-as-freshened`, `close`, `split`, `relink`, `reblock`, `reframe-as-spike`); zero fails `required`, two can't be expressed, out-of-set fails the enum.
- **Only proceed admits to `define`** — step 5 conditions delivery on `proceed-as-freshened`; since `define`'s sole trigger is the `work-unit` artifact, every other disposition structurally withholds the unit. The coherence gate derives the admitted destination from the manifest, not a literal.
- **Freshen record (4 elements) + six-facet graph finding** — the schema is the single home of the required elements and the `graph_finding` facet set (`blockers`, `blocked`, `epic_membership`, `siblings`, `milestone`, `labels`); the record lands as a comment, not in the body.
- **Proceed re-craft** — routed through `decompose`'s `refine-work-unit` (Principle #13), not reimplemented; freshening contributes the staleness trigger + graph re-verification.
- **Mode parity** — one acquisition boundary, ADR-0015 (mode is a property of the session), no per-mode fork.
- **Conformance-gated** — the schema is auto-swept by `tooling.conformance`; `tests/test_freshen_conformance.py` (discovered by `unittest`) validates fixtures and runs a coherence gate that **consults the schema + manifest authorities** (never a phrase list), with mutation probes — including a schema-widening probe — proving the checks bite.

## Verification

- `python -m unittest discover -s tests` → **457 passed** (7 skipped runa-binary), incl. 13 new.
- `python -m tooling.conformance` → **22 passed, 0 failed** (freshen-record swept).
- `tooling.protocol_prose` clean; `entry_surface_coherence` (#516) preserved green.

Refs #465.