### PR TITLE
contract(policy): execution-binding policy home — policy.toml carries ci/harness/manual and the one revisable CI-gating line (#584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Execution-binding policy home** (#584).
+  `policy.toml` at the repository root is the single home of the
+  execution-binding register ADR-0010 names: the binding set
+  (`ci`/`harness`/`manual`) with per-binding meanings, the CI-gating
+  constraint as one revisable line (`ci_gating`), attestation as the
+  manual binding of a criterion's stated procedure, and the monotone
+  strengthening order (manual → harness → ci, no contract edit to
+  migrate). A conformance gate reads the constraint line from the home
+  at run time and asserts it occurs in exactly one tracked file
+  repository-wide; ADR-0010 now consults the home in place of its former
+  inline statement.
+
 - **Content kinds: behavior and meaning** (#582).
   [ADR-0010](docs/architecture/decisions/0010-content-kinds-behavior-and-meaning.md)
   (Accepted 2026-07-10) ratifies the contract-ontology rotation: every criterion carries

--- a/docs/architecture/decisions/0010-content-kinds-behavior-and-meaning.md
+++ b/docs/architecture/decisions/0010-content-kinds-behavior-and-meaning.md
@@ -195,9 +195,10 @@ while a binding register is revisable operational policy — different
 revision cadence, one file each.
 
 The environment constraint that produced the original leak lives in that
-policy home as one revisable line, and is stated exactly once in this
-decision: **no interpreter-graded check gates CI.** When the constraint
-falls, the line is revised at its home and no contract changes.
+policy home as one revisable line — the `ci_gating` value in
+[`policy.toml`](../../../policy.toml), the constraint's single home
+repository-wide. When the constraint falls, the line is revised at its
+home and no contract changes.
 
 **Attestation is redefined.** It is not a kind of check; it is the
 **manual binding** of a criterion's stated operational procedure — a

--- a/policy.toml
+++ b/policy.toml
@@ -1,0 +1,36 @@
+# Groundwork Policy
+#
+# Revisable operational policy, in its own file beside manifest.toml for the
+# reason ADR-0005 drew for its surface and ADR-0010 draws here: the manifest
+# is the invariant topology the runtime executes; policy is revisable and
+# moves on its own cadence. One file each.
+#
+# This file is the single home of the execution-binding register and the
+# CI-gating constraint. Every other surface consults or points here.
+# Origin: docs/architecture/decisions/0010-content-kinds-behavior-and-meaning.md
+
+[execution-binding]
+
+# The binding set. What a criterion is — its claim and the operational
+# procedure (actor, procedure, observable, declared cases) that checks it —
+# is contract content. A binding names where that procedure runs, selected
+# per criterion.
+bindings = ["ci", "harness", "manual"]
+
+# Attestation is the manual binding of a criterion's stated operational
+# procedure — never a kind of check.
+attestation = "a named actor performs the contract's own stated procedure and signs that performance"
+
+# The CI-gating constraint — one revisable line. When the constraint falls,
+# revise it here; no contract changes.
+ci_gating = "no interpreter-graded check gates CI"
+
+# Bindings strengthen monotonically, weakest to strongest. Migrating a
+# criterion's binding up this ladder requires no contract edit — the
+# procedure was always the contract's; only where it runs changes.
+strengthening = ["manual", "harness", "ci"]
+
+[execution-binding.meanings]
+ci = "the procedure runs mechanically and gates the merge"
+harness = "the procedure runs mechanically outside the merge gate"
+manual = "a named actor performs the criterion's stated procedure and signs the performance"

--- a/tests/test_execution_binding_policy.py
+++ b/tests/test_execution_binding_policy.py
@@ -1,0 +1,109 @@
+"""The execution-binding policy home: policy.toml.
+
+ADR-0010 separates what a criterion is (contract content: the claim and
+the operational procedure that checks it) from where its check runs (a
+binding, selected per criterion). The binding register and the CI-gating
+constraint are revisable policy with a single home: ``policy.toml`` at
+the repository root, beside ``manifest.toml``.
+
+The exactly-once gate consults the home rather than modelling it: it
+reads the ``ci_gating`` line from ``policy.toml`` at run time and holds
+no copy of it, so the gate follows any revision of the line unchanged
+and structurally cannot match itself.
+"""
+
+import subprocess
+import tomllib
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = ROOT / "policy.toml"
+
+BINDING_SET = {"ci", "harness", "manual"}
+STRENGTHENING_ORDER = ["manual", "harness", "ci"]
+
+
+def _execution_binding() -> dict:
+    with POLICY_PATH.open("rb") as handle:
+        return tomllib.load(handle)["execution-binding"]
+
+
+class PolicyHomeTests(unittest.TestCase):
+    """policy.toml exists at the root and carries the register."""
+
+    def test_policy_home_exists_beside_manifest(self) -> None:
+        self.assertTrue(POLICY_PATH.is_file())
+        self.assertTrue((ROOT / "manifest.toml").is_file())
+
+    def test_execution_binding_table_present(self) -> None:
+        self.assertIsInstance(_execution_binding(), dict)
+
+
+class BindingRegisterTests(unittest.TestCase):
+    """The register declares the binding set, self-described."""
+
+    def test_binding_set_is_exactly_ci_harness_manual(self) -> None:
+        self.assertEqual(set(_execution_binding()["bindings"]), BINDING_SET)
+
+    def test_every_binding_carries_a_meaning(self) -> None:
+        meanings = _execution_binding()["meanings"]
+
+        self.assertEqual(set(meanings), BINDING_SET)
+        for binding, meaning in meanings.items():
+            with self.subTest(binding=binding):
+                self.assertIsInstance(meaning, str)
+                self.assertTrue(meaning.strip())
+
+    def test_attestation_redefinition_stated_at_the_home(self) -> None:
+        attestation = _execution_binding()["attestation"]
+
+        self.assertIsInstance(attestation, str)
+        self.assertTrue(attestation.strip())
+
+    def test_strengthening_is_monotone_weakest_to_strongest(self) -> None:
+        strengthening = _execution_binding()["strengthening"]
+
+        self.assertEqual(strengthening, STRENGTHENING_ORDER)
+        self.assertEqual(set(strengthening), BINDING_SET)
+
+
+class CiGatingConstraintTests(unittest.TestCase):
+    """The CI-gating constraint: one revisable line, one home."""
+
+    def test_constraint_is_one_revisable_line(self) -> None:
+        line = _execution_binding()["ci_gating"]
+
+        self.assertIsInstance(line, str)
+        self.assertTrue(line.strip())
+        self.assertNotIn("\n", line)
+
+    def test_constraint_occurs_exactly_once_repository_wide(self) -> None:
+        """The only tracked file containing the constraint line is the home.
+
+        The line is read from policy.toml, never hardcoded here, so this
+        gate enforces the count for whatever the home currently states.
+        """
+        line = _execution_binding()["ci_gating"]
+        tracked = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=ROOT,
+            capture_output=True,
+            check=True,
+        ).stdout.decode("utf-8")
+
+        containing = []
+        for name in filter(None, tracked.split("\0")):
+            path = ROOT / name
+            try:
+                content = path.read_text(encoding="utf-8", errors="ignore")
+            except (IsADirectoryError, FileNotFoundError):
+                continue
+            if line in content:
+                containing.append(name)
+
+        self.assertEqual(containing, ["policy.toml"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Delivers tesserine/groundwork#584. Contract of record: [c-4932183972](https://github.com/tesserine/groundwork/issues/584#issuecomment-4932183972); plan: c-4932185645.

**What lands**
- `policy.toml` (new, repo root) — single home of the execution-binding register: `bindings`, per-binding `meanings`, `ci_gating` as one revisable line, `attestation` redefinition, monotone `strengthening` order.
- ADR-0010 — the one repoint AC2 directs: the inline constraint statement gives way to a pointer at the home; supersession clause and all other decision content stand.
- `tests/test_execution_binding_policy.py` — table shape, register content, and the exactly-once gate: reads `ci_gating` from the home at run time (holds no copy), scans tracked files, asserts the sole containing file is `policy.toml`. Falsifying case probed red, clean tree green.
- CHANGELOG Unreleased/Added entry, consulting the home.

**Verification** — local: `python -m unittest discover -s tests` 472 OK (7 pre-existing skips); `python -m tooling.conformance` 22/22 PASS.