### PR TITLE
contract(schema): completion-evidence v-next — every performed result stamps its discharging binding (#585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   at run time and asserts it occurs in exactly one tracked file
   repository-wide; ADR-0010 now consults the home in place of its former
   inline statement.
+- **Binding-stamped completion evidence** (#585). `completion-evidence.schema.json`
+  v-next requires an execution-binding stamp (`ci` | `harness` | `manual`,
+  ADR-0010) on every performed result and binds the evidence form to the
+  stamp — a `manual` result carries the signed performance and cannot carry
+  machine evidence; a `ci`/`harness` result carries machine evidence and
+  cannot ride a bare sign-off — so a manually-discharged criterion is never
+  presentable as machine-verified. The binding profile is queryable at
+  contract and repository grain; worked queries live at `schemas/README.md`.
 
 - **Content kinds: behavior and meaning** (#582).
   [ADR-0010](docs/architecture/decisions/0010-content-kinds-behavior-and-meaning.md)

--- a/protocols/verify/PROTOCOL.md
+++ b/protocols/verify/PROTOCOL.md
@@ -88,6 +88,7 @@ criteria are covered, and the documentation still tells the truth.
      results: [{
        criterion_id: "<contract criterion id>",
        result: "pass" | "fail",
+       binding: "ci" | "harness",
        evidence: {
          summary: "<what the evidence proves>",
          run: {
@@ -99,6 +100,7 @@ criteria are covered, and the documentation still tells the truth.
      }, {
        criterion_id: "<attested contract criterion id>",
        result: "pass" | "fail",
+       binding: "manual",
        evidence: {
          summary: "<what the reviewer found>",
          attestation: {

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -61,7 +61,32 @@ way — `actor`, `procedure`, `observable`, and declared `conforming_case`
 and `falsifying_case` — whether or not today's environment runs it
 mechanically; where a check runs is binding policy, not contract content.
 `completion-evidence.schema.json` records one
-performed result shape per contract criterion.
+performed result shape per contract criterion. Every result is stamped with
+the execution binding that discharged it — `ci`, `harness`, or `manual`
+(ADR-0010; the register's single home is `policy.toml` `[execution-binding]`, from which the schema's enum derives, drift-gated) — and
+the evidence form is coherent with the stamp: `ci` and `harness` results
+carry run or artifact evidence, `manual` results carry the signed performance
+(`attestation`: the named actor who performed the criterion's stated
+procedure). The coherence is schema-enforced, so a manually-discharged
+criterion cannot present as machine-verified and a machine stamp cannot ride
+a bare sign-off.
+
+The stamp makes the binding profile queryable — the per-criterion
+degradation debt register ADR-0010 names, visible at two grains:
+
+```sh
+# contract grain — one evidence record
+jq '.results | group_by(.binding)
+    | map({binding: .[0].binding, count: length})' completion-evidence.json
+
+# repository grain — the record set
+jq -s '[.[].results[]] | group_by(.binding)
+    | map({binding: .[0].binding, count: length})' path/to/records/*.json
+
+# the manual-bound criteria to manage downward
+jq -r '.results[] | select(.binding == "manual") | .criterion_id' \
+    completion-evidence.json
+```
 Root schemas remain ordinary top-level object schemas with no root `oneOf`,
 `anyOf`, `allOf`, or `$ref`, so runtime tool advertisement continues to expose
 them as MCP artifact tools.

--- a/schemas/completion-evidence.schema.json
+++ b/schemas/completion-evidence.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/tesserine/groundwork/main/schemas/completion-evidence.schema.json",
   "title": "Completion Evidence",
-  "description": "Validates the content of a completion-evidence artifact. Records performed evidence for every contract criterion in one lens-agnostic result shape.",
+  "description": "Validates the content of a completion-evidence artifact. Records performed evidence for every contract criterion in one lens-agnostic result shape, each result stamped with the execution binding that discharged it (ADR-0010).",
   "type": "object",
   "required": ["work_unit", "results", "documentation"],
   "additionalProperties": false,
@@ -18,8 +18,40 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["criterion_id", "result", "evidence"],
+        "required": ["criterion_id", "result", "binding", "evidence"],
         "additionalProperties": false,
+        "allOf": [
+          {
+            "if": {
+              "required": ["binding"],
+              "properties": { "binding": { "const": "manual" } }
+            },
+            "then": {
+              "properties": {
+                "evidence": {
+                  "required": ["attestation"],
+                  "not": {
+                    "anyOf": [{ "required": ["run"] }, { "required": ["artifact"] }]
+                  }
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "required": ["binding"],
+              "properties": { "binding": { "enum": ["ci", "harness"] } }
+            },
+            "then": {
+              "properties": {
+                "evidence": {
+                  "anyOf": [{ "required": ["run"] }, { "required": ["artifact"] }],
+                  "not": { "required": ["attestation"] }
+                }
+              }
+            }
+          }
+        ],
         "properties": {
           "criterion_id": {
             "type": "string",
@@ -31,9 +63,14 @@
             "description": "Observed criterion result.",
             "enum": ["pass", "fail"]
           },
+          "binding": {
+            "type": "string",
+            "description": "Execution binding that discharged this result. The register's single home is policy.toml ([execution-binding], ADR-0010); this enum derives from it, drift-gated. The stamp is the honest-signal surface: how a result presents derives from it.",
+            "enum": ["ci", "harness", "manual"]
+          },
           "evidence": {
             "type": "object",
-            "description": "Performed evidence. Executable criteria use run or artifact evidence; attested criteria use reviewer attestation.",
+            "description": "Performed evidence, form-coherent with the binding stamp: ci and harness results carry run or artifact evidence; manual results carry the signed performance.",
             "required": ["summary"],
             "additionalProperties": false,
             "anyOf": [
@@ -49,7 +86,7 @@
               },
               "run": {
                 "type": "object",
-                "description": "Executable run evidence.",
+                "description": "Mechanically run evidence (ci or harness binding).",
                 "required": ["command", "result", "output_summary"],
                 "additionalProperties": false,
                 "properties": {
@@ -69,7 +106,7 @@
               },
               "artifact": {
                 "type": "object",
-                "description": "Artifact evidence produced or inspected by an executable check.",
+                "description": "Artifact evidence produced or inspected by a mechanically run check (ci or harness binding).",
                 "required": ["path", "description"],
                 "additionalProperties": false,
                 "properties": {
@@ -85,7 +122,7 @@
               },
               "attestation": {
                 "type": "object",
-                "description": "Reviewer attestation evidence.",
+                "description": "Signed manual performance: a named actor performed the criterion's stated procedure and signs it (ADR-0010's manual binding).",
                 "required": ["reviewer", "finding"],
                 "additionalProperties": false,
                 "properties": {

--- a/tests/fixtures/artifacts/hollow-completion-evidence-documentation.json
+++ b/tests/fixtures/artifacts/hollow-completion-evidence-documentation.json
@@ -4,6 +4,7 @@
     {
       "criterion_id": "documentation-generic-review",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "Reviewer marked documentation as reviewed.",
         "attestation": {
@@ -14,7 +15,9 @@
     }
   ],
   "documentation": {
-    "updated": ["README.md"],
+    "updated": [
+      "README.md"
+    ],
     "verified_accurate": [],
     "follow_up_work_units": []
   }

--- a/tests/fixtures/artifacts/invalid-completion-evidence-attested-bare-pass.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-attested-bare-pass.json
@@ -4,14 +4,19 @@
     {
       "criterion_id": "documentation-api-reference",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "Documentation passed."
       }
     }
   ],
   "documentation": {
-    "updated": ["schemas/README.md"],
-    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "updated": [
+      "schemas/README.md"
+    ],
+    "verified_accurate": [
+      "schemas/completion-evidence.schema.json"
+    ],
     "follow_up_work_units": []
   }
 }

--- a/tests/fixtures/artifacts/invalid-completion-evidence-ci-bare-signoff.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-ci-bare-signoff.json
@@ -1,15 +1,15 @@
 {
-  "work_unit": "work-unit-485-hollow-refactor",
+  "work_unit": "work-unit-585-binding-stamps",
   "results": [
     {
-      "criterion_id": "code-quality-generic-review",
+      "criterion_id": "behavior-api-validates-records",
       "result": "pass",
-      "binding": "manual",
+      "binding": "ci",
       "evidence": {
-        "summary": "Reviewer marked code quality as reviewed.",
+        "summary": "A machine stamp riding a bare sign-off is a lying surface.",
         "attestation": {
           "reviewer": "core",
-          "finding": "Code quality reviewed."
+          "finding": "Looks fine."
         }
       }
     }

--- a/tests/fixtures/artifacts/invalid-completion-evidence-manual-machine-evidence.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-manual-machine-evidence.json
@@ -1,0 +1,23 @@
+{
+  "work_unit": "work-unit-585-binding-stamps",
+  "results": [
+    {
+      "criterion_id": "documentation-api-reference",
+      "result": "pass",
+      "binding": "manual",
+      "evidence": {
+        "summary": "A manual stamp wearing machine evidence cannot present as machine-verified.",
+        "run": {
+          "command": "python -m unittest tests.test_ingestion",
+          "result": "pass",
+          "output_summary": "tests passed"
+        }
+      }
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": [],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence-unstamped.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence-unstamped.json
@@ -1,0 +1,22 @@
+{
+  "work_unit": "work-unit-585-binding-stamps",
+  "results": [
+    {
+      "criterion_id": "behavior-api-validates-records",
+      "result": "pass",
+      "evidence": {
+        "summary": "A performed result with no binding stamp.",
+        "run": {
+          "command": "python -m unittest tests.test_ingestion",
+          "result": "pass",
+          "output_summary": "tests passed"
+        }
+      }
+    }
+  ],
+  "documentation": {
+    "updated": [],
+    "verified_accurate": [],
+    "follow_up_work_units": []
+  }
+}

--- a/tests/fixtures/artifacts/invalid-completion-evidence.json
+++ b/tests/fixtures/artifacts/invalid-completion-evidence.json
@@ -4,6 +4,7 @@
     {
       "criterion_id": "behavior-api-validates-records",
       "result": "pass",
+      "binding": "ci",
       "evidence": {
         "summary": "A bare summary with no run, artifact, or attestation is not performed evidence."
       }

--- a/tests/fixtures/artifacts/mismatched-work-unit-completion-evidence.json
+++ b/tests/fixtures/artifacts/mismatched-work-unit-completion-evidence.json
@@ -4,6 +4,7 @@
     {
       "criterion_id": "behavior-api-validates-records",
       "result": "pass",
+      "binding": "ci",
       "evidence": {
         "summary": "Behavior test passed for valid record forwarding.",
         "run": {
@@ -16,6 +17,7 @@
     {
       "criterion_id": "documentation-api-reference",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "Reviewer performed the submission and a failure recovery from the API reference alone.",
         "attestation": {
@@ -27,6 +29,7 @@
     {
       "criterion_id": "documentation-error-taxonomy-transmits",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "A reference-only reader classified a novel validation failure into the documented taxonomy.",
         "attestation": {
@@ -38,6 +41,7 @@
     {
       "criterion_id": "code-quality-single-validation-path",
       "result": "pass",
+      "binding": "ci",
       "evidence": {
         "summary": "The shared validation path remains the only endpoint validation path.",
         "artifact": {

--- a/tests/fixtures/artifacts/valid-completion-evidence-artifact.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-artifact.json
@@ -4,6 +4,7 @@
     {
       "criterion_id": "code-quality-single-validation-path",
       "result": "pass",
+      "binding": "harness",
       "evidence": {
         "summary": "The validation-entry fitness test emitted its entry-point report.",
         "artifact": {
@@ -15,7 +16,9 @@
   ],
   "documentation": {
     "updated": [],
-    "verified_accurate": ["schemas/completion-evidence.schema.json"],
+    "verified_accurate": [
+      "schemas/completion-evidence.schema.json"
+    ],
     "follow_up_work_units": []
   }
 }

--- a/tests/fixtures/artifacts/valid-completion-evidence-attested.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-attested.json
@@ -4,6 +4,7 @@
     {
       "criterion_id": "documentation-api-reference",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "Reviewer performed the submission and a failure recovery from the API reference alone.",
         "attestation": {

--- a/tests/fixtures/artifacts/valid-completion-evidence-code-quality-projections.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-code-quality-projections.json
@@ -4,6 +4,7 @@
     {
       "criterion_id": "code-quality-layer-import-direction",
       "result": "pass",
+      "binding": "ci",
       "evidence": {
         "summary": "The import-direction fitness function reports the src-to-tests edge absent.",
         "run": {
@@ -16,6 +17,7 @@
     {
       "criterion_id": "code-quality-earns-its-place",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "Reviewer audited each added element against the universal.",
         "attestation": {
@@ -27,6 +29,7 @@
     {
       "criterion_id": "code-quality-fail-loudly",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "Reviewer traced both failure paths the change adds.",
         "attestation": {
@@ -38,7 +41,9 @@
   ],
   "documentation": {
     "updated": [],
-    "verified_accurate": ["docs/architecture/layers.md"],
+    "verified_accurate": [
+      "docs/architecture/layers.md"
+    ],
     "follow_up_work_units": []
   }
 }

--- a/tests/fixtures/artifacts/valid-completion-evidence-documentation-pillars.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence-documentation-pillars.json
@@ -4,6 +4,7 @@
     {
       "criterion_id": "documentation-user-first-task",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "Reviewer reached first success from the README alone.",
         "attestation": {
@@ -15,6 +16,7 @@
     {
       "criterion_id": "documentation-developer-integration",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "Reviewer integrated against the documented contract without reading source.",
         "attestation": {
@@ -26,6 +28,7 @@
     {
       "criterion_id": "documentation-discovery-entry",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "Reviewer stated the project's what, who, and why from the entry surface opening.",
         "attestation": {
@@ -36,8 +39,14 @@
     }
   ],
   "documentation": {
-    "updated": ["README.md", "docs/architecture.md", "CHANGELOG.md"],
-    "verified_accurate": ["docs/api-reference.md"],
+    "updated": [
+      "README.md",
+      "docs/architecture.md",
+      "CHANGELOG.md"
+    ],
+    "verified_accurate": [
+      "docs/api-reference.md"
+    ],
     "follow_up_work_units": []
   }
 }

--- a/tests/fixtures/artifacts/valid-completion-evidence.json
+++ b/tests/fixtures/artifacts/valid-completion-evidence.json
@@ -4,6 +4,7 @@
     {
       "criterion_id": "behavior-api-validates-records",
       "result": "pass",
+      "binding": "ci",
       "evidence": {
         "summary": "Behavior test passed for valid record forwarding.",
         "run": {
@@ -16,6 +17,7 @@
     {
       "criterion_id": "documentation-api-reference",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "Reviewer performed the submission and a failure recovery from the API reference alone.",
         "attestation": {
@@ -27,6 +29,7 @@
     {
       "criterion_id": "documentation-error-taxonomy-transmits",
       "result": "pass",
+      "binding": "manual",
       "evidence": {
         "summary": "A reference-only reader classified a novel validation failure into the documented taxonomy.",
         "attestation": {
@@ -38,6 +41,7 @@
     {
       "criterion_id": "code-quality-single-validation-path",
       "result": "pass",
+      "binding": "ci",
       "evidence": {
         "summary": "The validation-entry fitness test confirms the shared validator is the single entry.",
         "run": {

--- a/tests/test_artifact_schemas.py
+++ b/tests/test_artifact_schemas.py
@@ -108,6 +108,53 @@ class ArtifactSchemaTests(unittest.TestCase):
 
         self.assertIn("results/0/evidence", context.exception.paths)
 
+    def test_completion_evidence_requires_binding_stamp_on_every_result(self) -> None:
+        artifact = load_artifact("completion-evidence", self.fixture("valid-completion-evidence.json"))
+        self.assertTrue(
+            {result["binding"] for result in artifact["results"]} <= {"ci", "harness", "manual"}
+        )
+
+        with self.assertRaises(ArtifactSchemaError) as context:
+            load_artifact(
+                "completion-evidence",
+                self.fixture("invalid-completion-evidence-unstamped.json"),
+            )
+        self.assertIn("results/0/binding", context.exception.paths)
+
+        unknown = json.loads(json.dumps(artifact))
+        unknown["results"][0]["binding"] = "reviewed"
+        with self.assertRaises(ArtifactSchemaError) as context:
+            validate_artifact("completion-evidence", unknown)
+        self.assertIn("results/0/binding", context.exception.paths)
+
+    def test_binding_stamp_enum_derives_from_the_policy_register(self) -> None:
+        """The register's single home is policy.toml; the schema's enum is a
+        drift-gated derived copy, read from both homes at run time."""
+        import tomllib
+
+        with (ROOT / "policy.toml").open("rb") as handle:
+            register = tomllib.load(handle)["execution-binding"]["bindings"]
+        schema = json.loads((SCHEMAS / "completion-evidence.schema.json").read_text(encoding="utf-8"))
+        enum = schema["properties"]["results"]["items"]["properties"]["binding"]["enum"]
+
+        self.assertEqual(set(enum), set(register))
+
+    def test_manual_stamp_cannot_present_as_machine_verified(self) -> None:
+        with self.assertRaises(ArtifactSchemaError) as context:
+            load_artifact(
+                "completion-evidence",
+                self.fixture("invalid-completion-evidence-manual-machine-evidence.json"),
+            )
+        self.assertIn("results/0/evidence", context.exception.paths)
+
+    def test_machine_stamp_cannot_ride_a_bare_signoff(self) -> None:
+        with self.assertRaises(ArtifactSchemaError) as context:
+            load_artifact(
+                "completion-evidence",
+                self.fixture("invalid-completion-evidence-ci-bare-signoff.json"),
+            )
+        self.assertIn("results/0/evidence", context.exception.paths)
+
     def test_completion_evidence_covers_every_contract_criterion(self) -> None:
         contract = load_artifact("contract", self.fixture("valid-contract.json"))
         evidence = load_artifact("completion-evidence", self.fixture("valid-completion-evidence.json"))


### PR DESCRIPTION
Closes #585. Origin: ADR-0010 §Evidence is binding-stamped.

- `completion-evidence.schema.json`: required `binding` (`ci` | `harness` | `manual`, closed enum) on every result; guarded `allOf` coherence — `manual` ⇒ signed performance, no machine evidence; `ci`/`harness` ⇒ machine evidence, no bare sign-off. Root stays a plain object schema (MCP-advertisable gate intact).
- Fixtures: every completion-evidence fixture stamped truthfully; three new rejection fixtures (unstamped, manual-wearing-machine-evidence, ci-riding-bare-signoff) with tests pinning the paths.
- Dimension parity tests re-pointed at the schema-level flag (the sharper surface now catches what the retiring `check_kind` cross-check caught later; that apparatus is untouched — #583 retires it).
- `schemas/README.md`: v-next paragraph + worked binding-profile queries at contract and repository grain (AC3).
- `protocols/verify/PROTOCOL.md`: delivery block shows the stamp, so the producer teaches the valid shape.
- CHANGELOG Unreleased entry.

Suite: 467 tests OK; `tooling.conformance` 22/22 on the changed tree.