### PR TITLE
contract: clarify acceptance criterion sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Contract acceptance-criterion source guidance** (#580).
+  `schemas/contract.schema.json` and the define protocol's contract tool
+  example now state that `contract.criteria[].acceptance_criterion` may cite
+  either a numbered work-unit acceptance criterion or an explicit body-ground
+  obligation, matching the Source Mapping reference without changing the
+  schema shape.
+
 ### Added
 
 - **Principle-derived contracts for open-ended methodology units** (#531).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Changed
-
-- **Contract acceptance-criterion source guidance** (#580).
-  `schemas/contract.schema.json` and the define protocol's contract tool
-  example now state that `contract.criteria[].acceptance_criterion` may cite
-  either a numbered work-unit acceptance criterion or an explicit body-ground
-  obligation, matching the Source Mapping reference without changing the
-  schema shape.
-
 ### Added
 
 - **Principle-derived contracts for open-ended methodology units** (#531).
@@ -194,6 +185,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   is deprecated in favor of this surface; retirement is tracked in #415.
 
 ### Changed
+
+- **Contract acceptance-criterion source guidance** (#580).
+  `schemas/contract.schema.json` and the define protocol's contract tool
+  example now state that `contract.criteria[].acceptance_criterion` may cite
+  either a numbered work-unit acceptance criterion or an explicit body-ground
+  obligation, matching the Source Mapping reference without changing the
+  schema shape.
 
 - **Forge Capability v2.0.0 consumption: neutral work-unit operation names**
   ([tesserine/commons#106](https://github.com/tesserine/commons/issues/106)).

--- a/docs/architecture/connecting-structure.md
+++ b/docs/architecture/connecting-structure.md
@@ -492,7 +492,8 @@ work-unit acceptance criteria → contract criteria that trace to them →
 test-evidence results that trace to criteria → completion-evidence
 coverage rolled up at the acceptance-criterion level. Two schema
 consequences carry the design: each contract criterion names the
-acceptance criterion it refines, and completion-evidence reports
+numbered work-unit acceptance criterion or explicit body-ground obligation
+source it refines, and completion-evidence reports
 coverage at the acceptance-criterion level — so verify can answer "are
 all acceptance criteria covered?" The exact fields live in
 [`schemas/`](../../schemas/).

--- a/protocols/define/PROTOCOL.md
+++ b/protocols/define/PROTOCOL.md
@@ -99,7 +99,7 @@ proves it, or records it.
      criteria: [{
        id: "<stable criterion id>",
        dimension: "behavior" | "documentation" | "code-quality" | "<other>",
-       acceptance_criterion: "<acceptance criterion this refines>",
+       acceptance_criterion: "<numbered acceptance criterion or explicit body-ground obligation source>",
        statement: "<dimension-specific definition of done>",
        hollow_delivery: "<plausible delivery that would fail this criterion>",
        check_kind: "executable" | "attested",

--- a/protocols/define/PROTOCOL.md
+++ b/protocols/define/PROTOCOL.md
@@ -82,9 +82,10 @@ proves it, or records it.
 
 5. **Deliver the contract spine.** Invoke the `contract` MCP tool with
    dimension-agnostic criteria. Each criterion declares the dimension it
-   serves, the work-unit acceptance criterion it refines, the statement that
-   defines done, the hollow delivery that would fail it, the `check_kind`
-   (`executable` or `attested`), and the check descriptor. The object below
+   serves, the numbered work-unit acceptance criterion or explicit body-ground
+   obligation source it refines, the statement that defines done, the hollow
+   delivery that would fail it, the `check_kind` (`executable` or `attested`),
+   and the check descriptor. The object below
    is MCP tool input, not artifact body. `instance_id` is a tool parameter
    that names the artifact instance; it is extracted before validating
    artifact content, becomes the workspace filename, and must not appear in

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -48,9 +48,10 @@ gate-bound to this schema.
 
 The scoped contract spine is dimension-agnostic. `contract.schema.json`
 declares criteria for any dimension; each criterion names its dimension,
-the acceptance criterion it refines, the statement that defines done, the
-hollow delivery that would fail it, the criterion-level `check_kind`, and
-the check descriptor. `completion-evidence.schema.json` records one
+the numbered work-unit acceptance criterion or explicit body-ground obligation
+source it refines, the statement that defines done, the hollow delivery that
+would fail it, the criterion-level `check_kind`, and the check descriptor.
+`completion-evidence.schema.json` records one
 performed result shape per contract criterion. Executable criteria carry run
 or artifact evidence; attested criteria carry reviewer identity and finding.
 Root schemas remain ordinary top-level object schemas with no root `oneOf`,

--- a/schemas/contract.schema.json
+++ b/schemas/contract.schema.json
@@ -46,7 +46,7 @@
           },
           "acceptance_criterion": {
             "type": "string",
-            "description": "Work-unit acceptance criterion this contract criterion refines.",
+            "description": "Source for this contract criterion: numbered work-unit acceptance criterion or explicit body-ground obligation.",
             "minLength": 1
           },
           "statement": {

--- a/tests/test_define_protocol_contract_dimensions.py
+++ b/tests/test_define_protocol_contract_dimensions.py
@@ -16,6 +16,9 @@ from tooling.prose_conformance import (
 ROOT = Path(__file__).resolve().parents[1]
 DEFINE_PROTOCOL = ROOT / "protocols" / "define" / "PROTOCOL.md"
 CONTRACT_SKILL = ROOT / "skills" / "contract" / "SKILL.md"
+PRINCIPLE_DERIVED_CONTRACTS = (
+    ROOT / "skills" / "contract" / "references" / "principle-derived-contracts.md"
+)
 EXPECTED_CONTRACT_DIMENSIONS = {
     "**Behavior**",
     "**Documentation**",
@@ -44,6 +47,27 @@ class DefineProtocolContractDimensionTests(unittest.TestCase):
         self.assertIn("check_kind", criterion["required"])
         self.assertEqual(["executable", "attested"], criterion["properties"]["check_kind"]["enum"])
         self.assertNotIn("behavior_form", criterion["properties"])
+
+    def test_acceptance_criterion_source_mapping_exposes_dual_use(self) -> None:
+        schema = artifact_schema(ROOT, "contract")
+        body = read(DEFINE_PROTOCOL)
+        source_mapping = markdown_section(read(PRINCIPLE_DERIVED_CONTRACTS), "Source Mapping")
+        acceptance_criterion = schema["properties"]["criteria"]["items"]["properties"][
+            "acceptance_criterion"
+        ]
+
+        self.assertEqual(
+            "Source for this contract criterion: numbered work-unit acceptance criterion or explicit body-ground obligation.",
+            acceptance_criterion["description"],
+        )
+        self.assertIn(
+            'acceptance_criterion: "<numbered acceptance criterion or explicit body-ground obligation source>",',
+            body,
+        )
+        self.assertIn("numbered acceptance criterion", source_mapping)
+        self.assertIn("explicit body-ground source", source_mapping)
+        self.assertIn("Body-ground mapping is not scope expansion", source_mapping)
+        self.assertNotIn("<acceptance criterion this refines>", body)
 
     def test_define_delivery_block_matches_manifest_and_schema_boundary(self) -> None:
         define = {boundary.protocol: boundary for boundary in delivery_boundaries(ROOT)}["define"]


### PR DESCRIPTION
## Summary

- Updates `schemas/contract.schema.json` so `contract.criteria[].acceptance_criterion` is described as a source field for either a numbered work-unit acceptance criterion or an explicit body-ground obligation.
- Updates the define protocol contract tool example with the same dual-use source placeholder.
- Adds focused regression coverage and an Unreleased changelog entry for groundwork#580.

## Contract Coverage

- `behavior-schema-description-dual-use`: schema description is exact and schema structure is unchanged.
- `behavior-define-annotation-dual-use`: define protocol example now uses the numbered/body-ground placeholder.
- `documentation-source-mapping-coherent`: regression reads the existing Source Mapping reference and confirms the schema/protocol wording stays compatible with it.
- `code-quality-structural-schema-unchanged`: final schema diff changes only the `acceptance_criterion.description` string.

## Verification

- `python -m unittest tests.test_define_protocol_contract_dimensions tests.test_principle_derived_contracts tests.test_artifact_schemas`
- `python -m tooling.conformance schemas/contract.schema.json`
- `python -m tooling.conformance`

Draft PR for #580.