### PR TITLE
implement/import_direction: retire executable/attested criterion-class prose (#583 follow-up)

### DIFF
--- a/protocols/implement/PROTOCOL.md
+++ b/protocols/implement/PROTOCOL.md
@@ -36,13 +36,15 @@ leads to untrusted code:
 
 Take the next contract criterion (the plan's `criterion_mapping` orders
 them). Consult the `contract` skill (`skills/contract/SKILL.md`) for the
-contract lifecycle: every criterion in every lens carries its own
-check, and an executable criterion is driven by watching that check fail
-first — a scenario test where its check names one, a structural, coherence,
-or conformance gate where its check names one. An attested criterion is
-advanced by producing the state its statement names; its performed evidence
-is the reviewer attestation `verify` records. Build toward every declared
-lens — behavior, documentation, and code quality — not behavior alone.
+contract lifecycle: every criterion under every lens states its own
+operational check. A criterion whose stated check this environment runs
+mechanically is driven by watching that check fail first — a scenario test
+where its procedure names one, a structural, coherence, or conformance gate
+where its procedure names one. A criterion whose check a recipient or
+reviewer performs is advanced by producing the state its statement names;
+its performed evidence is the recorded finding `verify` records. Build
+toward every declared lens — behavior, documentation, and code quality —
+not behavior alone.
 
 1. **RED — write one failing check.** The check name is the criterion's
    behavior statement. One behavior, real code over mocks
@@ -76,10 +78,10 @@ lens — behavior, documentation, and code quality — not behavior alone.
    Documentation outcomes and code-quality projections stay true while the
    internal form improves.
 
-6. **Repeat** for the next criterion. When every executable criterion in
-   scope has cycle evidence, and the attested criteria — documentation and
-   code-quality among them — have been advanced where declared, deliver
-   (below).
+6. **Repeat** for the next criterion. When every mechanically-run check in
+   scope has cycle evidence, and the recipient- and reviewer-performed
+   criteria — documentation and code-quality among them — have been
+   advanced where declared, deliver (below).
 
 Worked good/bad examples for each phase:
 [references/cycle-examples.md](references/cycle-examples.md).
@@ -105,8 +107,8 @@ should be built.
 
 The capstone is delivery of the `test-evidence` artifact through the
 `test-evidence` MCP tool: one uniform entry shape keyed by `criterion_id`,
-recording each executable criterion's cycle — the same shape for every
-lens. The object below is MCP tool input, not artifact body. `instance_id` is a tool parameter that names the
+recording the cycle of each criterion whose check ran — the same shape for
+every lens. The object below is MCP tool input, not artifact body. `instance_id` is a tool parameter that names the
 artifact instance; it is extracted before validating artifact content,
 becomes the workspace filename, and must not appear in the artifact body.
 Runa injects `work_unit` from session context; the agent does not supply
@@ -127,7 +129,7 @@ test-evidence({
 Runa validates the remaining artifact body fields against the test-evidence
 schema, persists the artifact, and records it in the artifact store.
 
-This protocol owns per-cycle evidence — each executable criterion watched
+This protocol owns per-cycle evidence — each mechanically-run check watched
 failing, then passing. The aggregate completion gate belongs to `verify`.
 
 ## When Stuck

--- a/tooling/import_direction.py
+++ b/tooling/import_direction.py
@@ -2,8 +2,8 @@
 
 Checks that no Python module inside one top-level layer imports from a
 forbidden top-level layer — the structurally-checkable code-quality
-projection the contract skill's code-quality lens types as an
-``executable`` criterion. A run of this checker is the recorded evidence
+projection the contract skill's code-quality lens types as a
+behavior-kind criterion. A run of this checker is the recorded evidence
 for such a criterion; a seeded violating change fails it.
 
 Scope, stated honestly: layers are top-level directories under the given


### PR DESCRIPTION
Completes #583's `prose-surfaces-teach-vnext` criterion on two loci the landed pass (#591) missed: `protocols/implement/PROTOCOL.md` still taught *executable/attested* as criterion classes, and `tooling/import_direction.py`'s docstring typed its projection ``executable``. Re-grounded on kind + binding vocabulary (mechanically-run vs recipient/reviewer-performed checks; behavior-kind projection). Suite 474 OK. Refs #583.